### PR TITLE
ci(test): install the DuckDB CLI so 66 gated assertions actually run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,30 @@ jobs:
           version: ${{ matrix.neovim }}
       - name: Seed SQLite test database
         run: sqlite3 tests/seed_sqlite.db < tests/seed_sqlite.sql
+      # duckdb_federation, duckdb_native_schema and duckdb_federated_schema gate on
+      # this binary — 66 assertions that print SKIPPED without it while the runner
+      # still reports ALL TESTS PASSED. Pinned rather than floating: those specs
+      # assert on catalog and cross-database semantics that have changed across
+      # DuckDB minors, so a bump belongs in a commit of its own. To bump, change the
+      # version and replace the checksum with the new asset's sha256.
+      - name: Install DuckDB CLI
+        run: |
+          curl -fsSL -o duckdb.zip \
+            https://github.com/duckdb/duckdb/releases/download/v1.5.5/duckdb_cli-linux-amd64.zip
+          echo "08c0ca117111fcede14239d0093792352befdc174218c344d232c13279643d05  duckdb.zip" \
+            | sha256sum -c -
+          mkdir -p "$RUNNER_TEMP/duckdb"
+          unzip -q duckdb.zip -d "$RUNNER_TEMP/duckdb"
+          rm duckdb.zip
+          echo "$RUNNER_TEMP/duckdb" >> "$GITHUB_PATH"
+      # GITHUB_PATH only applies to later steps, so the check is its own step. It
+      # is not redundant with GRIP_REQUIRE_DUCKDB below: this one names the cause.
+      - name: Verify DuckDB is on PATH
+        run: duckdb --version
       - name: Run unit tests
+        # Turns a missing duckdb/sqlite3 into a failure instead of a silent skip,
+        # so removing the step above can't quietly take those 66 assertions with it.
+        env:
+          GRIP_REQUIRE_DUCKDB: '1'
         run: |
           nvim --headless -u tests/minimal_init.lua -l tests/run_specs.lua

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **CI installs the DuckDB CLI, so 66 previously unrun assertions actually run.**
+  `duckdb_federation_spec`, `duckdb_native_schema_spec` and `duckdb_federated_schema_spec` gate on
+  the `duckdb` binary and printed `SKIPPED` without it, while the runner still reported
+  `ALL TESTS PASSED` — cross-database federation, native non-`main` schemas and schema-prefixed
+  table names were never exercised on any push. The version is pinned (1.5.5) and the download
+  checksum-verified, because those specs assert on catalog semantics that have changed across
+  DuckDB minors; a bump should be a deliberate commit. The three specs still skip locally when
+  `duckdb` is absent, but CI sets `GRIP_REQUIRE_DUCKDB=1`, which turns a missing binary into a
+  failure so the install step cannot be dropped without the suite going red.
+
 - **luacheck now covers `tests/` too, and the specs it flagged were fixed rather than silenced.**
   Excluding the suite from the gate in 3.9.0 left 15 warnings unexamined; read individually, most
   marked a real hole. Seven `mutation_spec` tests copied the statement-detection and

--- a/tests/spec/duckdb_federated_schema_spec.lua
+++ b/tests/spec/duckdb_federated_schema_spec.lua
@@ -35,7 +35,12 @@ local function falsy(v, msg)
   end
 end
 
+-- CI sets GRIP_REQUIRE_DUCKDB so a missing binary fails instead of skipping:
+-- the runner prints ALL TESTS PASSED either way.
 if vim.fn.executable("duckdb") ~= 1 then
+  if vim.env.GRIP_REQUIRE_DUCKDB == "1" then
+    error("duckdb_federated_schema_spec: duckdb missing while GRIP_REQUIRE_DUCKDB=1")
+  end
   print("duckdb_federated_schema_spec: SKIPPED (duckdb not found)")
   return
 end

--- a/tests/spec/duckdb_federation_spec.lua
+++ b/tests/spec/duckdb_federation_spec.lua
@@ -24,8 +24,13 @@ local function truthy(v, msg)
   end
 end
 
--- Skip if duckdb or sqlite3 not available
+-- Skip if duckdb or sqlite3 not available. CI sets GRIP_REQUIRE_DUCKDB so a
+-- missing binary fails instead: the runner prints ALL TESTS PASSED either way,
+-- which is how these assertions went unrun in CI for as long as they did.
 if vim.fn.executable("duckdb") ~= 1 or vim.fn.executable("sqlite3") ~= 1 then
+  if vim.env.GRIP_REQUIRE_DUCKDB == "1" then
+    error("duckdb_federation_spec: duckdb or sqlite3 missing while GRIP_REQUIRE_DUCKDB=1")
+  end
   print("duckdb_federation_spec: SKIPPED (duckdb or sqlite3 not found)")
   return
 end

--- a/tests/spec/duckdb_native_schema_spec.lua
+++ b/tests/spec/duckdb_native_schema_spec.lua
@@ -35,7 +35,12 @@ local function falsy(v, msg)
   end
 end
 
+-- CI sets GRIP_REQUIRE_DUCKDB so a missing binary fails instead of skipping:
+-- the runner prints ALL TESTS PASSED either way.
 if vim.fn.executable("duckdb") ~= 1 then
+  if vim.env.GRIP_REQUIRE_DUCKDB == "1" then
+    error("duckdb_native_schema_spec: duckdb missing while GRIP_REQUIRE_DUCKDB=1")
+  end
   print("duckdb_native_schema_spec: SKIPPED (duckdb not found)")
   return
 end


### PR DESCRIPTION
Follow-up to #32, which noted that a green suite did not mean the DuckDB specs had run.

Three specs gate on the `duckdb` binary, which the runner has never had. They printed `SKIPPED` and the suite still reported `ALL TESTS PASSED`, so cross-database federation, native non-`main` schemas and schema-prefixed table names were never exercised on any push. Measured by running the suite with and without the binary on `PATH`:

```
- duckdb_federated_schema_spec: SKIPPED (duckdb not found)    →  14 passed, 0 failed
- duckdb_federation_spec: SKIPPED (duckdb or sqlite3 not found) →  36 passed, 0 failed
- duckdb_native_schema_spec: SKIPPED (duckdb not found)       →  16 passed, 0 failed
```

## Pinned, not floating

1.5.5 with the download checksum-verified. These specs assert on catalog and cross-database semantics that have changed across DuckDB minors, so a version bump should be a commit someone made deliberately rather than a build that goes red on its own one morning. The comment in the workflow says how to bump. Verified locally against 1.1.3 and 1.5.5, on nvim 0.10.0 and 0.12.4.

Unzipped into `RUNNER_TEMP` and exported through `GITHUB_PATH` rather than written to `/usr/local/bin`, which is root-owned on hosted runners.

## The skip is now loud in CI

Installing the binary fixes today's gap but not the failure mode: delete the step later and the suite quietly goes back to reporting `ALL TESTS PASSED` over 66 assertions it never ran. So the three gates now honour `GRIP_REQUIRE_DUCKDB`, which CI sets:

```lua
if vim.fn.executable("duckdb") ~= 1 then
  if vim.env.GRIP_REQUIRE_DUCKDB == "1" then
    error("duckdb_native_schema_spec: duckdb missing while GRIP_REQUIRE_DUCKDB=1")
  end
  print("duckdb_native_schema_spec: SKIPPED (duckdb not found)")
  return
end
```

Contributors without duckdb are not blocked — locally, with no flag set, the specs still skip and the suite is green. Checked all three ways: no binary + flag → `RESULT: SOME TESTS FAILED` naming each spec; binary + flag → pass; no binary, no flag → skips, green.

## Still not covered

`pg_integration_spec` and `mysql_integration_spec` gate on `GRIP_TEST_PG_URL`/`GRIP_TEST_MYSQL_URL` and a reachable server, so they remain skipped in CI. Wiring those up means adding `services:` containers to the job — a bigger change than this one, and not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)