### PR TITLE
fix(view): correct cell padding/truncation for multibyte (CJK) characters

### DIFF
--- a/lua/dadbod-grip/view.lua
+++ b/lua/dadbod-grip/view.lua
@@ -119,6 +119,41 @@ vim.api.nvim_create_autocmd("ColorScheme", {
 local _ag = vim.api.nvim_create_augroup("DadbodGripView", { clear = true })
 
 -- ── column width calculation ──────────────────────────────────────────────
+local function truncate_display(s, width, ellipsize)
+  s = tostring(s or "")
+  if width <= 0 then return "", 0 end
+  local dw = vim.fn.strdisplaywidth(s)
+  if dw <= width then return s, dw end
+
+  local ell = ellipsize ~= false and "…" or ""
+  local ell_w = vim.fn.strdisplaywidth(ell)
+  if ell ~= "" and ell_w <= width and width <= ell_w then
+    return ell, ell_w
+  end
+
+  local target = math.max(0, width - ell_w)
+  local out = {}
+  local used = 0
+  for i = 0, vim.fn.strchars(s) - 1 do
+    local ch = vim.fn.strcharpart(s, i, 1)
+    local cw = vim.fn.strdisplaywidth(ch)
+    if used + cw > target then break end
+    out[#out + 1] = ch
+    used = used + cw
+  end
+
+  if ell ~= "" and used + ell_w <= width then
+    out[#out + 1] = ell
+    used = used + ell_w
+  end
+  return table.concat(out), used
+end
+
+local function pad_display(s, width, ellipsize)
+  local trimmed, dw = truncate_display(s, width, ellipsize)
+  return trimmed .. string.rep(" ", math.max(0, width - dw)), dw
+end
+
 local function calc_col_widths(columns, rows, max_width)
   local widths = {}
   for _, col in ipairs(columns) do
@@ -145,27 +180,17 @@ end
 -- ── cell display formatting ───────────────────────────────────────────────
 local function format_cell(value, width, is_null_staged)
   if is_null_staged or value == nil then
-    local s = NULL_DISPLAY
-    local sw = vim.fn.strdisplaywidth(s)
-    if sw > width then
-      s = vim.fn.strcharpart(s, 0, width - 1) .. "…"
-      sw = width
-    end
-    return s .. string.rep(" ", width - sw), "GripNull"
+    local s = pad_display(NULL_DISPLAY, width)
+    return s, "GripNull"
   end
+  value = tostring(value)
   if value:sub(1, #BINARY_PREFIX) == BINARY_PREFIX then
-    local s = vim.fn.strcharpart(value, 0, width)
-    local sw = vim.fn.strdisplaywidth(s)
-    return s .. string.rep(" ", width - sw), "GripReadonly"
+    local s = pad_display(value, width, false)
+    return s, "GripReadonly"
   end
   local display = value ~= "" and value:gsub("\n", "↵"):gsub("\r", "") or NULL_DISPLAY
   local hl = value == "" and "GripNull" or nil
-  local dw = vim.fn.strdisplaywidth(display)
-  if dw > width then
-    display = vim.fn.strcharpart(display, 0, width - 1) .. "…"
-    dw = width
-  end
-  return display .. string.rep(" ", width - dw), hl
+  return pad_display(display, width), hl
 end
 
 --- Classify a cell value for conditional formatting.
@@ -318,7 +343,7 @@ local function title_line(session, columns, widths, total_width)
 
   -- If still too wide, truncate
   if title_dw > available and available > 4 then
-    title = vim.fn.strcharpart(title, 0, available - 1) .. "…"
+    title = truncate_display(title, available)
     title_dw = vim.fn.strdisplaywidth(title)
   end
 
@@ -440,8 +465,7 @@ local function build_render(session, opts)
       local w = widths[col]
       local lw = vim.fn.strdisplaywidth(label)
       if lw > w then
-        label = vim.fn.strcharpart(label, 0, w - 1) .. "…"
-        lw = w
+        label, lw = truncate_display(label, w)
       end
       local padded = label .. string.rep(" ", w - lw)
       hdr_byte_positions[col] = { start = hbp, finish = hbp + #padded - 1 }
@@ -478,8 +502,7 @@ local function build_render(session, opts)
       local w = widths[col]
       local dw = vim.fn.strdisplaywidth(dtype)
       if dw > w then
-        dtype = vim.fn.strcharpart(dtype, 0, w - 1) .. "…"
-        dw = w
+        dtype, dw = truncate_display(dtype, w)
       end
       local padded = dtype .. string.rep(" ", w - dw)
       type_row_byte_positions[col] = { start = tbp, finish = tbp + #padded - 1 }
@@ -5046,5 +5069,7 @@ end
 
 -- Exposed for testing
 M._classify_cell = classify_cell
+M._format_cell = format_cell
+M._truncate_display = truncate_display
 
 return M

--- a/tests/spec/view_spec.lua
+++ b/tests/spec/view_spec.lua
@@ -1,5 +1,6 @@
--- view_spec.lua: unit tests for classify_cell conditional formatting
+-- view_spec.lua: unit tests for view rendering helpers
 local view = require("dadbod-grip.view")
+local data = require("dadbod-grip.data")
 
 local pass = 0
 local fail = 0
@@ -18,7 +19,50 @@ local function eq(a, b, msg)
   assert(a == b, (msg or "") .. ": expected " .. tostring(b) .. ", got " .. tostring(a))
 end
 
+local function cleanup()
+  for bufnr, _ in pairs(view._sessions) do
+    view._sessions[bufnr] = nil
+    pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+  end
+  while #vim.api.nvim_tabpage_list_wins(0) > 1 do
+    pcall(vim.api.nvim_win_close, vim.api.nvim_tabpage_list_wins(0)[#vim.api.nvim_tabpage_list_wins(0)], true)
+  end
+end
+
 local classify = view._classify_cell
+
+-- ── display width padding/truncation ────────────────────────────────────────
+
+test("format_cell: pads Korean text to exact display width", function()
+  local cell = view._format_cell("개념 삼각비의 값", 12)
+  eq(vim.fn.strdisplaywidth(cell), 12)
+end)
+
+test("format_cell: truncates Korean text to exact display width", function()
+  local cell = view._format_cell("수선에 의해 나누어진 두 직각삼각형", 11)
+  eq(vim.fn.strdisplaywidth(cell), 11)
+end)
+
+test("render: Korean cell content keeps table lines aligned", function()
+  cleanup()
+  local st = data.new({
+    columns = { "id", "hints", "comment" },
+    rows = {
+      { "1", "수선에 의해 나누어진 두 직각삼각형", "중3학년 삼각형 내부 수선" },
+      { "2", "먼저 직각삼각형에서 tan 값을 이용", "한글 폭 정렬 확인" },
+    },
+    primary_keys = { "id" },
+    table_name = "problem_hint",
+    url = "mysql://localhost/local_db",
+  })
+  local bufnr = view.open(st, st.url, "SELECT * FROM problem_hint", { max_col_width = 12 })
+  local lines = vim.api.nvim_buf_get_lines(bufnr, 0, 6, false)
+  local expected = vim.fn.strdisplaywidth(lines[1])
+  for i = 2, 6 do
+    eq(vim.fn.strdisplaywidth(lines[i]), expected, "line " .. i .. " display width")
+  end
+  cleanup()
+end)
 
 -- ── boolean detection (no type) ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

When a result set contains CJK (Korean, Chinese, Japanese) characters, table
border lines become misaligned. Each CJK character occupies **2 terminal
columns** but only **1 Unicode code-point**, so the previous truncation logic
(`vim.fn.strcharpart(s, 0, width - 1)`) counted code-points instead of display
columns. This caused cells to be padded with too few spaces, shifting every
subsequent column border to the left.

Example (before fix):

```
╔═════╦══════════════╦══════════════╗
║ id  ║ hints        ║ comment      ║
╠═════╬══════════════╬══════════════╣
║ 1   ║ 수선에 의해  ║ 중3학년 삼각형║   ← borders misalign
║ 2   ║ 먼저 직각삼각║ 한글 폭 정렬 ║
```

## Solution

Introduce two display-width-aware helpers:

- **`truncate_display(s, width, ellipsize)`** — walks the string one grapheme
  at a time with `vim.fn.strcharpart`, measures each character's terminal width
  with `vim.fn.strdisplaywidth`, and stops before the column budget is exceeded.
  Appends `…` only when it fits within the target width.
- **`pad_display(s, width, ellipsize)`** — delegates truncation to
  `truncate_display`, then appends exactly `(width - display_width)` spaces so
  every cell reaches the same terminal column regardless of Unicode content.

These helpers replace all four ad-hoc `strcharpart`-based truncation sites:
`format_cell`, the title bar, column header labels, and the type-annotation row.

## Tests

Three new specs added to `tests/spec/view_spec.lua`:

1. `format_cell` pads a Korean string to the exact requested display width.
2. `format_cell` truncates a long Korean string to the exact requested display width.
3. A rendered grid with CJK cell data produces lines of equal `strdisplaywidth` throughout.

## Checklist

- [x] `just test` passes (all specs green)
- [x] `just lint` passes (no luacheck warnings)
- [x] No new dependencies introduced
- [x] Existing ASCII/emoji rendering unaffected (display-width logic is a strict superset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)