### PR TITLE
fix(view): clamp visual-mode G/j/k to data rows (fixes #20)

### DIFF
--- a/lua/dadbod-grip/view.lua
+++ b/lua/dadbod-grip/view.lua
@@ -971,6 +971,19 @@ function M._snap_col(vis_cols, bp_row, col_nr)
   return nil
 end
 
+--- Clamp a buffer line to the data-row range [data_start, data_start + #ordered - 1].
+--- The title/header/type/separator rows sit above this range and the footer/hint
+--- line sits below it; visual-mode navigation reuses this so `G`/`j`/`k` stop at the
+--- last data row instead of overshooting onto the footer (issue #20). Pure/testable.
+function M._clamp_data_line(r, line)
+  local ds = r.data_start or 4
+  local last = ds + #r.ordered - 1
+  if last < ds then last = ds end  -- empty result set: collapse to data_start
+  if line < ds then return ds end
+  if line > last then return last end
+  return line
+end
+
 -- ── badge helpers ────────────────────────────────────────────────────────
 
 --- Update the winbar badge for watch/write mode indicators.
@@ -2178,6 +2191,24 @@ function M._setup_keymaps(bufnr)
     end
     return rows
   end
+
+  -- Visual gg/G/j/k: clamp selection to the data-row range so it stops at the
+  -- last data row instead of overshooting onto the separator/footer/hint line
+  -- (issue #20). Mirrors the normal-mode clamps; like them, it ignores counts.
+  local function visual_nav(target_fn)
+    return function()
+      local session = M._sessions[bufnr]
+      if not session or not session._render then return end
+      local r = session._render
+      local cursor = vim.api.nvim_win_get_cursor(0)
+      local target = M._clamp_data_line(r, target_fn(r, cursor[1]))
+      vim.api.nvim_win_set_cursor(0, { target, cursor[2] })
+    end
+  end
+  vmap("gg", visual_nav(function() return 0 end), "First data row (visual)")
+  vmap("G", visual_nav(function() return math.huge end), "Last data row (visual)")
+  vmap("j", visual_nav(function(_, line) return line + 1 end), "Down, clamped to data rows")
+  vmap("k", visual_nav(function(_, line) return line - 1 end), "Up, clamped to data rows")
 
   -- Visual e: batch edit (set all selected cells in column to same value)
   kvmap("grid_v_edit", function()

--- a/tests/spec/visual_nav_spec.lua
+++ b/tests/spec/visual_nav_spec.lua
@@ -1,0 +1,82 @@
+-- visual_nav_spec.lua: TDD tests for M._clamp_data_line
+--
+-- Bug being fixed (issue #20): in the data grid, cursor navigation is clamped
+-- to the data-row range in NORMAL mode but not in VISUAL mode, so `V` then `G`
+-- (or j/k) overshoots past the last data row onto the separator/footer/hint
+-- line. This pure helper computes the clamped target line that the visual-mode
+-- G/gg/j/k handlers snap the cursor to.
+--
+-- Data-row range is [data_start, data_start + #ordered - 1]. The footer/hint
+-- line lives below that range; the title/header/type/separator rows above it.
+
+local view = require("dadbod-grip.view")
+
+local pass = 0
+local fail = 0
+
+local function test(name, fn)
+  local ok, err = pcall(fn)
+  if ok then
+    pass = pass + 1
+  else
+    fail = fail + 1
+    print("FAIL: " .. name .. ": " .. tostring(err))
+  end
+end
+
+local function eq(a, b, msg)
+  assert(a == b, (msg or "") .. ": expected " .. tostring(b) .. ", got " .. tostring(a))
+end
+
+local clamp = view._clamp_data_line
+
+-- Layout without type row: title/header/sep then data at line 4.
+-- 3 data rows → data lines 4,5,6; footer/hint at 7.
+local r = { data_start = 4, ordered = { 1, 2, 3 } }
+
+test("clamp: line within data range is unchanged", function()
+  eq(clamp(r, 5), 5)
+end)
+
+test("clamp: line below range (footer/hint) snaps to last data row", function()
+  eq(clamp(r, 7), 6, "footer line 7 must clamp to last data row 6")
+end)
+
+test("clamp: G target (very large line) snaps to last data row", function()
+  eq(clamp(r, 9999), 6, "G overshoot must clamp to last data row 6")
+end)
+
+test("clamp: separator line just above data snaps to first data row", function()
+  eq(clamp(r, 3), 4, "separator line 3 must clamp to first data row 4")
+end)
+
+test("clamp: title line (1) snaps to first data row", function()
+  eq(clamp(r, 1), 4)
+end)
+
+test("clamp: first and last data lines are fixed points", function()
+  eq(clamp(r, 4), 4, "first data line")
+  eq(clamp(r, 6), 6, "last data line")
+end)
+
+-- Layout WITH type row: data_start = 5, 2 data rows → data lines 5,6; footer 7.
+local rt = { data_start = 5, ordered = { 1, 2 } }
+
+test("clamp (type row): footer clamps to last data row", function()
+  eq(clamp(rt, 7), 6)
+end)
+
+test("clamp (type row): above-data clamps to first data row", function()
+  eq(clamp(rt, 3), 5)
+end)
+
+-- Empty result set: no data rows → clamp collapses to data_start.
+local re = { data_start = 4, ordered = {} }
+
+test("clamp: empty result set clamps to data_start", function()
+  eq(clamp(re, 4), 4)
+  eq(clamp(re, 99), 4)
+end)
+
+print("visual_nav_spec: " .. pass .. " passed, " .. fail .. " failed")
+if fail > 0 then vim.cmd("cquit 1") end


### PR DESCRIPTION
Fixes #20.

## Problem

Cursor navigation in the data grid is clamped to the data-row range in **normal** mode but not in **visual** mode. Pressing `G` (or `j`/`k`) after `V` moves past the last data row onto the separator/footer/hint line (`i:edit c:clone d:delete a:apply …`), so `V` + `G` selects the chrome instead of stopping at the last data row.

## Fix

- Extract the clamp into a pure, testable helper `M._clamp_data_line(r, line)` that snaps a line into `[data_start, data_start + #ordered - 1]`.
- Bind visual-mode `gg`/`G`/`j`/`k` via the existing `vmap()` helper to reuse it, mirroring the normal-mode clamps. Like the normal-mode handlers, these ignore counts.

## Not a data-safety issue

Cosmetic/UX only — `get_visual_rows()` already clamps collected indices to real data rows, so a batch edit/delete over an overshooting selection only ever touched data rows. The selection just *looked* alarming.

## Tests

Added `tests/spec/visual_nav_spec.lua` covering `_clamp_data_line`: within-range, below-range (footer), `G` overshoot, above-range (separator/title), fixed points, the type-row layout (`data_start = 5`), and the empty result set. Written test-first (RED → GREEN).

Full suite via `nvim --headless -u tests/minimal_init.lua -l tests/run_specs.lua` stays green except one pre-existing `mutation_spec` failure that reproduces on `main` without this change (missing local DB seed — `no such table: orders`).

I kept the visual bindings as a thin wrapper so the actual clamping logic lives in the unit-tested helper, matching how `_next_edit_cursor` / `_snap_col` are tested in this repo (keymaps themselves aren't exercised in the headless harness).

Environment: Neovim 0.12.4, macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)