### PR TITLE
chore(lint): enforce luacheck in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,17 @@
 name: Tests
 on: [push, pull_request]
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Settings live in .luacheckrc. Catches missing requires read as globals,
+      # typo'd locals and shadowing — see tests/spec/globals_spec.lua for the
+      # bytecode-side check of the same class.
+      - uses: lunarmodules/luacheck@v1
+        with:
+          args: lua/ plugin/ lazy.lua
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,37 @@
+-- luacheck configuration. Run via `just lint`; enforced in CI (.github/workflows/test.yml).
+--
+-- Catches at parse time the class of mistake that otherwise only surfaces when a
+-- user reaches the affected code path — a missing `require` read as a global,
+-- a typo'd local, a shadowed variable. See tests/spec/globals_spec.lua, which
+-- covers the missing-require case from the bytecode side and runs in the same CI.
+
+-- Neovim embeds LuaJIT, so the plugin targets Lua 5.1 + LuaJIT extensions.
+std = "luajit"
+
+-- `vim` is writable, not just readable: plugin/ sets vim.g.loaded_* guards and
+-- modules assign to vim.b/vim.wo/vim.o.
+globals = {
+  "vim",
+}
+
+read_globals = {
+  "Snacks", -- folke/snacks.nvim, probed by lua/dadbod-grip/pickers/snacks.lua
+}
+
+-- Unused function arguments are usually signature-driven (autocmd/callback shapes,
+-- adapter interfaces implemented uniformly across backends), so naming them is
+-- documentation rather than dead code.
+unused_args = false
+
+-- Line length is left to review, not the linter.
+max_line_length = false
+
+-- The gate covers shipped code only (see the `lint` recipe in the justfile).
+-- tests/ is deliberately out: specs legitimately stub read-only fields such as
+-- os.exit and os.time, and their remaining warnings are unused locals that look
+-- like missing assertions — renaming those to `_` to please the linter would
+-- hide the question rather than answer it. Worth its own pass.
+exclude_files = {
+  ".luarocks",
+  "tests",
+}

--- a/justfile
+++ b/justfile
@@ -12,9 +12,10 @@ test:
 spec name:
     nvim --headless -u tests/minimal_init.lua -l tests/spec/{{name}}_spec.lua
 
-# Lint with luacheck (if installed)
+# Lint with luacheck. Settings live in .luacheckrc; same args as CI.
+# Install: luarocks --lua-version=5.1 --local install luacheck
 lint:
-    luacheck lua/ --no-unused-args --no-max-line-length
+    luacheck lua/ plugin/ lazy.lua
 
 # Seed PostgreSQL test database
 seed-pg:

--- a/lua/dadbod-grip/adapters/duckdb.lua
+++ b/lua/dadbod-grip/adapters/duckdb.lua
@@ -600,7 +600,7 @@ function M.get_indexes(table_name, url)
     ORDER BY is_primary DESC, index_name
   ]], is_prefix, is_prefix, db_filter, esc(schema), esc(tbl))
 
-  local stdout, stderr, code = duckdb(db_path, idx_sql, nil, url)
+  local stdout, _, code = duckdb(db_path, idx_sql, nil, url)
   if code ~= 0 then
     -- DuckDB may not support duckdb_indexes() in all versions; fallback
     return {}, nil
@@ -647,7 +647,7 @@ function M.get_constraints(table_name, url)
     ORDER BY constraint_type, constraint_name
   ]], db_filter, esc(schema), esc(tbl))
 
-  local stdout, stderr, code = duckdb(db_path, sql_str, nil, url)
+  local stdout, _, code = duckdb(db_path, sql_str, nil, url)
   if code ~= 0 then
     -- duckdb_constraints() may not exist in older versions
     return {}, nil

--- a/lua/dadbod-grip/adapters/mysql.lua
+++ b/lua/dadbod-grip/adapters/mysql.lua
@@ -325,7 +325,10 @@ function M.explain(sql_str, url)
   local parsed = parse_url(url)
   if not parsed then return nil, "Invalid MySQL URL: " .. url end
 
-  -- Try FORMAT=TREE (MySQL 8.0.16+), fallback to plain EXPLAIN
+  -- Try FORMAT=TREE (MySQL 8.0.16+), fallback to plain EXPLAIN. This stderr is
+  -- dropped on purpose: a failure here only means the server predates 8.0.16, and
+  -- the plain-EXPLAIN retry below produces the error worth showing.
+  -- luacheck: ignore 311
   local stdout, stderr, code = mysql_query(parsed, "EXPLAIN FORMAT=TREE " .. sql_str)
   if code ~= 0 then
     stdout, stderr, code = mysql_query(parsed, "EXPLAIN " .. sql_str)

--- a/lua/dadbod-grip/ai.lua
+++ b/lua/dadbod-grip/ai.lua
@@ -239,7 +239,7 @@ function M.build_schema_context(url, question)
   end
 
   vim.notify("Fetching schema...", vim.log.levels.INFO)
-  local tables, err = db.list_tables(url)
+  local tables = db.list_tables(url)
   if not tables then return "", "unknown" end
 
   -- Detect adapter name (generic "SQL" when no adapter claims the scheme)

--- a/lua/dadbod-grip/connections.lua
+++ b/lua/dadbod-grip/connections.lua
@@ -395,7 +395,6 @@ function M.list()
   local hidden = vim.fn.stdpath("data") .. "/grip/softrear.hidden"
   local sql_files = vim.api.nvim_get_runtime_file("demo/softrear.sql", false)
   if #sql_files > 0 and vim.fn.filereadable(hidden) == 0 then
-    local has_duck = vim.fn.executable("duckdb") == 1
     local ext      = has_duck and ".duckdb" or ".db"
     local db_path  = vim.fn.stdpath("data") .. "/grip/softrear" .. ext
     local demo_url = (has_duck and "duckdb:" or "sqlite:") .. db_path
@@ -932,7 +931,6 @@ function M.pick(opts)
           if not alias then return end
           local duckdb_adapter = require("dadbod-grip.adapters.duckdb")
           local schema_mod = require("dadbod-grip.schema")
-          local url = vim.g.db
           local dsn = duckdb_adapter.url_to_dsn(c.url)
           local err = duckdb_adapter.attach(url, dsn, alias)
           if err then

--- a/lua/dadbod-grip/db.lua
+++ b/lua/dadbod-grip/db.lua
@@ -249,7 +249,7 @@ end
 --- Ping a connection. Returns true on success, false on any error.
 --- File-backed adapters check filereadable(); network adapters run SELECT 1 (5s timeout).
 function M.ping(url)
-  local adapter, conn, err = resolve(url)
+  local adapter, conn = resolve(url)
   if not adapter then return false end
   if adapter.ping then return adapter.ping(conn) end
   return false
@@ -308,7 +308,7 @@ end
 --- Returns { [table_name] = [{column_name, data_type, is_nullable}] } or nil.
 --- nil means the adapter doesn't support batch fetch; callers fall back to per-table.
 function M.get_schema_batch(url)
-  local adapter, conn, err = resolve(url)
+  local adapter, conn = resolve(url)
   if not adapter then return nil end
   if not adapter.get_schema_batch then return nil end
   return adapter.get_schema_batch(conn)
@@ -317,7 +317,7 @@ end
 --- Async variant of get_schema_batch. Calls callback(tables) when done, or callback(nil) on error.
 --- No-op if the adapter doesn't support async batch fetch.
 function M.get_schema_batch_async(url, callback)
-  local adapter, conn, err = resolve(url)
+  local adapter, conn = resolve(url)
   if not adapter or not adapter.get_schema_batch_async then callback(nil); return end
   adapter.get_schema_batch_async(conn, callback)
 end

--- a/lua/dadbod-grip/diff.lua
+++ b/lua/dadbod-grip/diff.lua
@@ -470,7 +470,6 @@ function M.open(left_arg, right_arg, url)
 
     -- Update mutable state for navigation
     diff_lines = new_diff_lines
-    lines = new_lines
 
     vim.api.nvim_win_set_height(winid, math.min(30, #new_lines + 2))
 

--- a/lua/dadbod-grip/er_diagram.lua
+++ b/lua/dadbod-grip/er_diagram.lua
@@ -649,12 +649,12 @@ function M.show(url, scroll_to, opts)
       target = targets[1].ref
     else
       -- Multiple FKs: show numbered prompt
-      local opts = {}
+      local choices = {}
       for i, t in ipairs(targets) do
-        opts[i] = i .. ": " .. t.col .. " → " .. t.ref
+        choices[i] = i .. ": " .. t.col .. " → " .. t.ref
       end
       local choice = ui.input({
-        prompt = table.concat(opts, "   ") .. "\nFollow FK [#]: ",
+        prompt = table.concat(choices, "   ") .. "\nFollow FK [#]: ",
       })
       if not choice then return end
       local idx = tonumber(choice)

--- a/lua/dadbod-grip/init.lua
+++ b/lua/dadbod-grip/init.lua
@@ -2090,8 +2090,8 @@ function M.setup(opts)
   })
 
   -- :GripOpen [path]: open any data source without saving to connections
-  vim.api.nvim_create_user_command("GripOpen", function(opts)
-    local path = vim.fn.trim(opts.args or "")
+  vim.api.nvim_create_user_command("GripOpen", function(cmd_opts)
+    local path = vim.fn.trim(cmd_opts.args or "")
     local connections = require("dadbod-grip.connections")
     if path == "" then
       connections.pick()

--- a/lua/dadbod-grip/ui.lua
+++ b/lua/dadbod-grip/ui.lua
@@ -375,6 +375,9 @@ function M.blocking(msg, fn)
   vim.api.nvim__redraw({ flush = true })
 
   if not ok then error(rets[1], 2) end
+  -- table.unpack is nil on the LuaJIT Neovim embeds; probed so this keeps working
+  -- if Neovim ever moves to a 5.2+ VM, where the bare `unpack` global is gone.
+  -- luacheck: ignore 143
   return (table.unpack or unpack)(rets)
 end
 

--- a/lua/dadbod-grip/view.lua
+++ b/lua/dadbod-grip/view.lua
@@ -113,14 +113,11 @@ local VIEW_LABELS = {
 local SEP_COL = "│"
 local SEP_HDR = "═"
 local SEP_MID = "╪"
-local TOP_L   = "╔"
-local TOP_R   = "╗"
 local MID_L   = "╠"
 local MID_R   = "╣"
 local BOT_L   = "╚"
 local BOT_R   = "╝"
 local BOT_MID = "╧"
-local TOP_MID = "╤"
 
 -- ── highlight group setup ──────────────────────────────────────────────────
 -- Groups are re-applied on ColorScheme so they survive :colorscheme switches.
@@ -579,7 +576,6 @@ local function build_render(session, opts)
   local ROW_PREFIX = "║ "
   local ROW_PREFIX_BYTES = #ROW_PREFIX  -- 4 bytes (3+1)
   local COL_SEP = " " .. SEP_COL .. " "
-  local COL_SEP_BYTES = #COL_SEP  -- 5 bytes (1+3+1)
   local row_byte_positions = {}  -- [row_order_idx] = {col_name = {start, finish}}
 
 
@@ -1754,7 +1750,6 @@ local function fetch_view_stats(table_name, url, session)
 
   local stats_sql = table.concat(parts, "\nUNION ALL\n")
 
-  local db_mod = require("dadbod-grip.db")
   local result, query_err = db_mod.query(stats_sql, url)
   if query_err then return nil, nil, "Stats query failed: " .. query_err end
   if not result then return nil, nil, "no stats result" end
@@ -2543,9 +2538,9 @@ function M.show_help(opts)
     local function hadd(ln, group, s, e)
       -- Missing or negative end column means "to the end of the line": add_highlight
       -- took col_end = -1 for that, set_extmark wants end_row = ln + 1 / end_col = 0.
-      local opts = { hl_group = group }
-      if e and e >= 0 then opts.end_col = e else opts.end_row, opts.end_col = ln + 1, 0 end
-      vim.api.nvim_buf_set_extmark(popup_buf, ns_h, ln, s or 0, opts)
+      local ext = { hl_group = group }
+      if e and e >= 0 then ext.end_col = e else ext.end_row, ext.end_col = ln + 1, 0 end
+      vim.api.nvim_buf_set_extmark(popup_buf, ns_h, ln, s or 0, ext)
     end
     local in_ro_box = false
     for i, line in ipairs(help) do


### PR DESCRIPTION
Follow-up to #29. The `just lint` recipe existed but was never wired into `.github/workflows/test.yml`, and there was no `.luacheckrc` — so the linter that would have caught #12 at parse time never ran anywhere. This adds the lint job plus the config it needs, and fixes everything it reported so the gate starts green.

## Config

`std = "luajit"` (the VM Neovim embeds), `vim` declared writable (plugin/ sets `vim.g.loaded_*` guards), `Snacks` declared read-only. `unused_args` and `max_line_length` off — argument names are signature documentation for autocmd/adapter callbacks, and line length belongs in review.

Scoped to shipped code: `lua/`, `plugin/`, `lazy.lua`. `tests/` is excluded on purpose — specs legitimately stub read-only fields like `os.exit`/`os.time`, and their remaining warnings are unused locals that **look like tests missing an assertion**. Renaming those to `_` to satisfy the linter would bury the question rather than answer it, so I left them for a pass of their own.

## What it found

2193 → 0. All but 11 were `vim`-is-undefined noise. The real ones:

| File | Finding |
|---|---|
| `view.lua` | `TOP_L`/`TOP_R`/`TOP_MID`/`COL_SEP_BYTES` declared, never read; `fetch_view_stats` required `dadbod-grip.db` twice in one scope |
| `connections.lua` | `has_duck` and `url` each re-declared over an identical binding already in scope |
| `db.lua`, `ai.lua`, `duckdb.lua` | `err`/`stderr` bound and dropped where the failure is deliberately collapsed into the `nil`/`false` return |
| `diff.lua` | `lines = new_lines` was dead bookkeeping — navigation reads `diff_lines`, nothing reads `lines` after it |
| `init.lua` | the `GripOpen` callback took `opts`, shadowing `M.setup`'s config table; every other command in the file already names it `cmd_opts` |
| `view.lua`, `er_diagram.lua` | two more shadowed `opts`, renamed to `ext`/`choices` for what they actually hold |

Two are annotated rather than changed:

- `ui.lua`'s `(table.unpack or unpack)` is correct as written — `table.unpack` really is `nil` on Neovim's LuaJIT, so the fallback fires, and the probe keeps it working if Neovim ever moves to a VM without the bare `unpack`.
- `mysql.lua`'s `explain()` drops the `FORMAT=TREE` stderr on purpose: a failure there only means the server predates 8.0.16, and the plain-EXPLAIN retry produces the error worth showing.

## Verification

luacheck 1.2.0 locally — the same version the CI action's image pins — reports `0 warnings / 0 errors in 59 files`. Full spec suite passes. Note the renames in `er_diagram.lua` needed the `table.concat` call updated too: the shadowing was load-bearing there, so a half-done rename would have silently changed the FK prompt.

Complements `globals_spec` from #29, which covers the missing-require case from the bytecode side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)