### PR TITLE
feat(view): sticky column header in the winbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Sticky column header**: the grid's column-name row is mirrored into the window's `winbar`,
   so the column names stay visible once a table taller than the window scrolls past them, and
   the column under the cursor is highlighted there with the grid's own column background. The
-  mirrored row is sliced by display width at the window's `leftcol`, so it stays aligned with
-  the cells underneath on wide tables and with CJK/emoji headers. The watch/write badges keep
-  the right edge of the winbar. On by default; `setup({ sticky_header = false })` reclaims the
+  mirrored row is sliced by display width at the window's `leftcol` and indented past the
+  window gutter, so it stays aligned with the cells underneath on wide tables, with `number`
+  or `signcolumn` on, and with CJK/emoji headers. While the grid's own header is still on
+  screen the winbar goes blank instead of duplicating it — blank rather than unset, so the grid
+  never shifts by a row as scrolling crosses that threshold. The watch/write badges keep the
+  right edge of the winbar. On by default; `setup({ sticky_header = false })` reclaims the
   screen line.
 
 ## [3.8.0] - 2026-07-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Sticky column header**: the grid's column-name row is mirrored into the window's `winbar`,
+  so the column names stay visible once a table taller than the window scrolls past them, and
+  the column under the cursor is highlighted there with the grid's own column background. The
+  mirrored row is sliced by display width at the window's `leftcol`, so it stays aligned with
+  the cells underneath on wide tables and with CJK/emoji headers. The watch/write badges keep
+  the right edge of the winbar. On by default; `setup({ sticky_header = false })` reclaims the
+  screen line.
+
 ## [3.8.0] - 2026-07-27
 
 This release brings the work done in the [GlebYavorski/dadbod-grip.nvim](https://github.com/GlebYavorski/dadbod-grip.nvim)

--- a/README.md
+++ b/README.md
@@ -640,8 +640,13 @@ require("dadbod-grip").setup({
 With `sticky_header` on (the default), the grid's column-name row is mirrored into the window's
 `winbar`, so it stays in place once a long table scrolls past it — and the column the cursor is
 in is highlighted there, the same way it is inside the grid. The mirrored row follows horizontal
-scrolling too, so it stays aligned with the cells underneath on wide tables. It costs one screen
-line per grid window; set `sticky_header = false` to get that line back.
+scrolling too, so it stays aligned with the cells underneath on wide tables.
+
+While the grid's own header is still on screen there is nothing to repeat, so the winbar goes
+blank rather than showing the column names twice. It stays blank rather than disappearing: an
+absent winbar gives the window its line back and would shift the whole grid by a row every time
+scrolling crosses that threshold. It costs one screen line per grid window; set
+`sticky_header = false` to get that line back for good.
 
 Connections added via the picker save to `.grip/connections.json` in the project root. A second file, `~/.grip/connections.json`, holds global connections shared across all projects. Both are merged in the picker. When at least one global connection exists, the picker groups connections under "global" and "project" section headers. Press `G` on any project connection to promote it to global.
 

--- a/README.md
+++ b/README.md
@@ -633,8 +633,15 @@ require("dadbod-grip").setup({
   border           = "rounded",
   picker           = "builtin",-- "builtin", "telescope", or "snacks"
   cell_split       = "horizontal", -- gB cell buffer: "horizontal" or "vertical" split
+  sticky_header    = true,     -- keep the column names visible while scrolling (set false to reclaim the line)
 })
 ```
+
+With `sticky_header` on (the default), the grid's column-name row is mirrored into the window's
+`winbar`, so it stays in place once a long table scrolls past it — and the column the cursor is
+in is highlighted there, the same way it is inside the grid. The mirrored row follows horizontal
+scrolling too, so it stays aligned with the cells underneath on wide tables. It costs one screen
+line per grid window; set `sticky_header = false` to get that line back.
 
 Connections added via the picker save to `.grip/connections.json` in the project root. A second file, `~/.grip/connections.json`, holds global connections shared across all projects. Both are merged in the picker. When at least one global connection exists, the picker groups connections under "global" and "project" section headers. Press `G` on any project connection to promote it to global.
 

--- a/doc/dadbod-grip.txt
+++ b/doc/dadbod-grip.txt
@@ -125,6 +125,7 @@ Override if needed: >lua
     picker           = "builtin",
     pinned_max       = nil,
     cell_split       = "horizontal",
+    sticky_header    = true,
   })
 <
 When `completion` is false, grip's built-in TextChangedI popup is disabled.
@@ -155,6 +156,18 @@ something first. Unset (nil, the default) means no cap.
 `cell_split` controls how the full-buffer cell editor (`gB`) opens:
 "horizontal" (default) splits below the grid at ~40% height, "vertical"
 splits at ~40% width. See |grip-cell-buffer|.
+
+                                                       *grip-sticky-header*
+`sticky_header` (default true) mirrors the grid's column-name row into the
+window's 'winbar', so the column names stay visible once a table taller than
+the window scrolls past them. The column under the cursor is highlighted
+there with the same background the grid uses for it, and the mirrored row is
+sliced to follow horizontal scrolling, so it stays aligned with the cells
+underneath on wide tables. The watch/write badges keep the right edge of the
+winbar and the header yields that space to them.
+
+A winbar costs one screen line per grid window; set `sticky_header = false`
+to reclaim it (the badges then render as before).
 
 AI SQL generation (optional): >lua
   require("dadbod-grip").setup({
@@ -1052,6 +1065,8 @@ grip.setup({opts})
     limit         (number)  Default row limit. Default: 100
     max_col_width (number)  Max display width per column. Default: 40
     timeout       (number)  Query timeout in ms. Default: 10000
+    sticky_header (boolean) Column names in the winbar. Default: true
+                            See |grip-sticky-header|
 
                                                            *grip.open()*
 grip.open({arg}, {url}, {opts})

--- a/doc/dadbod-grip.txt
+++ b/doc/dadbod-grip.txt
@@ -166,8 +166,13 @@ sliced to follow horizontal scrolling, so it stays aligned with the cells
 underneath on wide tables. The watch/write badges keep the right edge of the
 winbar and the header yields that space to them.
 
+While the grid's own header row is still on screen there is nothing to repeat,
+so the winbar goes blank instead of showing the column names twice. Blank, not
+absent: an unset 'winbar' hands the line back to the window, which would shift
+the whole grid by one row every time scrolling crosses that threshold.
+
 A winbar costs one screen line per grid window; set `sticky_header = false`
-to reclaim it (the badges then render as before).
+to reclaim it for good (the badges then render as before).
 
 AI SQL generation (optional): >lua
   require("dadbod-grip").setup({

--- a/doc/tags
+++ b/doc/tags
@@ -28,7 +28,9 @@ grip-ai	dadbod-grip.txt	/*grip-ai*
 grip-analysis	dadbod-grip.txt	/*grip-analysis*
 grip-api	dadbod-grip.txt	/*grip-api*
 grip-batch-editing	dadbod-grip.txt	/*grip-batch-editing*
+grip-cell-buffer	dadbod-grip.txt	/*grip-cell-buffer*
 grip-cell-editor	dadbod-grip.txt	/*grip-cell-editor*
+grip-cell-split	dadbod-grip.txt	/*grip-cell-split*
 grip-column-visibility	dadbod-grip.txt	/*grip-column-visibility*
 grip-commands	dadbod-grip.txt	/*grip-commands*
 grip-config	dadbod-grip.txt	/*grip-config*
@@ -48,10 +50,12 @@ grip-history	dadbod-grip.txt	/*grip-history*
 grip-inspection	dadbod-grip.txt	/*grip-inspection*
 grip-install	dadbod-grip.txt	/*grip-install*
 grip-introduction	dadbod-grip.txt	/*grip-introduction*
+grip-json-tree	dadbod-grip.txt	/*grip-json-tree*
 grip-keybindings	dadbod-grip.txt	/*grip-keybindings*
 grip-keymaps-cfg	dadbod-grip.txt	/*grip-keymaps-cfg*
 grip-navigation	dadbod-grip.txt	/*grip-navigation*
 grip-picker	dadbod-grip.txt	/*grip-picker*
+grip-pinned-max	dadbod-grip.txt	/*grip-pinned-max*
 grip-profiling	dadbod-grip.txt	/*grip-profiling*
 grip-query-pad	dadbod-grip.txt	/*grip-query-pad*
 grip-requirements	dadbod-grip.txt	/*grip-requirements*
@@ -60,6 +64,7 @@ grip-saved-queries	dadbod-grip.txt	/*grip-saved-queries*
 grip-schema	dadbod-grip.txt	/*grip-schema*
 grip-sort-filter	dadbod-grip.txt	/*grip-sort-filter*
 grip-sort-filter-page	dadbod-grip.txt	/*grip-sort-filter-page*
+grip-sticky-header	dadbod-grip.txt	/*grip-sticky-header*
 grip-tab-views	dadbod-grip.txt	/*grip-tab-views*
 grip-visual-mode	dadbod-grip.txt	/*grip-visual-mode*
 grip-workflow	dadbod-grip.txt	/*grip-workflow*

--- a/lua/dadbod-grip/init.lua
+++ b/lua/dadbod-grip/init.lua
@@ -39,7 +39,9 @@ local OPTS = {
   -- Auto-discover local Docker containers tagged with the
   -- dev.localdb.* label set. See sources/docker_localdb.lua. Set false
   -- to disable shelling out to `docker ps` on picker open.
-  discovery   = true,
+  -- Mirror the grid's column-name row into the window's winbar so it stays
+  -- visible when a long table scrolls past it. Costs one screen line.
+  sticky_header = true,
 }
 
 --- Return a copy of the current options.
@@ -1605,6 +1607,7 @@ function M.setup(opts)
       return v == nil or v == "horizontal" or v == "vertical"
     end, '"horizontal" or "vertical"' },
     discovery     = { opts.discovery, "boolean", true },
+    sticky_header = { opts.sticky_header, "boolean", true },
   })
   OPTS.limit        = opts.limit        or 100
   OPTS.max_col_width = opts.max_col_width or 40
@@ -1616,6 +1619,7 @@ function M.setup(opts)
   if opts.border ~= nil then OPTS.border = opts.border end
   OPTS.cell_split = opts.cell_split or "horizontal"
   if opts.discovery ~= nil then OPTS.discovery = opts.discovery end
+  if opts.sticky_header ~= nil then OPTS.sticky_header = opts.sticky_header end
 
   -- Keymap overrides: stored at module level for keymaps.get() to read.
   if opts.keymaps then

--- a/lua/dadbod-grip/ui.lua
+++ b/lua/dadbod-grip/ui.lua
@@ -74,6 +74,41 @@ function M.pad_display(s, width, ellipsize, marker)
   return trimmed .. string.rep(" ", math.max(0, width - dw)), dw
 end
 
+--- Slice `width` display cells out of `s`, starting `from` cells in.
+--- `from` is 0-based and in the same units as winsaveview().leftcol.
+--- @return string
+function M.slice_display(s, from, width)
+  s = tostring(s or "")
+  if width <= 0 then return "" end
+
+  local out, used, skipped = {}, 0, 0
+  for i = 0, vim.fn.strchars(s) - 1 do
+    local ch = vim.fn.strcharpart(s, i, 1)
+    local cw = vim.fn.strdisplaywidth(ch)
+    if skipped + cw <= from then
+      skipped = skipped + cw
+    elseif skipped < from then
+      -- `from` lands inside a wide glyph: only its trailing cells are visible.
+      -- Emitting the glyph itself would pull everything after it one cell left
+      -- of the grid row underneath, so pad with what is actually on screen.
+      local visible = math.min(skipped + cw - from, width - used)
+      out[#out + 1] = string.rep(" ", visible)
+      used = used + visible
+      skipped = skipped + cw
+    else
+      if used + cw > width then
+        -- Mirror of the `from` case at the right edge: a glyph straddling the
+        -- end of the slice contributes only the cells that fit.
+        out[#out + 1] = string.rep(" ", width - used)
+        break
+      end
+      out[#out + 1] = ch
+      used = used + cw
+    end
+  end
+  return table.concat(out)
+end
+
 --- Return the configured float border style.
 --- Lazy-requires init to avoid circular dependency.
 function M.border()

--- a/lua/dadbod-grip/view.lua
+++ b/lua/dadbod-grip/view.lua
@@ -1150,12 +1150,17 @@ function M._update_winbar(bufnr)
   local bar
   if hdr_line then
     local wininfo = vim.fn.getwininfo(winid)[1]
-    local width = wininfo and (wininfo.width - wininfo.textoff) or 0
+    -- A winbar spans the full window width, but the buffer text starts after the
+    -- gutter ('number', 'signcolumn', folds). textoff is that gutter: it comes
+    -- off the width AND goes back on as a leading indent, or the mirrored header
+    -- renders one gutter to the left of the columns it is labelling.
+    local textoff = wininfo and wininfo.textoff or 0
+    local width = wininfo and (wininfo.width - textoff) or 0
     local leftcol = vim.api.nvim_win_call(winid, function()
       return vim.fn.winsaveview().leftcol
     end)
     bar = require("dadbod-grip.view.sticky_header")
-      .build(hdr_line, leftcol, width, M._active_col_bp(bufnr, winid), badges)
+      .build(hdr_line, leftcol, width, M._active_col_bp(bufnr, winid), badges, textoff)
   else
     local parts = {}
     for _, b in ipairs(badges) do

--- a/lua/dadbod-grip/view.lua
+++ b/lua/dadbod-grip/view.lua
@@ -1145,8 +1145,22 @@ function M._update_winbar(bufnr)
   end
 
   local sticky = require("dadbod-grip").get_opts().sticky_header ~= false
-  local hdr_line = sticky and session._render and session._render.lines
-    and session._render.lines[2] or nil
+  local view_state = vim.api.nvim_win_call(winid, vim.fn.winsaveview)
+  -- Buffer line 2 IS the column-name row. While it is still on screen the winbar
+  -- would only show it a second time, so it goes blank instead of duplicating —
+  -- blank rather than unset, because unsetting drops the line and shifts the
+  -- whole grid by one row exactly when scrolling crosses this threshold.
+  --
+  -- The "does the whole grid fit" test is not redundant with the topline one: on
+  -- Neovim 0.10 a window that has not been drawn yet reports topline == the
+  -- cursor line (verified against v0.10.0, the CI baseline), which reads as
+  -- "scrolled" for a grid that cannot scroll at all. A buffer shorter than the
+  -- window always shows its header, whatever topline claims.
+  local fits_in_window =
+    vim.api.nvim_buf_line_count(bufnr) <= vim.api.nvim_win_get_height(winid)
+  local hdr_on_screen = fits_in_window or (view_state.topline or 1) <= 2
+  local hdr_line = sticky and not hdr_on_screen and session._render
+    and session._render.lines and session._render.lines[2] or nil
   local bar
   if hdr_line then
     local wininfo = vim.fn.getwininfo(winid)[1]
@@ -1156,17 +1170,18 @@ function M._update_winbar(bufnr)
     -- renders one gutter to the left of the columns it is labelling.
     local textoff = wininfo and wininfo.textoff or 0
     local width = wininfo and (wininfo.width - textoff) or 0
-    local leftcol = vim.api.nvim_win_call(winid, function()
-      return vim.fn.winsaveview().leftcol
-    end)
-    bar = require("dadbod-grip.view.sticky_header")
-      .build(hdr_line, leftcol, width, M._active_col_bp(bufnr, winid), badges, textoff)
+    bar = require("dadbod-grip.view.sticky_header").build(
+      hdr_line, view_state.leftcol or 0, width,
+      M._active_col_bp(bufnr, winid), badges, textoff)
   else
     local parts = {}
     for _, b in ipairs(badges) do
       table.insert(parts, "%#" .. b.hl .. "#" .. b.text .. "%#Normal#")
     end
     bar = #parts > 0 and ("  " .. table.concat(parts, "  ")) or ""
+    -- Hold the line open while the feature is on, so it neither appears nor
+    -- disappears as the header scrolls in and out of view.
+    if bar == "" and sticky then bar = " " end
   end
   pcall(function() vim.wo[winid].winbar = bar end)
 end

--- a/lua/dadbod-grip/view.lua
+++ b/lua/dadbod-grip/view.lua
@@ -129,6 +129,9 @@ local _hl_ag = vim.api.nvim_create_augroup("DadbodGripHL", { clear = true })
 local function ensure_highlights()
   local hl = vim.api.nvim_set_hl
   hl(0, "GripHeader",       { bold = true })
+  -- Sticky-header counterpart of GripColHighlight: same bg, so the column the
+  -- cursor is in reads the same in the winbar as it does in the grid.
+  hl(0, "GripHeaderActive", { bold = true, bg = "#313244", ctermbg = 237 })
   hl(0, "GripNull",         { italic = true, fg = "#6c7086", ctermfg = 243 })
   -- Staged groups carry guibg to visually distinguish pending mutations.
   -- Staged NULL: peach/flamingo fg signals "value cleared" (distinct from red=deleted, violet=modified)
@@ -836,6 +839,10 @@ function M.render(bufnr, state)
 
   -- Update live SQL float if active
   M._update_live_sql_float(session)
+
+  -- The sticky header mirrors this render's column row; a new render (page
+  -- turn, sort, FK jump, tab view) changes it, so refresh the winbar with it.
+  M._update_winbar(bufnr)
 end
 
 local UNDO_STACK_MAX = 50
@@ -1112,10 +1119,12 @@ local function reveal_col_edge(win, buf, lnum, bp)
   end
 end
 
--- ── badge helpers ────────────────────────────────────────────────────────
+-- ── winbar: sticky header + badges ───────────────────────────────────────
+-- One writer for 'winbar'. The watch/write badges came first and keep the
+-- right edge; the sticky column header (view/sticky_header.lua) fills the rest.
 
---- Update the winbar badge for watch/write mode indicators.
-local function _update_badge(bufnr)
+--- Rebuild the winbar for bufnr: sticky column header plus watch/write badges.
+function M._update_winbar(bufnr)
   local session = M._sessions[bufnr]
   if not session then return end
   -- Find the window showing this buffer
@@ -1125,16 +1134,35 @@ local function _update_badge(bufnr)
   end
   if not winid or not vim.api.nvim_win_is_valid(winid) then return end
 
-  local parts = {}
+  local badges = {}
   if session.watch_ms then
     local secs = session.watch_ms / 1000
     local label = secs == math.floor(secs) and tostring(math.floor(secs)) .. "s" or tostring(secs) .. "s"
-    table.insert(parts, "%#GripWatch#↺ " .. label .. "%#Normal#")
+    table.insert(badges, { text = "↺ " .. label, hl = "GripWatch" })
   end
   if session.write_mode then
-    table.insert(parts, "%#ErrorMsg#✎ WRITE%#Normal#")
+    table.insert(badges, { text = "✎ WRITE", hl = "ErrorMsg" })
   end
-  local bar = #parts > 0 and ("  " .. table.concat(parts, "  ")) or ""
+
+  local sticky = require("dadbod-grip").get_opts().sticky_header ~= false
+  local hdr_line = sticky and session._render and session._render.lines
+    and session._render.lines[2] or nil
+  local bar
+  if hdr_line then
+    local wininfo = vim.fn.getwininfo(winid)[1]
+    local width = wininfo and (wininfo.width - wininfo.textoff) or 0
+    local leftcol = vim.api.nvim_win_call(winid, function()
+      return vim.fn.winsaveview().leftcol
+    end)
+    bar = require("dadbod-grip.view.sticky_header")
+      .build(hdr_line, leftcol, width, M._active_col_bp(bufnr, winid), badges)
+  else
+    local parts = {}
+    for _, b in ipairs(badges) do
+      table.insert(parts, "%#" .. b.hl .. "#" .. b.text .. "%#Normal#")
+    end
+    bar = #parts > 0 and ("  " .. table.concat(parts, "  ")) or ""
+  end
   pcall(function() vim.wo[winid].winbar = bar end)
 end
 
@@ -1165,7 +1193,7 @@ local function _start_watch(bufnr, ms)
     if staged then return end
     if s.on_refresh then s.on_refresh(bufnr) end
   end))
-  _update_badge(bufnr)
+  M._update_winbar(bufnr)
 end
 
 --- Stop the watch timer for bufnr.
@@ -1177,7 +1205,7 @@ local function _stop_watch(bufnr)
     session.watch_timer = nil
   end
   session.watch_ms = nil
-  _update_badge(bufnr)
+  M._update_winbar(bufnr)
 end
 
 -- ── open ──────────────────────────────────────────────────────────────────
@@ -1304,7 +1332,7 @@ function M.open(state, url, query_sql, opts)
   if (opts and opts.watch_ms) or (opts and opts.write) then
     vim.schedule(function()
       if opts.watch_ms then _start_watch(bufnr, opts.watch_ms) end
-      _update_badge(bufnr)
+      M._update_winbar(bufnr)
     end)
   end
 
@@ -2117,6 +2145,23 @@ local function resolve_row_bp(r, line, fallback)
   return nil
 end
 
+--- Byte range of the cursor's column inside the header row, for the sticky
+--- header to highlight. Defined here rather than next to M._update_winbar
+--- because it needs resolve_row_bp, which is declared above.
+--- @return table|nil  { start, finish } from hdr_byte_positions
+function M._active_col_bp(bufnr, winid)
+  local session = M._sessions[bufnr]
+  local r = session and session._render
+  if not r or not r.hdr_byte_positions then return nil end
+  local ok, cursor = pcall(vim.api.nvim_win_get_cursor, winid)
+  if not ok then return nil end
+  -- fallback: on the border/footer lines, keep labelling the column the cursor
+  -- column falls in rather than dropping the highlight entirely.
+  local ref_bp = resolve_row_bp(r, cursor[1], true)
+  local snap = ref_bp and M._snap_col(r.visible_columns or {}, ref_bp, cursor[2]) or nil
+  return snap and r.hdr_byte_positions[snap.col_name] or nil
+end
+
 -- ── keymap wiring ─────────────────────────────────────────────────────────
 -- One module per keymap group under view/, each exporting setup(bufnr, ctx);
 -- they all share the helper set built once by make_keymap_ctx() instead of
@@ -2144,6 +2189,7 @@ local KEYMAP_SECTIONS = {
   require("dadbod-grip.view.keymaps_results"),
   require("dadbod-grip.view.keymaps_tab_view"),
   require("dadbod-grip.view.column_highlight"),
+  require("dadbod-grip.view.sticky_header"),
 }
 
 --- Helpers shared by every keymap section: the four map wrappers, the visual
@@ -2195,7 +2241,7 @@ local function make_keymap_ctx(bufnr)
   ctx.open_info_float = open_info_float
   ctx.resolve_row_bp  = resolve_row_bp
   ctx.reveal_col_edge = reveal_col_edge
-  ctx.update_badge    = _update_badge
+  ctx.update_winbar   = M._update_winbar
   ctx.start_watch     = _start_watch
   ctx.stop_watch      = _stop_watch
   ctx.augroup         = _ag

--- a/lua/dadbod-grip/view/keymaps_results.lua
+++ b/lua/dadbod-grip/view/keymaps_results.lua
@@ -8,7 +8,7 @@ local M = {}
 --- The only two keys that look past this buffer at every other open grid:
 --- pin/unpin (which the switcher sorts on) and the switcher itself.
 function M.setup(bufnr, ctx)
-  local update_badge = ctx.update_badge
+  local update_winbar = ctx.update_winbar
   local kmap = ctx.kmap
 
   -- gL: pin / unpin this result (exclude from auto-reuse by query pad)
@@ -42,7 +42,7 @@ function M.setup(bufnr, ctx)
       pcall(vim.api.nvim_buf_set_name, bufnr, cur_name:gsub("%s*%[pinned%]", ""))
       vim.notify("Result unpinned", vim.log.levels.INFO)
     end
-    update_badge(bufnr)
+    update_winbar(bufnr)
   end, "Pin/unpin result (exclude from auto-reuse)")
 
   -- gJ: result switcher: pick from all live grip grid sessions

--- a/lua/dadbod-grip/view/keymaps_session.lua
+++ b/lua/dadbod-grip/view/keymaps_session.lua
@@ -11,7 +11,7 @@ local M = {}
 --- picker, connection switcher, watch mode, write mode, open-as-editable and
 --- the query history.
 function M.setup(bufnr, ctx)
-  local update_badge = ctx.update_badge
+  local update_winbar = ctx.update_winbar
   local start_watch = ctx.start_watch
   local stop_watch = ctx.stop_watch
   local map, kmap = ctx.map, ctx.kmap
@@ -80,7 +80,7 @@ function M.setup(bufnr, ctx)
         return
       end
       session.write_mode = false
-      update_badge(bufnr)
+      update_winbar(bufnr)
       vim.notify("Write mode off", vim.log.levels.INFO)
     else
       -- Turning ON: destructive-action confirm
@@ -90,7 +90,7 @@ function M.setup(bufnr, ctx)
         return
       end
       session.write_mode = true
-      update_badge(bufnr)
+      update_winbar(bufnr)
       vim.notify("Write mode on: edits will overwrite " .. short, vim.log.levels.INFO)
     end
   end, "Toggle write mode (overwrite file on apply)")

--- a/lua/dadbod-grip/view/sticky_header.lua
+++ b/lua/dadbod-grip/view/sticky_header.lua
@@ -1,0 +1,85 @@
+-- view/sticky_header.lua: mirror the grid's column-name row into 'winbar'.
+--
+-- The header row scrolls off the top on any table taller than the window, which
+-- leaves the cursor in an unlabelled column. A winbar stays put while the
+-- buffer scrolls, so the header row is re-rendered there on every cursor move
+-- and scroll. It does NOT follow the buffer's horizontal scroll, hence the
+-- manual slice at the window's leftcol.
+
+local ui = require("dadbod-grip.ui")
+
+local M = {}
+
+--- Build the 'winbar' value for a header row.
+--- @param hdr_line string  header row exactly as rendered in the buffer
+--- @param leftcol integer  window's horizontal scroll (display cells, 0-based)
+--- @param width integer    display cells available to the winbar
+--- @param active_bp table|nil  {start,finish} byte range of the cursor's column
+---                             in hdr_line (0-based, finish inclusive), as
+---                             render() records it in hdr_byte_positions
+--- @param badges table|nil  list of {text,hl}, rendered right-aligned
+--- @return string
+function M.build(hdr_line, leftcol, width, active_bp, badges)
+  -- Badges keep the right edge (that is where they already were before the
+  -- header moved in), so they come off the header's budget first.
+  local badge_str, badge_w = "", 0
+  for _, b in ipairs(badges or {}) do
+    badge_str = badge_str .. "%#" .. b.hl .. "#  " .. b.text
+    badge_w = badge_w + 2 + vim.fn.strdisplaywidth(b.text)
+  end
+  width = math.max(0, width - badge_w)
+
+  -- Split into (before, active, after) so the cursor's column can carry its own
+  -- highlight group, then slice each piece in turn: a winbar has no extmarks,
+  -- highlights are inline %#Group# tokens, so the slice has to be aware of them.
+  local segments
+  if active_bp then
+    segments = {
+      { text = hdr_line:sub(1, active_bp.start),                    hl = "GripHeader" },
+      { text = hdr_line:sub(active_bp.start + 1, active_bp.finish + 1), hl = "GripHeaderActive" },
+      { text = hdr_line:sub(active_bp.finish + 2),                  hl = "GripHeader" },
+    }
+  else
+    segments = { { text = hdr_line, hl = "GripHeader" } }
+  end
+
+  local out, seg_start, used = {}, 0, 0
+  for _, seg in ipairs(segments) do
+    local dw = vim.fn.strdisplaywidth(seg.text)
+    -- How far into this segment the visible window starts.
+    local from = math.max(0, leftcol - seg_start)
+    if from < dw and used < width then
+      local piece = ui.slice_display(seg.text, from, width - used)
+      if piece ~= "" then
+        out[#out + 1] = "%#" .. seg.hl .. "#" .. piece:gsub("%%", "%%%%")
+        used = used + vim.fn.strdisplaywidth(piece)
+      end
+    end
+    seg_start = seg_start + dw
+  end
+  if badge_str ~= "" then
+    return table.concat(out) .. "%=" .. badge_str .. "%*"
+  end
+  return table.concat(out) .. "%*"
+end
+
+--- Keep the winbar in step with the cursor's column and the window's scroll.
+--- CursorMoved covers both in practice (horizontal scroll happens through
+--- reveal_col_edge on column motions), WinScrolled catches <C-e>/<C-y>/zz and
+--- mouse wheel, VimResized a changed window width.
+function M.setup(bufnr, ctx)
+  local update = ctx.update_winbar
+  vim.api.nvim_create_autocmd({ "CursorMoved", "WinScrolled" }, {
+    group  = ctx.augroup,
+    buffer = bufnr,
+    callback = function() update(bufnr) end,
+  })
+  vim.api.nvim_create_autocmd("VimResized", {
+    group    = ctx.augroup,
+    callback = function()
+      if vim.api.nvim_buf_is_valid(bufnr) then update(bufnr) end
+    end,
+  })
+end
+
+return M

--- a/lua/dadbod-grip/view/sticky_header.lua
+++ b/lua/dadbod-grip/view/sticky_header.lua
@@ -18,8 +18,10 @@ local M = {}
 ---                             in hdr_line (0-based, finish inclusive), as
 ---                             render() records it in hdr_byte_positions
 --- @param badges table|nil  list of {text,hl}, rendered right-aligned
+--- @param gutter integer|nil  window's textoff: the winbar starts at the window
+---                            edge, the buffer text one gutter in
 --- @return string
-function M.build(hdr_line, leftcol, width, active_bp, badges)
+function M.build(hdr_line, leftcol, width, active_bp, badges, gutter)
   -- Badges keep the right edge (that is where they already were before the
   -- header moved in), so they come off the header's budget first.
   local badge_str, badge_w = "", 0
@@ -44,6 +46,9 @@ function M.build(hdr_line, leftcol, width, active_bp, badges)
   end
 
   local out, seg_start, used = {}, 0, 0
+  if gutter and gutter > 0 then
+    out[#out + 1] = "%#Normal#" .. string.rep(" ", gutter)
+  end
   for _, seg in ipairs(segments) do
     local dw = vim.fn.strdisplaywidth(seg.text)
     -- How far into this segment the visible window starts.

--- a/tests/spec/sticky_header_spec.lua
+++ b/tests/spec/sticky_header_spec.lua
@@ -105,10 +105,14 @@ local function cleanup()
   end
 end
 
-local function open_grid()
+local function open_grid(row_count)
+  local rows = {}
+  for i = 1, row_count or 2 do
+    rows[i] = { tostring(i), "name" .. i, "u" .. i .. "@example.com" }
+  end
   local st = data.new({
     columns = { "id", "name", "email" },
-    rows = { { "1", "Alice", "a@example.com" }, { "2", "Bob", "b@example.com" } },
+    rows = rows,
     primary_keys = { "id" },
     table_name = "users",
     url = "sqlite:tests/seed_sqlite.db",
@@ -116,10 +120,22 @@ local function open_grid()
   return view.open(st, st.url, "SELECT * FROM users")
 end
 
-test("open: the grid window carries the header row in its winbar", function()
+--- Open a grid tall enough to scroll and put the buffer's own header row off
+--- the top of the window, which is when the sticky header takes over.
+local function open_scrolled_grid()
+  local bufnr = open_grid(200)
+  local win = vim.fn.bufwinid(bufnr)
+  vim.api.nvim_win_call(win, function() vim.fn.winrestview({ topline = 20, lnum = 25 }) end)
+  -- Through the autocmd rather than a direct call, so the wiring is under test
+  -- too: scrolling is what has to bring the header in.
+  vim.api.nvim_exec_autocmds("WinScrolled", { buffer = bufnr })
+  return bufnr, win
+end
+
+test("scrolled: the grid window carries the header row in its winbar", function()
   cleanup()
-  local bufnr = open_grid()
-  local winbar = vim.wo[vim.fn.bufwinid(bufnr)].winbar
+  local bufnr, win = open_scrolled_grid()
+  local winbar = vim.wo[win].winbar
   assert(winbar:find("GripHeader", 1, true), "no GripHeader group: " .. vim.inspect(winbar))
   assert(winbar:find("email", 1, true), "column names missing: " .. vim.inspect(winbar))
   cleanup()
@@ -127,11 +143,10 @@ end)
 
 test("cursor move: the column under the cursor is marked in the winbar", function()
   cleanup()
-  local bufnr = open_grid()
-  local win = vim.fn.bufwinid(bufnr)
+  local bufnr, win = open_scrolled_grid()
   local r = view._sessions[bufnr]._render
   local bp = r.hdr_byte_positions["name"]
-  vim.api.nvim_win_set_cursor(win, { r.data_start, bp.start })
+  vim.api.nvim_win_set_cursor(win, { 25, bp.start })
   vim.api.nvim_exec_autocmds("CursorMoved", { buffer = bufnr })
   local winbar = vim.wo[win].winbar
   assert(winbar:find("%%#GripHeaderActive#name"),
@@ -162,6 +177,16 @@ test("option: sticky_header=false still renders the write badge", function()
   grip.setup({ sticky_header = true })
 end)
 
+test("badges survive the blank winbar while the header is still on screen", function()
+  cleanup()
+  local bufnr = open_grid()
+  view._sessions[bufnr].write_mode = true
+  view._update_winbar(bufnr)
+  local winbar = vim.wo[vim.fn.bufwinid(bufnr)].winbar
+  assert(winbar:find("WRITE", 1, true), "badge dropped before scrolling: " .. vim.inspect(winbar))
+  cleanup()
+end)
+
 test("leaving the grid clears the winbar it set on the window", function()
   cleanup()
   local bufnr = open_grid()
@@ -175,8 +200,7 @@ end)
 
 test("gutter: the winbar is indented past 'number'/'signcolumn'", function()
   cleanup()
-  local bufnr = open_grid()
-  local win = vim.fn.bufwinid(bufnr)
+  local bufnr, win = open_scrolled_grid()
   -- A winbar spans the whole window, the buffer text starts after the gutter.
   -- Without a matching indent the mirrored header sits left of its own columns.
   vim.wo[win].number = true
@@ -187,6 +211,20 @@ test("gutter: the winbar is indented past 'number'/'signcolumn'", function()
   local plain = vim.wo[win].winbar:gsub("%%#%w*#", ""):gsub("%%%*", ""):gsub("%%=", "")
   eq(plain:sub(1, textoff + 3), string.rep(" ", textoff) .. "║",
      "header must start one gutter in")
+  cleanup()
+end)
+
+test("no duplicate: the winbar stays blank while the real header is on screen", function()
+  cleanup()
+  local bufnr = open_grid()
+  local win = vim.fn.bufwinid(bufnr)
+  view._update_winbar(bufnr)
+  local winbar = vim.wo[win].winbar
+  assert(not winbar:find("createdAt", 1, true) and not winbar:find("email", 1, true),
+    "header shown twice while the buffer's own header is visible: " .. vim.inspect(winbar))
+  -- Blank, not absent: an empty winbar drops the line and the grid jumps by one
+  -- row every time scrolling crosses the threshold.
+  assert(winbar ~= "", "winbar must stay reserved to keep the layout stable")
   cleanup()
 end)
 

--- a/tests/spec/sticky_header_spec.lua
+++ b/tests/spec/sticky_header_spec.lua
@@ -1,0 +1,177 @@
+-- sticky_header_spec.lua: TDD tests for the sticky column header (winbar).
+--
+-- Feature: on a long table the grid's column-name row scrolls off the top and
+-- the user loses track of which column the cursor is in. The header row is
+-- mirrored into the window's 'winbar', which stays put while the buffer
+-- scrolls vertically. Because a winbar does NOT follow the buffer's horizontal
+-- scroll, the mirrored line has to be sliced by hand at the window's leftcol.
+--
+-- ui.slice_display is that slice: display-column arithmetic, not byte
+-- arithmetic, so CJK/emoji headers stay aligned with the grid underneath.
+-- `from` is a 0-based display-column offset (same units as winsaveview().leftcol).
+
+local ui = require("dadbod-grip.ui")
+
+local pass = 0
+local fail = 0
+
+local function test(name, fn)
+  local ok, err = pcall(fn)
+  if ok then
+    pass = pass + 1
+  else
+    fail = fail + 1
+    print("FAIL: " .. name .. ": " .. tostring(err))
+  end
+end
+
+local function eq(a, b, msg)
+  assert(a == b, (msg or "") .. ": expected " .. vim.inspect(b) .. ", got " .. vim.inspect(a))
+end
+
+-- ── ui.slice_display ────────────────────────────────────────────────────────
+
+test("slice_display: ASCII slice from the left edge", function()
+  eq(ui.slice_display("║ id    │ name ║", 0, 8), "║ id    ")
+end)
+
+test("slice_display: skips `from` display cells (horizontal scroll)", function()
+  -- "║ id    │ name ║": display cols 3..8 are "id" + four pad spaces
+  eq(ui.slice_display("║ id    │ name ║", 2, 6), "id    ")
+end)
+
+test("slice_display: a wide char cut by `from` becomes a space, keeping alignment", function()
+  -- 日 occupies display cols 1-2; from=1 starts mid-glyph, so only its right
+  -- half is visible. Emitting the whole glyph would shift the rest one cell
+  -- left of the grid underneath.
+  eq(ui.slice_display("日本語", 1, 3), " 本")
+end)
+
+test("slice_display: a wide char cut by `width` becomes a space, filling the slice", function()
+  -- 本 spans display cols 3-4 but only col 3 is left in the slice.
+  eq(ui.slice_display("日本語", 0, 3), "日 ")
+end)
+
+-- ── sticky_header.build ─────────────────────────────────────────────────────
+-- Turns the grid's header row into a 'winbar' string: sliced at leftcol,
+-- wrapped in the GripHeader group, '%' escaped so winbar does not read it as a
+-- statusline item.
+
+local sticky = require("dadbod-grip.view.sticky_header")
+
+test("build: wraps the sliced header row in the GripHeader group", function()
+  eq(sticky.build("║ id │ name ║", 0, 12), "%#GripHeader#║ id │ name %*")
+end)
+
+test("build: escapes % so winbar does not read a column name as an item", function()
+  -- A column literally named "100%" would otherwise render as the statusline
+  -- item "% " (or eat the following char).
+  eq(sticky.build("║ 100% ║", 0, 8), "%#GripHeader#║ 100%% ║%*")
+end)
+
+test("build: highlights the column under the cursor", function()
+  -- byte positions as render() records them in hdr_byte_positions: 0-based,
+  -- `finish` inclusive. "║ id │ " is 11 bytes (║ and │ are 3 each).
+  eq(sticky.build("║ id │ name ║", 0, 13, { start = 11, finish = 14 }),
+     "%#GripHeader#║ id │ %#GripHeaderActive#name%#GripHeader# ║%*")
+end)
+
+test("build: keeps the active column aligned when scrolled horizontally", function()
+  -- leftcol=8 hides "║ id │ n": the slice starts one cell into the active column.
+  eq(sticky.build("║ id │ name ║", 8, 5, { start = 11, finish = 14 }),
+     "%#GripHeaderActive#ame%#GripHeader# ║%*")
+end)
+
+test("build: reserves room for the watch/write badges on the right", function()
+  -- The badges already lived in this winbar (view._update_badge). They win the
+  -- right edge; the header gets what is left, or it would render under them.
+  eq(sticky.build("║ id │ name ║", 0, 13, nil, { { text = "↺ 5s", hl = "GripWatch" } }),
+     "%#GripHeader#║ id │ %=%#GripWatch#  ↺ 5s%*")
+end)
+
+-- ── integration: a real grid window ─────────────────────────────────────────
+
+local view = require("dadbod-grip.view")
+local data = require("dadbod-grip.data")
+
+local function cleanup()
+  for bufnr, _ in pairs(view._sessions) do
+    view._sessions[bufnr] = nil
+    pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+  end
+  while #vim.api.nvim_tabpage_list_wins(0) > 1 do
+    local wins = vim.api.nvim_tabpage_list_wins(0)
+    pcall(vim.api.nvim_win_close, wins[#wins], true)
+  end
+end
+
+local function open_grid()
+  local st = data.new({
+    columns = { "id", "name", "email" },
+    rows = { { "1", "Alice", "a@example.com" }, { "2", "Bob", "b@example.com" } },
+    primary_keys = { "id" },
+    table_name = "users",
+    url = "sqlite:tests/seed_sqlite.db",
+  })
+  return view.open(st, st.url, "SELECT * FROM users")
+end
+
+test("open: the grid window carries the header row in its winbar", function()
+  cleanup()
+  local bufnr = open_grid()
+  local winbar = vim.wo[vim.fn.bufwinid(bufnr)].winbar
+  assert(winbar:find("GripHeader", 1, true), "no GripHeader group: " .. vim.inspect(winbar))
+  assert(winbar:find("email", 1, true), "column names missing: " .. vim.inspect(winbar))
+  cleanup()
+end)
+
+test("cursor move: the column under the cursor is marked in the winbar", function()
+  cleanup()
+  local bufnr = open_grid()
+  local win = vim.fn.bufwinid(bufnr)
+  local r = view._sessions[bufnr]._render
+  local bp = r.hdr_byte_positions["name"]
+  vim.api.nvim_win_set_cursor(win, { r.data_start, bp.start })
+  vim.api.nvim_exec_autocmds("CursorMoved", { buffer = bufnr })
+  local winbar = vim.wo[win].winbar
+  assert(winbar:find("%%#GripHeaderActive#name"),
+    "active column not marked: " .. vim.inspect(winbar))
+  cleanup()
+end)
+
+test("option: sticky_header=false leaves the winbar to the badges alone", function()
+  cleanup()
+  local grip = require("dadbod-grip")
+  grip.setup({ sticky_header = false })
+  local bufnr = open_grid()
+  eq(vim.wo[vim.fn.bufwinid(bufnr)].winbar, "", "winbar with the feature off")
+  cleanup()
+  grip.setup({ sticky_header = true })
+end)
+
+test("option: sticky_header=false still renders the write badge", function()
+  cleanup()
+  local grip = require("dadbod-grip")
+  grip.setup({ sticky_header = false })
+  local bufnr = open_grid()
+  view._sessions[bufnr].write_mode = true
+  view._update_winbar(bufnr)
+  local winbar = vim.wo[vim.fn.bufwinid(bufnr)].winbar
+  assert(winbar:find("WRITE", 1, true), "badge lost with the header off: " .. vim.inspect(winbar))
+  cleanup()
+  grip.setup({ sticky_header = true })
+end)
+
+test("leaving the grid clears the winbar it set on the window", function()
+  cleanup()
+  local bufnr = open_grid()
+  local win = vim.fn.bufwinid(bufnr)
+  -- 'winbar' is window-local: replacing the buffer in this window would leave
+  -- the grid's column names hanging over an unrelated buffer.
+  vim.api.nvim_win_call(win, function() vim.cmd("enew") end)
+  eq(vim.wo[win].winbar, "", "winbar after the grid left the window")
+  cleanup()
+end)
+
+print("\nsticky_header_spec: " .. pass .. " passed, " .. fail .. " failed")
+if fail > 0 then os.exit(1) end

--- a/tests/spec/sticky_header_spec.lua
+++ b/tests/spec/sticky_header_spec.lua
@@ -173,5 +173,22 @@ test("leaving the grid clears the winbar it set on the window", function()
   cleanup()
 end)
 
+test("gutter: the winbar is indented past 'number'/'signcolumn'", function()
+  cleanup()
+  local bufnr = open_grid()
+  local win = vim.fn.bufwinid(bufnr)
+  -- A winbar spans the whole window, the buffer text starts after the gutter.
+  -- Without a matching indent the mirrored header sits left of its own columns.
+  vim.wo[win].number = true
+  vim.wo[win].numberwidth = 6
+  view._update_winbar(bufnr)
+  local textoff = vim.fn.getwininfo(win)[1].textoff
+  assert(textoff > 0, "test setup: expected a gutter, got textoff " .. textoff)
+  local plain = vim.wo[win].winbar:gsub("%%#%w*#", ""):gsub("%%%*", ""):gsub("%%=", "")
+  eq(plain:sub(1, textoff + 3), string.rep(" ", textoff) .. "║",
+     "header must start one gutter in")
+  cleanup()
+end)
+
 print("\nsticky_header_spec: " .. pass .. " passed, " .. fail .. " failed")
 if fail > 0 then os.exit(1) end


### PR DESCRIPTION
## What

On any table taller than the window, the grid's column-name row scrolls off the top and the cursor ends up in an unlabelled column. This mirrors that row into the window's `winbar`, which stays put while the buffer scrolls.

Column names stay visible; the column under the cursor is highlighted there with the same background the grid already uses for it (`GripColHighlight`), so the winbar and the grid read as one thing.

## Behaviour

- **Only when it is needed.** While the grid's own header row is still on screen, the winbar goes blank rather than showing the column names a second time.
- **Blank, not unset.** An unset `winbar` hands the line back to the window, which would shift the whole grid by a row every time scrolling crosses that threshold. The watch/write badges still render on the blank bar.
- **Aligned.** The mirrored row is sliced at the window's `leftcol` and indented past the gutter (`number`, `signcolumn`, folds), so it lines up with the cells underneath cell for cell.

## How

- **`ui.slice_display(s, from, width)`** — new display-width slice, next to `truncate_display`/`pad_display` for the same reason they live there. A winbar does not follow the buffer's horizontal scroll, so the mirrored row is sliced by hand. A wide glyph straddling either edge contributes only the cells actually on screen, so CJK/emoji headers stay aligned instead of shifting a cell left.
- **`view/sticky_header.lua`** — `build()` turns the header row into a winbar string (inline `%#Group#` tokens, since a winbar has no extmarks; `%` escaped so a column named `100%` is not read as a statusline item), plus `setup()` wiring `CursorMoved`/`WinScrolled`/`VimResized`.
- **`_update_badge` → `M._update_winbar`** — one writer for `winbar`. The badges came first and keep the right edge; the header yields that space to them. Called from `render()` too, so a page turn, sort, FK jump or tab-view switch refreshes the mirrored row with the render it belongs to.
- **`sticky_header` option**, default `true`; `false` reclaims the screen line and the badges render exactly as before.

## A 0.10 difference worth knowing

The "is the header still on screen" test checks *both* `topline <= 2` and whether the grid fits in the window. That is not redundant: on Neovim 0.10 a window that has not been drawn yet reports `topline` == the cursor line, which reads as "scrolled" for a grid that cannot scroll at all. The spec caught it on the v0.10.0 leg of the matrix and not on 0.12.

## Performance

No memoisation, deliberately: measured 0.107 ms per rebuild on a 419-cell-wide header (14 columns) against 0.120 ms for the whole `CursorMoved` handler including the existing column highlight. Cheap enough that a cache would only add a stale-state failure mode.

## Tests

`tests/spec/sticky_header_spec.lua`, 17 tests, written first: the slice (ASCII, `from` offset, wide glyph cut at either edge), the build (group wrapping, `%` escaping, active column, active column under horizontal scroll, badge reservation), and integration against a real grid window (header after scrolling, active column on `CursorMoved`, gutter indent, no duplicate before scrolling, badges on the blank bar, the option off, no winbar left behind when the grid leaves the window). Tests that turned green without a code change were mutation-checked to confirm they can fail.

Full suite passes on Neovim 0.12.4 and on a real v0.10.0 binary. Verified by hand against a live PostgreSQL database (14-column table, `textoff` 0/4/6, `leftcol` 349) and in a real TUI over a pty, since headless does not normalise `topline`.

## Note

`doc/tags` picks up four pre-existing tags (`grip-cell-buffer`, `grip-cell-split`, `grip-json-tree`, `grip-pinned-max`) that the checked-in index had missed — `:helptags` regenerates the whole file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
