### PR TITLE
fix: correct NULL handling in cell editing and export (fixes #24)

### DIFF
--- a/lua/dadbod-grip/data.lua
+++ b/lua/dadbod-grip/data.lua
@@ -280,8 +280,11 @@ function M.effective_value(state, row_idx, field)
   local idx = col_idx[field]
   if not idx then return nil end
   local raw = state.rows[row_idx] and state.rows[row_idx][idx]
-  -- psql --csv emits empty string for NULL
-  return raw == "" and nil or raw
+  -- CSV adapters emit an empty string for NULL. Must be an explicit if —
+  -- `raw == "" and nil or raw` is the classic Lua and/or trap: when raw is
+  -- "", the and-branch yields nil, so `or` short-circuits back to raw ("").
+  if raw == "" then return nil end
+  return raw
 end
 
 -- M.count_staged(state) → int (total staged operations)

--- a/lua/dadbod-grip/editor.lua
+++ b/lua/dadbod-grip/editor.lua
@@ -67,6 +67,14 @@ end
 -- Sentinel: caller uses this to distinguish "user set NULL" from "user cancelled".
 M.NULL_VALUE = "__GRIP_NULL__"
 
+-- Translate the sentinel to a real nil for staging. Callers MUST use this
+-- instead of `v == M.NULL_VALUE and nil or v` — that and/or expression
+-- yields v (the sentinel string!) whenever the comparison is true.
+function M.resolve_null(v)
+  if v == M.NULL_VALUE then return nil end
+  return v
+end
+
 -- M.open(prompt, initial_value, on_save, opts)
 --   prompt:        string shown in border title (e.g. "users.name")
 --   initial_value: string | nil (nil = current value is NULL, pre-fill empty)

--- a/lua/dadbod-grip/init.lua
+++ b/lua/dadbod-grip/init.lua
@@ -553,7 +553,7 @@ local function do_edit(bufnr, cell, url)
     end
 
     -- Valid mutation: stage and advance to next row (spreadsheet style).
-    local actual_val = now_null and nil or new_val
+    local actual_val = editor.resolve_null(new_val)
     local new_state = data.add_change(session.state, cell.row_idx, cell.col_name, actual_val)
     view.apply_edit(bufnr, new_state)
 

--- a/lua/dadbod-grip/view.lua
+++ b/lua/dadbod-grip/view.lua
@@ -2117,7 +2117,9 @@ function M._setup_keymaps(bufnr)
     for _, row_idx in ipairs(r_gy.ordered) do
       local row = {}
       for _, col in ipairs(cols) do
-        table.insert(row, data.effective_value(st_gy, row_idx, col))
+        -- effective_value returns nil for NULL; table.insert(row, nil) is a
+        -- no-op that would shift the remaining columns left, so map to "".
+        table.insert(row, data.effective_value(st_gy, row_idx, col) or "")
       end
       table.insert(rows_data, row)
     end
@@ -2196,7 +2198,7 @@ function M._setup_keymaps(bufnr)
     local col_name = cell.col_name
     editor.open("Set " .. #row_indices .. " cells (" .. col_name .. ")", cell.value, function(new_val)
       if new_val == nil then return end
-      local actual = new_val == editor.NULL_VALUE and nil or new_val
+      local actual = editor.resolve_null(new_val)
       local st = session.state
       for _, ri in ipairs(row_indices) do
         st = data.add_change(st, ri, col_name, actual)
@@ -4030,8 +4032,11 @@ function M._setup_keymaps(bufnr)
       local rows_data = {}
       for _, row_idx in ipairs(r_e.ordered) do
         local row = {}
-        for _, col in ipairs(cols) do
-          table.insert(row, data.effective_value(st_e, row_idx, col))
+        -- Indexed assignment: effective_value returns nil for NULL, and
+        -- table.insert(row, nil) is a no-op that would shift columns left.
+        -- Holes are intentional; consumers below iterate `for ci = 1, #cols`.
+        for ci, col in ipairs(cols) do
+          row[ci] = data.effective_value(st_e, row_idx, col)
         end
         table.insert(rows_data, row)
       end
@@ -4041,8 +4046,8 @@ function M._setup_keymaps(bufnr)
         local lines_out = { table.concat(cols, ",") }
         for _, row in ipairs(rows_data) do
           local parts = {}
-          for _, v in ipairs(row) do
-            local s = v or ""
+          for ci = 1, #cols do
+            local s = row[ci] or ""
             if s:find('[,"\n]') then s = '"' .. s:gsub('"', '""') .. '"' end
             table.insert(parts, s)
           end
@@ -4053,7 +4058,7 @@ function M._setup_keymaps(bufnr)
         local lines_out = { table.concat(cols, "\t") }
         for _, row in ipairs(rows_data) do
           local parts = {}
-          for _, v in ipairs(row) do table.insert(parts, v or "") end
+          for ci = 1, #cols do table.insert(parts, row[ci] or "") end
           table.insert(lines_out, table.concat(parts, "\t"))
         end
         output = table.concat(lines_out, "\n")
@@ -4079,7 +4084,8 @@ function M._setup_keymaps(bufnr)
         local tbl = st_e.table_name or "table_name"
         for _, row in ipairs(rows_data) do
           local vals = {}
-          for _, v in ipairs(row) do table.insert(vals, sql.quote_value(v)) end
+          -- quote_value(nil) emits unquoted NULL for NULL cells
+          for ci = 1, #cols do table.insert(vals, sql.quote_value(row[ci])) end
           table.insert(stmts, string.format("INSERT INTO %s (%s) VALUES (%s);",
             sql.quote_ident(tbl),
             table.concat(vim.tbl_map(function(c) return sql.quote_ident(c) end, cols), ", "),
@@ -4092,8 +4098,8 @@ function M._setup_keymaps(bufnr)
         local lines_out = { hdr, sep }
         for _, row in ipairs(rows_data) do
           local parts = {}
-          for _, v in ipairs(row) do
-            table.insert(parts, (tostring(v or ""):gsub("|", "\\|")))
+          for ci = 1, #cols do
+            table.insert(parts, (tostring(row[ci] or ""):gsub("|", "\\|")))
           end
           table.insert(lines_out, "| " .. table.concat(parts, " | ") .. " |")
         end
@@ -4105,8 +4111,8 @@ function M._setup_keymaps(bufnr)
           widths[ci] = vim.fn.strdisplaywidth(col)
         end
         for _, row in ipairs(rows_data) do
-          for ci, v in ipairs(row) do
-            widths[ci] = math.max(widths[ci], vim.fn.strdisplaywidth(tostring(v or "NULL")))
+          for ci = 1, #cols do
+            widths[ci] = math.max(widths[ci], vim.fn.strdisplaywidth(tostring(row[ci] or "NULL")))
           end
         end
         -- Top border: ╔════╤════╗
@@ -4132,7 +4138,8 @@ function M._setup_keymaps(bufnr)
         local data_lines = {}
         for _, row in ipairs(rows_data) do
           local row_parts = {}
-          for ci, v in ipairs(row) do
+          for ci = 1, #cols do
+            local v = row[ci]
             local display = v or "NULL"
             local pad = widths[ci] - vim.fn.strdisplaywidth(display)
             -- Right-align numbers

--- a/tests/spec/data_spec.lua
+++ b/tests/spec/data_spec.lua
@@ -184,11 +184,32 @@ test("effective_value: returns original for unstaged", function()
   eq(data.effective_value(st, 2, "name"), "bob")
 end)
 
-test("effective_value: empty string in original stays empty", function()
-  -- In the CSV output from DB CLIs, empty string represents NULL.
-  -- effective_value returns it as-is; view.lua handles display.
+test("effective_value: NULL original (empty CSV cell) returns nil", function()
+  -- All CSV CLIs emit "" for NULL, and db.parse_csv collapses quoted "" (a
+  -- genuinely empty string) and unquoted empty (NULL) into the same Lua "".
+  -- The distinction is therefore unrecoverable at this layer: "" in original
+  -- rows uniformly means NULL, and the documented contract is that
+  -- effective_value returns nil for NULL.
   local st = make_state({ rows = { { "1", "", "test@x.com" } } })
-  eq(data.effective_value(st, 1, "name"), "", "empty string preserved from original")
+  eq(data.effective_value(st, 1, "name"), nil, "NULL original must come back as nil")
+end)
+
+test("effective_value: staged NULL round-trip", function()
+  -- Stage a value over a NULL original, then undo: the cell must read as
+  -- NULL (nil) again, not "".
+  local st = make_state({ rows = { { "1", "", "test@x.com" } } })
+  local st2 = data.add_change(st, 1, "name", "temp")
+  eq(data.effective_value(st2, 1, "name"), "temp", "staged value visible")
+  local st3 = data.undo_row(st2, 1)
+  eq(data.effective_value(st3, 1, "name"), nil, "undo restores NULL original as nil")
+end)
+
+test("effective_value: staged nil reads back as nil over non-NULL original", function()
+  local st = make_state({})
+  local st2 = data.add_change(st, 1, "name", nil)
+  eq(data.effective_value(st2, 1, "name"), nil, "staged NULL is nil")
+  local st3 = data.undo_row(st2, 1)
+  eq(data.effective_value(st3, 1, "name"), "alice", "undo restores original")
 end)
 
 test("effective_value: staged overrides original", function()

--- a/tests/spec/null_resolve_spec.lua
+++ b/tests/spec/null_resolve_spec.lua
@@ -1,0 +1,46 @@
+-- null_resolve_spec.lua: editor NULL sentinel must resolve to real nil.
+-- Regression for the `x and nil or y` trap that staged the literal string
+-- "__GRIP_NULL__" into the database when a user set a cell to NULL.
+local editor = require("dadbod-grip.editor")
+
+local pass = 0
+local fail = 0
+
+local function test(name, fn)
+  local ok, err = pcall(fn)
+  if ok then
+    pass = pass + 1
+  else
+    fail = fail + 1
+    print("FAIL: " .. name .. ": " .. tostring(err))
+  end
+end
+
+local function eq(a, b, msg)
+  assert(a == b, (msg or "") .. ": expected " .. tostring(b) .. ", got " .. tostring(a))
+end
+
+test("resolve_null: NULL sentinel becomes real nil", function()
+  eq(editor.resolve_null(editor.NULL_VALUE), nil, "sentinel -> nil")
+end)
+
+test("resolve_null: ordinary values pass through", function()
+  eq(editor.resolve_null("done"), "done", "plain string")
+  eq(editor.resolve_null(""), "", "empty string untouched (data layer maps it)")
+  eq(editor.resolve_null(nil), nil, "nil stays nil")
+end)
+
+test("no and/or NULL traps remain in edit flows", function()
+  for _, rel in ipairs({ "lua/dadbod-grip/view.lua", "lua/dadbod-grip/init.lua" }) do
+    local f = assert(io.open(rel, "r"), "open " .. rel)
+    local src = f:read("*a")
+    f:close()
+    assert(not src:find("editor.NULL_VALUE and nil or", 1, true),
+      rel .. " reintroduced the `x == editor.NULL_VALUE and nil or x` trap")
+    assert(not src:find("now_null and nil or", 1, true),
+      rel .. " reintroduced the `now_null and nil or x` trap")
+  end
+end)
+
+print(string.format("null_resolve_spec: %d passed, %d failed", pass, fail))
+if fail > 0 then os.exit(1) end


### PR DESCRIPTION
Fixes #24, plus a related NULL/empty-string bug in `data.effective_value`.

Both are instances of the Lua `x and nil or y` trap — when the comparison is true, `(true and nil) or y` evaluates to `y`, never `nil`.

### 1. Setting a cell to NULL wrote the literal string `__GRIP_NULL__` ([#24](https://github.com/joryeugene/dadbod-grip.nvim/issues/24))

`do_edit` (`init.lua`) and the visual batch edit `grid_v_edit` (`view.lua`) translated the editor NULL sentinel with `new_val == editor.NULL_VALUE and nil or new_val`, which returns the sentinel string. Result: the string `__GRIP_NULL__` was staged and committed to the database instead of SQL `NULL`.

Fixed with a shared `editor.resolve_null` helper used at both call sites.

### 2. `data.effective_value` returned `""` instead of `nil` for NULL originals

`return raw == "" and nil or raw` returned `""` for NULL originals, violating the documented "nil means NULL" contract. Consequences:
- `grid_fk_follow`s `cell.value == nil` guard was unreachable for original NULL cells — it built `ref_column = ` queries.
- `quick_filter` emitted `= ` instead of `IS NULL`.
- NULL cells exported as `` and shifted columns left in `gy`/`gE` (`table.insert(row, nil)` is a no-op).

Fixed with an explicit `if`; export callers now collect by index and iterate `1..#cols`, so NULL holes no longer shift columns (JSON exports `null`, SQL INSERT exports unquoted `NULL`).

CSV-layer note: `db.parse_csv` collapses quoted `""` (empty string) and unquoted empty (NULL) into the same Lua `""`, so the distinction is unrecoverable downstream — `""` in original rows uniformly means NULL, now documented in code and tests.

### Tests

Regression tests in `tests/spec/null_resolve_spec.lua` (new) and `tests/spec/data_spec.lua`. Full suite passes (`nvim --headless -u tests/minimal_init.lua -l tests/run_specs.lua`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ZTuFUH4n1C6eRRXF5o6Mh