### PR TITLE
test(specs): fix the tests that asserted nothing, and lint tests/ in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,11 @@ jobs:
       - uses: actions/checkout@v4
       # Settings live in .luacheckrc. Catches missing requires read as globals,
       # typo'd locals and shadowing — see tests/spec/globals_spec.lua for the
-      # bytecode-side check of the same class.
+      # bytecode-side check of the same class. tests/ is linted too: an unused
+      # local in a spec is often a result nothing asserted on.
       - uses: lunarmodules/luacheck@v1
         with:
-          args: lua/ plugin/ lazy.lua
+          args: lua/ plugin/ lazy.lua tests/
 
   test:
     runs-on: ubuntu-latest

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -26,12 +26,12 @@ unused_args = false
 -- Line length is left to review, not the linter.
 max_line_length = false
 
--- The gate covers shipped code only (see the `lint` recipe in the justfile).
--- tests/ is deliberately out: specs legitimately stub read-only fields such as
--- os.exit and os.time, and their remaining warnings are unused locals that look
--- like missing assertions — renaming those to `_` to please the linter would
--- hide the question rather than answer it. Worth its own pass.
+-- tests/ is in the gate too. Its warnings were worth reading rather than
+-- silencing: an unused local in a spec is often a result that was captured and
+-- never asserted on, or — worse — a test that re-implements the logic it claims
+-- to cover and so asserts on its own copy. See the mutation_spec rewrite. The
+-- two legitimate stubs of read-only fields (os.exit in the runner, os.time in
+-- connections_spec) carry inline `-- luacheck: push ignore 122` at their site.
 exclude_files = {
   ".luarocks",
-  "tests",
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **luacheck now covers `tests/` too, and the specs it flagged were fixed rather than silenced.**
+  Excluding the suite from the gate in 3.9.0 left 15 warnings unexamined; read individually, most
+  marked a real hole. Seven `mutation_spec` tests copied the statement-detection and
+  table/WHERE-extraction logic out of `init.lua` into their own bodies and asserted on the copy,
+  so they passed no matter what the plugin did — including the "UPDATE wrapped in SELECT" bug one
+  of them was named after. They now drive `_resolve_query` and `_mutation_preview` directly; each
+  new assertion was checked against a deliberately broken build to confirm it can fail.
+  `completion_spec` had the same defect in its auto-trigger guard test. `enum_hint_spec` fed the
+  editor a callback whose result nothing read, and tore the window down without going through the
+  cancel mapping, so a commit-on-cancel regression was invisible; the teardown now cancels for
+  real. `adapter_spec` and `duckdb_federation_spec` captured an error value and never checked it.
+  The two legitimate stubs of read-only fields (`os.exit` in the runner, `os.time` in
+  `connections_spec`) carry inline luacheck directives at their site. No production behaviour
+  changes.
+
 ## [3.9.0] - 2026-07-28
 
 ### Added
@@ -266,5 +285,6 @@ older tags are left in place so anyone pinned to them keeps working.
 - **joryeugene** — SQL Server adapter, PostgreSQL routines in the schema sidebar, focused ER diagram
   ([PR #17](https://github.com/joryeugene/dadbod-grip.nvim/pull/17)).
 
+[Unreleased]: https://github.com/joryeugene/dadbod-grip.nvim/compare/v3.9.0...HEAD
 [3.9.0]: https://github.com/joryeugene/dadbod-grip.nvim/releases/tag/v3.9.0
 [3.8.0]: https://github.com/joryeugene/dadbod-grip.nvim/releases/tag/v3.8.0

--- a/justfile
+++ b/justfile
@@ -15,7 +15,7 @@ spec name:
 # Lint with luacheck. Settings live in .luacheckrc; same args as CI.
 # Install: luarocks --lua-version=5.1 --local install luacheck
 lint:
-    luacheck lua/ plugin/ lazy.lua
+    luacheck lua/ plugin/ lazy.lua tests/
 
 # Seed PostgreSQL test database
 seed-pg:

--- a/tests/run_specs.lua
+++ b/tests/run_specs.lua
@@ -6,6 +6,7 @@
 -- Override os.exit so individual specs don't kill the runner
 local any_failure = false
 local real_exit = os.exit
+-- luacheck: push ignore 122
 os.exit = function(code)
   if code and code ~= 0 then any_failure = true end
 end
@@ -35,6 +36,7 @@ for _, file in ipairs(files) do
 end
 
 os.exit = real_exit
+-- luacheck: pop
 
 print("═══════════════════════════════════")
 if any_failure then

--- a/tests/spec/adapter_spec.lua
+++ b/tests/spec/adapter_spec.lua
@@ -777,7 +777,11 @@ test("duckdb get_constraints: returns empty list on query failure", function()
     with_system_mock("", "Error: table not found", 1, function()
       local result, err = duckdb.get_constraints("missing", "duckdb::memory:")
       eq(#result, 0, "empty list on error")
-      -- error is returned (or nil: either is acceptable since duckdb silences errors)
+      -- The error is swallowed on purpose: a non-zero exit here usually means the
+      -- server predates duckdb_constraints(), which must degrade to "no
+      -- constraints", not surface as a failure. Pinned so a later "let's
+      -- propagate the error" change has to face that trade-off deliberately.
+      eq(err, nil, "query failure reports no error")
     end)
   end)
 end)

--- a/tests/spec/completion_spec.lua
+++ b/tests/spec/completion_spec.lua
@@ -419,19 +419,19 @@ end
 -- parse_context("supplier.") should return "dotted" so the auto-trigger
 -- detects dotted context even when word == "".
 do
-  local ctx = completion.parse_context_full("FROM supplier.")
-  eq(ctx and ctx.type, "dotted", "auto-trigger guard: dotted context detected after '.'")
-  eq(ctx and ctx.qualifier, "supplier", "auto-trigger guard: qualifier is 'supplier'")
-  eq(ctx and ctx.word, "", "auto-trigger guard: word is empty after '.'")
+  local guard_ctx = completion.parse_context_full("FROM supplier.")
+  eq(guard_ctx and guard_ctx.type, "dotted", "auto-trigger guard: dotted context detected after '.'")
+  eq(guard_ctx and guard_ctx.qualifier, "supplier", "auto-trigger guard: qualifier is 'supplier'")
+  eq(guard_ctx and guard_ctx.word, "", "auto-trigger guard: word is empty after '.'")
 
-  -- Ensure before:match("[%w_]+%.[%w_]*$") fires for the guard condition
-  local before = "FROM supplier."
-  local in_dotted = before:match("[%w_]+%.[%w_]*$") ~= nil
-  ok(in_dotted, "auto-trigger guard: dotted pattern matches 'supplier.'")
-
-  local before2 = "FROM "
-  local not_dotted = before2:match("[%w_]+%.[%w_]*$") ~= nil
-  ok(not not_dotted, "auto-trigger guard: plain FROM does not match dotted pattern")
+  -- The autotrigger's own guard (completion.lua:532) tests the same thing with
+  -- the pattern parse_context holds at line 197, so assert through that function.
+  -- Re-matching the pattern in the test body, as this used to, only asserts that
+  -- string.match works: it stays green however the plugin's copies drift.
+  eq(completion.parse_context("FROM supplier."), "dotted",
+    "auto-trigger guard: 'supplier.' reads as dotted, so word == '' must not bail out")
+  eq(completion.parse_context("FROM "), "table",
+    "auto-trigger guard: a plain FROM is not dotted, so word == '' does bail out")
 end
 
 -- ── DuckDB federation: live-query fallback for SQLite attachments ─────────────

--- a/tests/spec/connections_spec.lua
+++ b/tests/spec/connections_spec.lua
@@ -311,6 +311,7 @@ end)
 
 test("switch: resulting file is byte-identical to the old add()+touch() sequence for the same inputs", function()
   local orig_os_time = os.time
+  -- luacheck: push ignore 122
   os.time = function() return 1700000000 end
 
   local old_content, new_content
@@ -332,6 +333,7 @@ test("switch: resulting file is byte-identical to the old add()+touch() sequence
   end)
 
   os.time = orig_os_time
+  -- luacheck: pop
 
   eq(old_content, new_content, "byte-identical output for the same logical mutation")
 end)

--- a/tests/spec/diff_spec.lua
+++ b/tests/spec/diff_spec.lua
@@ -162,7 +162,7 @@ test("render_compact: highlight marks match expected count", function()
   local left  = make_state({"id", "name"}, {"id"}, {{"1", "Alice"}, {"2", "Bob"}})
   local right = make_state({"id", "name"}, {"id"}, {{"1", "Alicia"}, {"2", "Bob"}})
   local result = diff.compute(left, right)
-  local lines, marks = diff._render_compact(result, left, right, left.columns)
+  local _, marks = diff._render_compact(result, left, right, left.columns)
   assert(#marks > 0, "should have highlight marks")
   -- Changed row: separator (1 mark) + changed col (1 mark) = at least 2
   local changed_marks = 0

--- a/tests/spec/duckdb_attach_spec.lua
+++ b/tests/spec/duckdb_attach_spec.lua
@@ -2,7 +2,6 @@
 dofile("tests/minimal_init.lua")
 local adapter = require("dadbod-grip.adapters.duckdb")
 
-local T = {}
 local pass, fail = 0, 0
 
 local function eq(a, b, msg)

--- a/tests/spec/duckdb_federation_spec.lua
+++ b/tests/spec/duckdb_federation_spec.lua
@@ -196,6 +196,7 @@ vim.fn.delete(native_duck_path)
 adapter.detach(duck_url, "supplier")
 tables, err = adapter.list_tables(duck_url)
 truthy(tables, "list_tables returns results after detach")
+eq(err, nil, "no error after detach")
 
 has_schema_field = false
 for _, t in ipairs(tables or {}) do

--- a/tests/spec/enum_hint_spec.lua
+++ b/tests/spec/enum_hint_spec.lua
@@ -156,16 +156,24 @@ end)
 
 --- Open the editor with opts, inspect its buffer via fn(buf), then cancel.
 local function with_editor(opts, fn)
-  local result_holder = {}
+  local committed = nil
   editor.open("orders.status", "pending", function(res)
-    result_holder.res = res
+    if res ~= nil then committed = res end
   end, opts)
   local buf = vim.api.nvim_get_current_buf()
   local win = vim.api.nvim_get_current_win()
   local ok, err = pcall(fn, buf)
+  -- Leave through the editor's own cancel mapping (NORMAL q) rather than closing
+  -- the window out from under it, so the teardown exercises the cancel path
+  -- instead of bypassing it. nvim_win_close is only the fallback.
   vim.cmd("stopinsert")
+  pcall(vim.cmd, "normal q")
   pcall(vim.api.nvim_win_close, win, true)
   if not ok then error(err) end
+  -- Cancelling must report nil, not write the value through. The callback used to
+  -- be captured into a table nothing ever read, so a commit-on-cancel regression
+  -- would have gone unnoticed here.
+  assert(committed == nil, "editor committed a value on cancel: " .. tostring(committed))
 end
 
 --- Collect virt_lines hint texts from the enum-hint namespace.

--- a/tests/spec/mutation_spec.lua
+++ b/tests/spec/mutation_spec.lua
@@ -16,123 +16,117 @@ local function eq(a, b, msg)
   assert(a == b, (msg or "") .. ": expected " .. tostring(b) .. ", got " .. tostring(a))
 end
 
--- ── resolve_query: statement detection ──
+local init = require("dadbod-grip")
+local view = require("dadbod-grip.view")
+local URL = "sqlite:tests/seed_sqlite.db"
 
-test("resolve_query: SELECT returns raw spec", function()
-  -- resolve_query is local, but we can test through the public interface
-  -- by checking that M.open doesn't error for SELECT
-  local query = require("dadbod-grip.query")
-  local spec = query.new_raw("SELECT * FROM users", 100)
+-- ── resolve_query: statement detection ──
+-- Through the real resolver, exported as _resolve_query for exactly this. An
+-- earlier version of these tests re-derived the keyword match in the test body
+-- (`sql:upper():match("^%s*(%u+)")`) and asserted on that, which is a test of
+-- string.match: it passes no matter what init.lua decides to do with the
+-- statement, including the very bug it was named after.
+
+test("resolve_query: SELECT returns a raw spec, not a mutation", function()
+  local spec, table_name, file_path, mutation = init._resolve_query("SELECT * FROM users", 100)
   assert(spec ~= nil, "spec should exist")
   eq(spec.is_raw, true, "is_raw")
   eq(spec.base_sql, "SELECT * FROM users", "base_sql")
+  eq(table_name, "users", "single-table SELECT still names its table")
+  eq(file_path, nil, "not a file")
+  eq(mutation, nil, "not routed to the mutation path")
 end)
 
-test("resolve_query: UPDATE is detected as mutation (not wrapped in SELECT)", function()
-  -- We test this by calling init.open with an UPDATE and checking it doesn't
-  -- produce a "no such table" error (which was the old bug: wrapping in SELECT)
-  -- Since resolve_query is local, we test the behavior:
-  -- An UPDATE should NOT be treated as a table name
-  local query = require("dadbod-grip.query")
-  -- If UPDATE were treated as table name, new_table would be called
-  -- Let's verify the first keyword detection
-  local sql = 'UPDATE "users" SET name = \'test\' WHERE id = 1'
-  local upper = sql:upper():match("^%s*(%u+)")
-  eq(upper, "UPDATE", "detects UPDATE keyword")
+-- The old bug: a mutation was treated as a table name and wrapped in SELECT,
+-- which surfaced as "no such table: UPDATE". The resolver must return the
+-- statement verbatim as its 4th value and nothing else.
+for _, case in ipairs({
+  { kw = "UPDATE",  sql = 'UPDATE "users" SET name = \'test\' WHERE id = 1' },
+  { kw = "DELETE",  sql = "DELETE FROM orders WHERE id = 5" },
+  { kw = "INSERT",  sql = "INSERT INTO users (name) VALUES ('test')" },
+  { kw = "REPLACE", sql = "REPLACE INTO users (id, name) VALUES (1, 'test')" },
+}) do
+  test("resolve_query: " .. case.kw .. " is routed to the mutation path", function()
+    local spec, table_name, file_path, mutation = init._resolve_query(case.sql, 100)
+    eq(spec, nil, "no SELECT spec")
+    eq(table_name, nil, "not treated as a table name")
+    eq(file_path, nil, "not a file")
+    eq(mutation, case.sql, "returned verbatim as mutation SQL")
+  end)
+end
+
+test("resolve_query: a bare word is a table name", function()
+  local spec, table_name, _, mutation = init._resolve_query("orders", 100)
+  assert(spec ~= nil, "spec should exist")
+  eq(spec.is_raw, false, "table spec is not raw")
+  eq(table_name, "orders", "table name passed through")
+  eq(mutation, nil, "not a mutation")
 end)
 
-test("resolve_query: DELETE is detected as mutation", function()
-  local sql = "DELETE FROM orders WHERE id = 5"
-  local upper = sql:upper():match("^%s*(%u+)")
-  eq(upper, "DELETE", "detects DELETE keyword")
-end)
+-- ── mutation preview: table and WHERE extraction ──
+-- _mutation_preview parses the table name and WHERE clause out of the statement
+-- and builds the preview SELECT from them, so session.state.sql is that parser's
+-- output. The previous tests copied its patterns into the test body instead,
+-- which cannot fail when the parser they were meant to cover changes.
 
-test("resolve_query: INSERT is detected as mutation", function()
-  local sql = "INSERT INTO users (name) VALUES ('test')"
-  local upper = sql:upper():match("^%s*(%u+)")
-  eq(upper, "INSERT", "detects INSERT keyword")
-end)
-
--- ── SQL parsing for preview ──
-
-test("extract table from UPDATE SQL", function()
-  local sql = 'UPDATE "orders" SET status = \'done\' WHERE id = 1'
-  local flat = sql:gsub("\n", " ")
-  local after_update = flat:match("[Uu][Pp][Dd][Aa][Tt][Ee]%s+(.*)")
-  local table_name = after_update:match('^"([^"]+)"')
-    or after_update:match("^`([^`]+)`")
-    or after_update:match("^([%w_%.]+)")
-  eq(table_name, "orders", "extracts table from UPDATE")
-end)
-
-test("extract table from DELETE SQL", function()
-  local sql = 'DELETE FROM "users" WHERE age > 60'
-  local flat = sql:gsub("\n", " ")
-  local table_name = flat:match('[Ff][Rr][Oo][Mm]%s+"([^"]+)"')
-    or flat:match("[Ff][Rr][Oo][Mm]%s+`([^`]+)`")
-    or flat:match("[Ff][Rr][Oo][Mm]%s+([%w_%.]+)")
-  eq(table_name, "users", "extracts table from DELETE")
-end)
-
-test("extract WHERE from UPDATE SQL", function()
-  local sql = 'UPDATE orders SET status = \'done\' WHERE id = 1;'
-  local flat = sql:gsub("\n", " ")
-  local where = flat:match("[Ww][Hh][Ee][Rr][Ee]%s+(.+)$")
-  if where then where = where:gsub("%s*;%s*$", "") end
-  eq(where, "id = 1", "extracts WHERE clause")
-end)
-
-test("extract WHERE from DELETE SQL", function()
-  local sql = "DELETE FROM orders WHERE status = 'cancelled' ORDER BY id LIMIT 10;"
-  local flat = sql:gsub("\n", " ")
-  local where = flat:match("[Ww][Hh][Ee][Rr][Ee]%s+(.+)$")
-  if where then
-    where = where:gsub("%s*;%s*$", "")
-    where = where:gsub("%s+[Oo][Rr][Dd][Ee][Rr]%s+[Bb][Yy].*$", "")
-    where = where:gsub("%s+[Ll][Ii][Mm][Ii][Tt]%s+.*$", "")
-  end
-  eq(where, "status = 'cancelled'", "extracts WHERE, strips ORDER BY/LIMIT")
-end)
-
--- ── mutation preview: grid opens with pending_mutation ──
-
-test("_mutation_preview opens grid with pending_mutation flag", function()
-  -- This requires a real DB. Use the test sqlite DB.
-  local init = require("dadbod-grip")
-  local view = require("dadbod-grip.view")
-  local url = "sqlite:tests/seed_sqlite.db"
-
-  -- Clean up any existing sessions
-  for bufnr, _ in pairs(view._sessions) do
-    view._sessions[bufnr] = nil
-    pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
-  end
-
-  -- Call _mutation_preview directly
-  local mutation_sql = 'UPDATE "orders" SET status = \'done\' WHERE id = 1'
-  init._mutation_preview(mutation_sql, url, "UPDATE", {})
-
-  -- Check that a grid was opened with pending_mutation
-  local found_mutation = false
-  for bufnr, session in pairs(view._sessions) do
-    if session.pending_mutation then
-      found_mutation = true
-      eq(session.pending_mutation.type, "UPDATE", "mutation type")
-      eq(session.pending_mutation.table_name, "orders", "mutation table")
-      assert(session.pending_mutation.row_count >= 0, "row_count set")
-      assert(session.pending_mutation.sql == mutation_sql, "original SQL stored")
-    end
-  end
-  assert(found_mutation, "grid opened with pending_mutation flag")
-
-  -- Clean up
-  for bufnr, _ in pairs(view._sessions) do
+local function close_sessions()
+  for bufnr in pairs(view._sessions) do
     view._sessions[bufnr] = nil
     pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
   end
   while #vim.api.nvim_tabpage_list_wins(0) > 1 do
-    pcall(vim.api.nvim_win_close, vim.api.nvim_tabpage_list_wins(0)[#vim.api.nvim_tabpage_list_wins(0)], true)
+    local wins = vim.api.nvim_tabpage_list_wins(0)
+    pcall(vim.api.nvim_win_close, wins[#wins], true)
   end
+end
+
+--- Run the real preview against the sqlite seed, hand back the session it staged.
+local function preview(mutation_sql, stmt_type)
+  close_sessions()
+  init._mutation_preview(mutation_sql, URL, stmt_type, {})
+  for _, session in pairs(view._sessions) do
+    if session.pending_mutation then return session end
+  end
+  error("no grid opened with pending_mutation for: " .. mutation_sql)
+end
+
+test("preview: UPDATE with a quoted table scopes the preview to its WHERE", function()
+  local mutation_sql = 'UPDATE "orders" SET status = \'done\' WHERE id = 1'
+  local s = preview(mutation_sql, "UPDATE")
+  eq(s.pending_mutation.type, "UPDATE", "mutation type")
+  eq(s.pending_mutation.table_name, "orders", "table parsed out of the quoted identifier")
+  eq(s.state.sql, 'SELECT * FROM "orders" WHERE id = 1', "preview SELECT")
+  eq(s.pending_mutation.row_count, 1, "one row matches the WHERE")
+  eq(s.pending_mutation.sql, mutation_sql, "original SQL stored")
+  close_sessions()
+end)
+
+test("preview: DELETE reads its table from FROM and stages every matched row", function()
+  local s = preview('DELETE FROM "users" WHERE age > 40', "DELETE")
+  eq(s.pending_mutation.table_name, "users", "table parsed out of the FROM clause")
+  eq(s.state.sql, 'SELECT * FROM "users" WHERE age > 40', "preview SELECT")
+  eq(s.pending_mutation.row_count, 3, "three seeded users are over 40")
+  local staged = 0
+  for _ in pairs(s.state.deleted) do staged = staged + 1 end
+  eq(staged, 3, "every previewed row is marked deleted, which is what shows it red")
+  close_sessions()
+end)
+
+test("preview: DELETE drops ORDER BY and LIMIT from the extracted WHERE", function()
+  -- The WHERE has to survive into a plain SELECT. Carrying ORDER BY/LIMIT over
+  -- would preview a different row set than the statement is going to touch.
+  local s = preview("DELETE FROM orders WHERE status = 'cancelled' ORDER BY id LIMIT 10;", "DELETE")
+  eq(s.state.sql, 'SELECT * FROM "orders" WHERE status = \'cancelled\'',
+    "trailing ORDER BY, LIMIT and semicolon stripped")
+  close_sessions()
+end)
+
+test("preview: INSERT previews the whole table and counts the incoming rows", function()
+  local s = preview("INSERT INTO users (name) VALUES ('probe')", "INSERT")
+  eq(s.pending_mutation.table_name, "users", "table parsed out of INSERT INTO")
+  eq(s.state.sql, 'SELECT * FROM "users"', "no WHERE for INSERT")
+  eq(s.pending_mutation.row_count, 1, "row_count is the rows being inserted, not the table size")
+  close_sessions()
 end)
 
 -- ── delete on inserted row ──
@@ -158,14 +152,16 @@ test("delete on inserted row removes it via undo_row", function()
   state = data.undo_row(state, ins_idx)
   eq(state.inserted[ins_idx], nil, "inserted row removed by undo_row")
 
-  -- toggle_delete should NOT be used for inserted rows
-  -- (this is a design test: the on_delete callback should check)
+  -- toggle_delete is the wrong verb for an unsaved inserted row: it only adds a
+  -- delete mark, leaving the row in `inserted` and thus staged both ways. That
+  -- is by design, not a bug -- deciding between the two is the caller's job, and
+  -- init.lua's on_delete does branch on state.inserted[row_idx] before choosing.
+  -- Both halves of that contract are pinned here so the branch stays meaningful.
   state = data.insert_row(state, 0)
   for idx in pairs(state.inserted) do ins_idx = idx end
   state = data.toggle_delete(state, ins_idx)
-  -- toggle_delete marks it in deleted but doesn't remove from inserted
   eq(state.deleted[ins_idx], true, "toggle_delete marks deleted")
-  assert(state.inserted[ins_idx] ~= nil, "toggle_delete does NOT remove from inserted (bug)")
+  assert(state.inserted[ins_idx] ~= nil, "toggle_delete leaves the row in inserted")
 end)
 
 print(string.format("\nmutation_spec: %d passed, %d failed", pass, fail))

--- a/tests/spec/mysql_integration_spec.lua
+++ b/tests/spec/mysql_integration_spec.lua
@@ -294,7 +294,7 @@ test("explain: SELECT produces a plan and never runs DML", function()
   assert(before ~= SENTINEL,
     "orders.id=1 already holds the sentinel; reseed with tests/seed_mysql.sql")
 
-  local ok, err = pcall(function()
+  local ok, sentinel_err = pcall(function()
     my.explain("UPDATE orders SET status = '" .. SENTINEL .. "' WHERE id = 1", URL)
     local after = my.query("SELECT status FROM orders WHERE id = 1", URL).rows[1][1]
     eq(after, before, "EXPLAIN must not mutate data")
@@ -302,7 +302,7 @@ test("explain: SELECT produces a plan and never runs DML", function()
 
   my.execute(string.format("UPDATE orders SET status = '%s' WHERE id = 1",
     sql.escape_literal(before)), URL)
-  if not ok then error(err) end
+  if not ok then error(sentinel_err) end
 end)
 
 print(string.format("\nmysql_integration_spec: %d passed, %d failed", pass, fail))

--- a/tests/spec/palette_spec.lua
+++ b/tests/spec/palette_spec.lua
@@ -24,10 +24,6 @@ local function gt(a, b, msg)
   assert(a > b, (msg or "") .. ": expected > " .. tostring(b) .. ", got " .. tostring(a))
 end
 
-local function is_fn(v, msg)
-  assert(type(v) == "function", (msg or "") .. ": expected function, got " .. type(v))
-end
-
 -- ── M.register ────────────────────────────────────────────────────────────
 
 test("register: accepts valid action", function()

--- a/tests/spec/profile_spec.lua
+++ b/tests/spec/profile_spec.lua
@@ -206,7 +206,7 @@ end)
 
 test("build_lines: highlight marks generated", function()
   local data = mock_profile_data()
-  local lines, marks = profile.build_lines(data, 120)
+  local _, marks = profile.build_lines(data, 120)
   assert(#marks > 0, "should have highlight marks")
 end)
 

--- a/tests/spec/sticky_header_spec.lua
+++ b/tests/spec/sticky_header_spec.lua
@@ -134,7 +134,7 @@ end
 
 test("scrolled: the grid window carries the header row in its winbar", function()
   cleanup()
-  local bufnr, win = open_scrolled_grid()
+  local _, win = open_scrolled_grid()
   local winbar = vim.wo[win].winbar
   assert(winbar:find("GripHeader", 1, true), "no GripHeader group: " .. vim.inspect(winbar))
   assert(winbar:find("email", 1, true), "column names missing: " .. vim.inspect(winbar))


### PR DESCRIPTION
Follow-up to #30, which put luacheck in CI but excluded `tests/`. That exclusion left 15 warnings unread, on the stated grounds that renaming unused locals to `_` would hide the question rather than answer it. This answers it. Read one at a time, most of those warnings marked a real hole, and the specs were fixed rather than silenced.

## mutation_spec asserted on its own copy of the code

Seven of its ten tests lifted `init.lua`'s statement detection and table/WHERE extraction into the test body and asserted on that:

```lua
test("resolve_query: UPDATE is detected as mutation (not wrapped in SELECT)", function()
  local query = require("dadbod-grip.query")   -- required, never used
  local sql = 'UPDATE "users" SET name = \'test\' WHERE id = 1'
  local upper = sql:upper():match("^%s*(%u+)")
  eq(upper, "UPDATE", "detects UPDATE keyword")  -- a test of string.match
end)
```

That passes however `init.lua` behaves. Proven, not assumed — with `UPDATE` removed from `resolve_query`'s destructive-statement list, which is exactly the bug this test is named after, the old spec reported **10 passed, 0 failed**. Same result with the `ORDER BY`/`LIMIT` stripping deleted from the WHERE extractor.

The rewrite drives the real code: `_resolve_query` for statement routing, and `_mutation_preview` against the sqlite seed for extraction, where `session.state.sql` *is* the parser's output. Each new assertion was checked against a deliberately broken build:

| Broken build | Caught by |
|---|---|
| `ORDER BY`/`LIMIT` stripping removed | `preview: DELETE drops ORDER BY and LIMIT…` |
| quoted identifiers dropped from `DELETE … FROM` | `preview: DELETE reads its table from FROM…` |
| `UPDATE` routed as a table name (the original bug) | `resolve_query: UPDATE is routed to the mutation path` |
| `DELETE` rows no longer staged as deleted | `preview: DELETE … stages every matched row` |

It also covers `REPLACE INTO` and the bare-table-name path, which had no test at all. `completion_spec` had the same defect in its auto-trigger guard test, re-matching a pattern lifted from `completion.lua:532`; it now asserts through `parse_context`, which holds the canonical copy.

## enum_hint_spec never exercised the path it tore down

`with_editor` handed the editor a callback that stored its result in a table nothing ever read, then closed the window with `nvim_win_close` — bypassing the cancel path entirely. My first attempt just asserted the captured result was nil; mutation testing showed that assertion was **vacuous**, since `do_cancel` never ran. The teardown now leaves through the editor's own `q` mapping. An editor mutated to commit on cancel fails three tests; before the change it failed none.

## Smaller

- `adapter_spec` and `duckdb_federation_spec` captured an error value and never checked it. `get_constraints` swallowing its error is deliberate — older DuckDB has no `duckdb_constraints()` — so that is now pinned as a decision rather than left ambiguous by a comment admitting "either is acceptable".
- Positional discards in `diff_spec`, `profile_spec`, `sticky_header_spec` use `_`.
- Dead helpers dropped: `is_fn` in `palette_spec` (the check it duplicates is done inline with better messages), `local T` in `duckdb_attach_spec`.
- Shadowed locals renamed in `completion_spec` and `mysql_integration_spec`.
- The two legitimate stubs of read-only fields — `os.exit` in the runner, `os.time` in `connections_spec` — carry inline `-- luacheck: push ignore 122` at their site, so the blanket exclusion is no longer needed for them.

## Verification

- `luacheck lua/ plugin/ lazy.lua tests/` → **0 warnings / 0 errors in 124 files**; `tests/` is now in the gate in both CI and the `just lint` recipe.
- Suite green on **nvim 0.10.0** and **0.12.4**.
- Green again with `duckdb` and `mysql` on `PATH`, so `duckdb_federation_spec` (36 assertions) and the MySQL integration spec actually ran instead of skipping — the new `eq(err, nil)` there would otherwise have shipped unexecuted.

No production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)