### PR TITLE
fix(postgresql): stop EXPLAIN from executing DML via ANALYZE (fixes #22)

### DIFF
--- a/lua/dadbod-grip/adapters/postgresql.lua
+++ b/lua/dadbod-grip/adapters/postgresql.lua
@@ -204,7 +204,14 @@ function M.get_schema_batch(url)
 end
 
 function M.explain(sql_str, url)
-  local explain_sql = "EXPLAIN (FORMAT TEXT, ANALYZE) " .. sql_str
+  -- ANALYZE actually executes the statement, so it is only safe for plain
+  -- read-only queries. DML (UPDATE/DELETE/INSERT/MERGE) and WITH (which may
+  -- contain data-modifying CTEs) get a plain EXPLAIN so previewing a plan
+  -- can never mutate data.
+  local first_kw = (sql_str:match("^%s*(%a+)") or ""):upper()
+  local read_only = first_kw == "SELECT" or first_kw == "TABLE" or first_kw == "VALUES"
+  local explain_sql = (read_only and "EXPLAIN (FORMAT TEXT, ANALYZE) " or "EXPLAIN (FORMAT TEXT) ")
+    .. sql_str
   local stdout, stderr, code = psql(url, explain_sql)
   if code ~= 0 then
     return nil, stderr ~= "" and stderr or "EXPLAIN failed"

--- a/tests/spec/adapter_spec.lua
+++ b/tests/spec/adapter_spec.lua
@@ -241,6 +241,46 @@ test("pg ping: passes -X to skip .psqlrc", function()
   end)
 end)
 
+-- ── PostgreSQL EXPLAIN safety ────────────────────────────────────────────
+-- ANALYZE executes the statement; it must only be added for read-only SQL.
+
+test("pg explain: SELECT uses ANALYZE for actual timings", function()
+  with_executable(function()
+    local args = capture_system_args("QUERY PLAN\nSeq Scan\n", function()
+      pg.explain("SELECT * FROM users", "postgresql://localhost/db")
+    end)
+    contains(last_arg(args), "EXPLAIN (FORMAT TEXT, ANALYZE) SELECT", "SELECT gets ANALYZE")
+  end)
+end)
+
+test("pg explain: UPDATE/DELETE/INSERT never use ANALYZE (would execute the DML)", function()
+  with_executable(function()
+    for _, stmt in ipairs({
+      "UPDATE users SET age = 1 WHERE id = 1",
+      "DELETE FROM users WHERE id = 1",
+      "INSERT INTO users (name) VALUES ('x')",
+    }) do
+      local args = capture_system_args("QUERY PLAN\nSeq Scan\n", function()
+        pg.explain(stmt, "postgresql://localhost/db")
+      end)
+      local sql_arg = last_arg(args)
+      assert(not sql_arg:find("ANALYZE", 1, true),
+        "no ANALYZE for: " .. stmt .. " (got: " .. sql_arg .. ")")
+      contains(sql_arg, "EXPLAIN (FORMAT TEXT) ", "plain EXPLAIN used")
+    end
+  end)
+end)
+
+test("pg explain: WITH gets plain EXPLAIN (may contain data-modifying CTEs)", function()
+  with_executable(function()
+    local args = capture_system_args("QUERY PLAN\nSeq Scan\n", function()
+      pg.explain("WITH gone AS (DELETE FROM users RETURNING *) SELECT * FROM gone",
+        "postgresql://localhost/db")
+    end)
+    assert(not last_arg(args):find("ANALYZE", 1, true), "no ANALYZE for WITH")
+  end)
+end)
+
 -- ── SQLite .sqliterc bypass ─────────────────────────────────────────────
 
 test("sqlite query: passes -init '' to skip .sqliterc", function()


### PR DESCRIPTION
Fixes #22.

`M.explain` unconditionally prepended `EXPLAIN (FORMAT TEXT, ANALYZE)`. `ANALYZE` **executes** the statement, so Query Doctor / `:GripExplain` on an `UPDATE`/`DELETE`/`INSERT` silently modified real data (verified against live PostgreSQL 14).

**Change:** `ANALYZE` is now added only when the statement's first keyword is `SELECT`/`TABLE`/`VALUES`. Everything else — including `WITH`, since CTEs can contain data-modifying statements — gets plain `EXPLAIN`.

**Trade-off:** DML plans show estimates only (no `actual time`), which is the safe default.

Includes 3 mocked regression tests in `tests/spec/adapter_spec.lua`; full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ZTuFUH4n1C6eRRXF5o6Mh