### PR TITLE
feat(profile): ASCII distribution in the gS column-statistics popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **ASCII distribution in the `gS` column-statistics popup.** Numeric columns get the eight
+  `build_histogram_sql` buckets with their bounds labelled and their counts drawn as horizontal
+  bars; every other type gets its top values the same way. Bars resolve to an eighth of a cell,
+  and a non-zero count never renders as blank — one row out of ten million must not be
+  indistinguishable from an empty bucket. `profile.hbar`, `profile.bucket_bounds`,
+  `profile.is_bucketed`, `profile.gather_column` and `profile.build_column_lines` are the new
+  public surface; the popup's logic moved out of the keymap closure into `profile.lua`, where it
+  is unit-testable.
+
+### Fixed
+
+- **Date columns produced a meaningless sparkline in `gR`.** A date's `MIN`/`MAX` are timestamp
+  strings, so `build_histogram_sql` always answered it with a top-values `GROUP BY` — but the
+  branch that read the rows back listed `text`, `boolean` and `unknown` and left `date` out. Date
+  rows therefore went down the bucketed path, where `tonumber("2025-01-02 13:13:00")` is `nil`,
+  every value collapsed into bucket 1, and the column drew one bar and seven zeros with no top
+  values to fall back on. Both sides now ask `profile.is_bucketed()`, so the SQL and the reader
+  cannot disagree again.
+- **Multibyte values were corrupted in the `gS` popup.** Top values were cut with
+  `value:sub(1, 30)` — a byte offset derived from a display-cell budget — which sliced Cyrillic,
+  CJK and emoji values mid-character. Labels are now truncated and padded with `ui.pad_display`.
+
 ### Changed
+
+- **`gS` shows a distribution instead of a bare top-5 list.** Text, boolean and date columns list
+  their top 8 values (was 5), and numeric columns show bucket ranges rather than individual
+  values, since the top values of an `id`-like column are all count 1. The popup still issues
+  exactly two queries: the distribution replaced its bespoke top-values query rather than adding
+  to it.
 
 - **CI installs the DuckDB CLI, so 66 previously unrun assertions actually run.**
   `duckdb_federation_spec`, `duckdb_native_schema_spec` and `duckdb_federated_schema_spec` gate on

--- a/KEYMAPS.md
+++ b/KEYMAPS.md
@@ -134,7 +134,7 @@ Opens with the top level expanded and children collapsed; documents with ≤ 20 
 | Key | Action |
 |-----|--------|
 | `ga` | Aggregate current column (count, sum, avg, min, max) |
-| `gS` | Column statistics popup (distinct, nulls%, top values) |
+| `gS` | Column statistics popup (distinct, nulls%, ASCII distribution) |
 | `gR` | Table profile (sparkline distributions) |
 | `gV` | Show CREATE TABLE DDL float |
 | `gQ` | Explain current query plan |

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ work without credentials.
 - **Reverse FK navigation** via `gm` to open the rows in other tables that reference the current row (e.g. `orders.user_id ← users`). One referencing table opens directly; several show a picker of `child_table.fk_column`. Hops chain: users → orders → order_items.
 - **Query history** via `gh` or `:GripHistory` browsing all executed queries with timestamp and SQL preview, stored in `.grip/history.jsonl`.
 - **Data profiling** via `gR` or `:GripProfile` showing sparkline distributions, completeness, cardinality, and top values per column.
-- **Column statistics** via `gS` showing count, distinct, nulls, min/max, and top values.
+- **Column statistics** via `gS` showing count, distinct, nulls, min/max, and an ASCII distribution: numeric columns get eight labelled buckets, everything else gets its top values, both as horizontal bars.
 - **Aggregate on selection** via `ga` in visual mode showing count/sum/avg/min/max.
 - **Query Doctor** via `:GripExplain` translating EXPLAIN plans into plain-English health checks with cost bars and index suggestions.
 - **AI SQL generation** via `A` or `:GripAsk` turning natural language into SQL queries using Anthropic, OpenAI, Gemini, or local Ollama. AI reads existing query pad SQL to modify it rather than generating from scratch. Schema context cached per connection.
@@ -382,7 +382,7 @@ Note: explain query plan is at `gQ` (Query Doctor).
 | Key | Action |
 |-----|--------|
 | `ga` | Aggregate selected cells (visual mode) |
-| `gS` | Column statistics popup |
+| `gS` | Column statistics popup (with ASCII distribution) |
 | `gR` | Table profile (sparkline distributions) |
 | `gQ` | Query Doctor (plain-English EXPLAIN) |
 | `gx` | Open URL in current cell (http/https/ftp) |

--- a/TODO.md
+++ b/TODO.md
@@ -40,7 +40,7 @@ Not committed to any release. Roughly ordered by expected impact.
 ### High Value -- Adapters
 - [ ] Snowflake adapter (snowsql CLI, auth delegated to `~/.snowsql/config`, 3-level hierarchy database/schema/table, `SHOW TABLES IN DATABASE` metadata, warehouse selection)
 - [ ] BigQuery adapter (bq CLI, auth via gcloud ADC, project/dataset/table hierarchy, `bq show --format=json` for schema, `bq query --use_legacy_sql=false`)
-- [ ] MSSQL adapter (sqlcmd CLI, `mssql://` scheme, sys.tables/sys.columns metadata, SET STATISTICS for explain, TOP N pagination, `##temp` table support)
+- [x] MSSQL adapter (sqlcmd CLI, `mssql://` scheme, sys.tables/sys.columns metadata, SET STATISTICS for explain): shipped v3.8.0, read-only. TOP N pagination and `##temp` table support are still open.
 - [ ] Turso/libSQL adapter (extend SQLite adapter with HTTP transport, auth token in URL, branch management via `:GripBranch`, time-travel queries)
 - [ ] CockroachDB adapter (extend PostgreSQL adapter, `cockroachdb://` scheme, CDC changefeed exposure, multi-region config display in properties)
 - [ ] MongoDB: deprioritized; document model incompatible with grid renderer; needs separate path (JSON tree view, not tabular)
@@ -48,18 +48,18 @@ Not committed to any release. Roughly ordered by expected impact.
 ### High Value -- Cell Editor
 - [x] Timestamp cells: detect ISO timestamp pattern in cell editor, show parsed human-readable date as extmark virtual text below the input line: shipped v1.2.0
 - [x] URL cells: `gx` opens the URL in the system browser -- cell editor NORMAL mode (buf-local keymap) and grid (current cell value): shipped v1.2.0
-- [ ] Markdown columns: auto-set `ft=markdown` in cell editor for columns named body, description, notes, content, text, bio (column name heuristic)
+- [x] Markdown columns: auto-set `ft=markdown` in cell editor for columns named body, description, notes, content, text, bio (column name heuristic): shipped with `gB` (`cell_buffer.lua`, `PROSE_COLUMNS`)
 - [x] Enum hint: if column has known distinct values, show them as virtual text in the cell editor (on-demand SELECT DISTINCT, cached per session): shipped
 
 ### Medium Value
 - [ ] Column reordering via keymap (`<` / `>` to shift column left/right)
-- [ ] Inline column resize with `+`/`-` on header row
+- [x] Inline column resize: solved differently in v3.4.0 -- `=` (`grid_col_width`) cycles the column under the cursor through compact -> expanded -> reset. `+`/`-` on the header row is not the binding to use: `-` already hides a column.
 - [ ] Bookmarked rows (mark interesting rows with `m`, recall with `'`, persist per table in `.grip/bookmarks.json`)
-- [ ] Multi-row selection for bulk ops (visual `V`-mode selects rows, then `d`=bulk DELETE, `gy`=copy all as table)
+- [x] Multi-row selection for bulk ops: shipped v3.4.0 (`view/keymaps_visual_batch.lua` -- visual `d` stages the selected rows for DELETE, `e` bulk-edits, `x` sets NULL, `y` yanks the column slice). Only `gy`-as-table is missing; `gE` already exports the whole grid in six formats.
 - [x] Quick data generation (`:GripFill N` / `gA` in grid): shipped v1.2.0 (merged with AI-assisted data generation)
 - [x] Connection health indicators: `*`/`o`/`x` dots in connection picker; `T` retests file connections; status set on successful switch
 - [ ] Saved views: persist full grid state (active filters, sort, hidden columns, page size) as a named snapshot per table in `.grip/views.json`; recall without writing SQL
-- [ ] ASCII histogram for numeric columns: extend `gS` to show a quick distribution histogram inline; complement to stats popup
+- [x] ASCII histogram for numeric columns: extend `gS` to show a quick distribution histogram inline; complement to stats popup: shipped (horizontal bars, eight labelled buckets for numeric, top values for every other type)
 - [ ] Row pinning: mark up to 5 rows to keep visible at the top of every page regardless of filter/sort; useful as reference anchors while editing
 
 ### Exploration

--- a/doc/dadbod-grip.txt
+++ b/doc/dadbod-grip.txt
@@ -584,7 +584,9 @@ ANALYSIS AND EXPORT ~
   ga              Aggregate selected cells (visual mode)
                   Shows count, sum, avg, min, max
   gS              Column statistics popup
-                  Shows count, distinct, nulls, min/max, top values
+                  Shows count, distinct, nulls, min/max and an ASCII
+                  distribution as horizontal bars: numeric columns get eight
+                  labelled buckets, every other type gets its top 8 values
   gQ              Explain current query plan
   gx              Open URL in current cell (http/https/ftp)
   gR              Table profile (sparkline distributions)

--- a/lua/dadbod-grip/profile.lua
+++ b/lua/dadbod-grip/profile.lua
@@ -9,8 +9,15 @@ local M = {}
 
 local SPARK_CHARS = { "\xe2\x96\x81", "\xe2\x96\x82", "\xe2\x96\x83", "\xe2\x96\x84",
                       "\xe2\x96\x85", "\xe2\x96\x86", "\xe2\x96\x87", "\xe2\x96\x88" }
+-- Horizontal bars: a full block plus the seven eighth-width blocks, so a bar
+-- resolves to 1/8 of a cell instead of a whole one.
+local HBAR_FULL = "\xe2\x96\x88"
+local HBAR_FRAC = { "\xe2\x96\x8f", "\xe2\x96\x8e", "\xe2\x96\x8d", "\xe2\x96\x8c",
+                    "\xe2\x96\x8b", "\xe2\x96\x8a", "\xe2\x96\x89" }
 local MAX_COLUMNS = 20
 local BUCKET_COUNT = 8
+local HBAR_WIDTH = 16      -- display cells a full-scale bar occupies
+local HBAR_LABEL_MAX = 30  -- widest bucket/value label; matches the popup's old cut
 
 -- ── pure helpers ──────────────────────────────────────────────────────────────
 
@@ -26,6 +33,44 @@ function M.sparkline(counts, max_count)
     table.insert(parts, SPARK_CHARS[idx])
   end
   return table.concat(parts)
+end
+
+--- Build a horizontal bar `width` display cells wide at full scale.
+--- A non-zero count never renders as empty: anything that would round below one
+--- eighth still gets the thinnest block. One row out of ten million has to stay
+--- visible, otherwise it is indistinguishable from an empty bucket.
+function M.hbar(count, max_count, width)
+  width = width or HBAR_WIDTH
+  local c = tonumber(count) or 0
+  local mx = tonumber(max_count) or 0
+  if c <= 0 or mx <= 0 or width <= 0 then return "" end
+
+  local eighths = math.floor((c / mx) * width * 8 + 0.5)
+  eighths = math.max(1, math.min(width * 8, eighths))
+  local bar = string.rep(HBAR_FULL, math.floor(eighths / 8))
+  local rem = eighths % 8
+  if rem > 0 then bar = bar .. HBAR_FRAC[rem] end
+  return bar
+end
+
+--- The BUCKET_COUNT ranges a numeric histogram spans, or nil when the column
+--- cannot be bucketed at all (missing, equal or non-numeric bounds -- a date
+--- whose MIN is a timestamp string lands here).
+--- Buckets are half-open [lo, hi) except the last, whose hi is max_val and is
+--- inclusive, because build_histogram_sql emits it as the CASE's ELSE arm.
+--- This is the single source of truth for the step: the SQL thresholds and the
+--- labels in the gS popup are both generated from it, so they cannot drift.
+function M.bucket_bounds(min_val, max_val)
+  if not min_val or not max_val or min_val == max_val then return nil end
+  local min_n, max_n = tonumber(min_val), tonumber(max_val)
+  if not min_n or not max_n then return nil end
+
+  local step = (max_n - min_n) / BUCKET_COUNT
+  local bounds = {}
+  for b = 1, BUCKET_COUNT do
+    bounds[b] = { lo = min_n + step * (b - 1), hi = min_n + step * b }
+  end
+  return bounds
 end
 
 --- Classify a column's data type into a profiling category.
@@ -75,40 +120,34 @@ function M.build_stats_sql(table_name, col_infos)
   return "SELECT " .. table.concat(parts, ", ")
 end
 
+--- Whether a column of `col_type` with these bounds gets CASE buckets rather
+--- than a top-values GROUP BY. Callers need to know which shape a
+--- build_histogram_sql result will have before they read its rows.
+function M.is_bucketed(col_type, min_val, max_val)
+  if col_type ~= "numeric" and col_type ~= "date" then return false end
+  return M.bucket_bounds(min_val, max_val) ~= nil
+end
+
 --- Build a histogram query for one column.
+--- Text, boolean and unknown columns -- and anything numeric or date-like whose
+--- bounds cannot be bucketed -- get the top BUCKET_COUNT values by frequency.
 function M.build_histogram_sql(table_name, col_name, col_type, min_val, max_val)
   local tbl = sql.quote_ident(table_name)
   local col = sql.quote_ident(col_name)
 
-  if col_type == "text" or col_type == "boolean" or col_type == "unknown" then
+  if not M.is_bucketed(col_type, min_val, max_val) then
     return string.format(
       "SELECT %s AS val, COUNT(*) AS cnt FROM %s WHERE %s IS NOT NULL GROUP BY %s ORDER BY cnt DESC LIMIT %d",
       col, tbl, col, col, BUCKET_COUNT
     )
   end
 
-  -- Numeric or date: build CASE WHEN buckets
-  if not min_val or not max_val or min_val == max_val then
-    return string.format(
-      "SELECT %s AS val, COUNT(*) AS cnt FROM %s WHERE %s IS NOT NULL GROUP BY %s ORDER BY cnt DESC LIMIT %d",
-      col, tbl, col, col, BUCKET_COUNT
-    )
-  end
-
-  local min_n = tonumber(min_val)
-  local max_n = tonumber(max_val)
-  if not min_n or not max_n then
-    -- Non-numeric min/max (dates): fall back to GROUP BY
-    return string.format(
-      "SELECT %s AS val, COUNT(*) AS cnt FROM %s WHERE %s IS NOT NULL GROUP BY %s ORDER BY cnt DESC LIMIT %d",
-      col, tbl, col, col, BUCKET_COUNT
-    )
-  end
-
-  local step = (max_n - min_n) / BUCKET_COUNT
+  -- Numeric or date: build CASE WHEN buckets. Only BUCKET_COUNT - 1 thresholds
+  -- are emitted; the last bucket is the ELSE arm, so max lands inside it.
+  local bounds = M.bucket_bounds(min_val, max_val)
   local cases = {}
   for b = 1, BUCKET_COUNT - 1 do
-    table.insert(cases, string.format("WHEN CAST(%s AS REAL) < %s THEN %d", col, min_n + step * b, b))
+    table.insert(cases, string.format("WHEN CAST(%s AS REAL) < %s THEN %d", col, bounds[b].hi, b))
   end
   table.insert(cases, "ELSE " .. BUCKET_COUNT)
 
@@ -187,8 +226,14 @@ function M.gather(table_name, url)
     local hist_sql = M.build_histogram_sql(table_name, p.name, p.category, p.min, p.max)
     local hist_result = db.query(hist_sql, url)
     if hist_result and #hist_result.rows > 0 then
-      if p.category == "text" or p.category == "boolean" or p.category == "unknown"
-        or (p.category == "numeric" and (not tonumber(p.min) or p.min == p.max)) then
+      -- Which shape the rows have is decided by the same predicate that chose
+      -- the SQL. The open-coded version this replaced left "date" out, so a
+      -- date column -- whose bounds are never numeric, hence always a
+      -- GROUP BY -- fell into the bucketed branch below, where tonumber() on a
+      -- timestamp string yields nil and every value collapsed into bucket 1: a
+      -- single-spike sparkline that described nothing, with no top values to
+      -- fall back on either.
+      if not M.is_bucketed(p.category, p.min, p.max) then
         -- Categorical: store as top_values and build sparkline from counts
         local top = {}
         local counts = {}
@@ -225,6 +270,74 @@ function M.gather(table_name, url)
   }
 end
 
+--- Gather stats plus a distribution for a single column -- the gS popup.
+--- Two queries, the same count the popup has always issued: the distribution
+--- replaces its bespoke top-values query instead of adding to it.
+--- `data_type` may be nil (column info unavailable), which classifies as
+--- "unknown" and yields a top-values distribution rather than an error.
+--- Returns (colstats, nil) or (nil, err). A failed *histogram* is not an error:
+--- the caller still gets its statistics, with kind left nil, because losing the
+--- whole popup over the optional half of it would be the worse trade.
+function M.gather_column(table_name, col_name, data_type, url)
+  local tbl = sql.quote_ident(table_name)
+  local col = sql.quote_ident(col_name)
+
+  local stats_sql = string.format(
+    "SELECT COUNT(*) AS total, COUNT(DISTINCT %s) AS distinct_count, " ..
+    "COUNT(*) - COUNT(%s) AS null_count, MIN(%s) AS min_val, MAX(%s) AS max_val " ..
+    "FROM %s",
+    col, col, col, col, tbl
+  )
+  local stats_result, stats_err = db.query(stats_sql, url)
+  if stats_err then return nil, stats_err end
+  if not stats_result or #stats_result.rows == 0 then return nil, "No stats returned" end
+
+  local row = stats_result.rows[1]
+  local cs = {
+    name       = col_name,
+    data_type  = data_type,
+    category   = M.classify_column(data_type),
+    total      = row[1],
+    distinct   = row[2],
+    nulls      = row[3],
+    min        = row[4],
+    max        = row[5],
+    kind       = nil,  -- "buckets" | "values" | nil when the histogram failed
+    buckets    = nil,
+    top_values = nil,
+  }
+
+  local bucketed = M.is_bucketed(cs.category, cs.min, cs.max)
+  local hist_result = db.query(
+    M.build_histogram_sql(table_name, col_name, cs.category, cs.min, cs.max), url)
+  if not hist_result or #hist_result.rows == 0 then return cs end
+
+  if bucketed then
+    local bounds = M.bucket_bounds(cs.min, cs.max)
+    local counts = {}
+    for b = 1, BUCKET_COUNT do counts[b] = 0 end
+    -- Buckets absent from the result set are empty, not missing: GROUP BY only
+    -- returns the ones that matched a row.
+    for _, r in ipairs(hist_result.rows) do
+      local b = math.max(1, math.min(BUCKET_COUNT, tonumber(r[1]) or 1))
+      counts[b] = tonumber(r[2]) or 0
+    end
+    cs.kind = "buckets"
+    cs.buckets = {}
+    for b = 1, BUCKET_COUNT do
+      cs.buckets[b] = { lo = bounds[b].lo, hi = bounds[b].hi, count = counts[b] }
+    end
+  else
+    cs.kind = "values"
+    cs.top_values = {}
+    for _, r in ipairs(hist_result.rows) do
+      table.insert(cs.top_values, { value = r[1], count = tonumber(r[2]) or 0 })
+    end
+  end
+
+  return cs
+end
+
 -- ── display rendering ─────────────────────────────────────────────────────────
 
 --- Format a percentage with one decimal place.
@@ -234,6 +347,82 @@ local function fmt_pct(v) return string.format("%.1f%%", v) end
 --- this module's original style: values are silently cut, not "…"-marked).
 local function pad(s, w) return (ui.pad_display(s, w, false)) end
 M._pad = pad  -- exposed for unit tests
+
+--- Pick one number format for a whole histogram. Integral bounds throughout
+--- print as integers, anything else as one decimal: switching format between
+--- adjacent rows of the same histogram reads as noise.
+local function bounds_formatter(buckets)
+  for _, b in ipairs(buckets) do
+    if b.lo % 1 ~= 0 or b.hi % 1 ~= 0 then
+      return function(v) return string.format("%.1f", v) end
+    end
+  end
+  return function(v) return string.format("%d", v) end
+end
+
+--- Render label/bar/count rows, aligned on display width. Widths come from
+--- strdisplaywidth, never from #s: the popup used to cut values with
+--- value:sub(1, 30) -- a byte offset derived from a display-cell budget -- which
+--- corrupted any multibyte value (the same bug class already fixed in _pad).
+local function bar_rows(rows)
+  local max_count, label_w, count_w = 0, 0, 0
+  for _, r in ipairs(rows) do
+    max_count = math.max(max_count, r.count or 0)
+    label_w = math.max(label_w, vim.fn.strdisplaywidth(r.label))
+    count_w = math.max(count_w, #tostring(r.count))
+  end
+  label_w = math.min(label_w, HBAR_LABEL_MAX)
+
+  local out = {}
+  for _, r in ipairs(rows) do
+    table.insert(out, "    " .. pad(r.label, label_w)
+      .. "  " .. pad(M.hbar(r.count, max_count, HBAR_WIDTH), HBAR_WIDTH)
+      .. "  " .. string.format("%" .. count_w .. "d", r.count))
+  end
+  return out, max_count
+end
+
+--- Build display lines for the single-column stats popup (gS).
+function M.build_column_lines(cs)
+  if not cs then return {} end
+
+  local lines = {
+    " " .. cs.name .. ": Column Statistics",
+    " " .. string.rep("─", 40),
+    "  Total:    " .. (cs.total or "?"),
+    "  Distinct: " .. (cs.distinct or "?"),
+    "  Nulls:    " .. (cs.nulls or "?"),
+    "  Min:      " .. (cs.min or "NULL"),
+    "  Max:      " .. (cs.max or "NULL"),
+  }
+
+  local header, rows = nil, {}
+  if cs.kind == "buckets" and cs.buckets then
+    header = "  Distribution (" .. BUCKET_COUNT .. " buckets)"
+    local fmt = bounds_formatter(cs.buckets)
+    for _, b in ipairs(cs.buckets) do
+      -- ".." and not an en dash: a column with negative values would otherwise
+      -- render bounds as "-12.5 - -3.0".
+      table.insert(rows, { label = fmt(b.lo) .. " .. " .. fmt(b.hi), count = b.count })
+    end
+  elseif cs.kind == "values" and cs.top_values then
+    header = "  Top values"
+    for _, tv in ipairs(cs.top_values) do
+      table.insert(rows, { label = tostring(tv.value or "?"), count = tv.count })
+    end
+  end
+  if not header or #rows == 0 then return lines end
+
+  local rendered, max_count = bar_rows(rows)
+  -- An empty table (or a column that is entirely NULL) has nothing to plot;
+  -- eight zero-height bars would only claim otherwise.
+  if max_count == 0 then return lines end
+
+  table.insert(lines, "")
+  table.insert(lines, header)
+  for _, l in ipairs(rendered) do table.insert(lines, l) end
+  return lines
+end
 
 --- Build display lines for the profile buffer.
 function M.build_lines(profile_data, term_width)

--- a/lua/dadbod-grip/view/keymaps_aggregate.lua
+++ b/lua/dadbod-grip/view/keymaps_aggregate.lua
@@ -4,7 +4,6 @@
 -- bearing.
 
 local data   = require("dadbod-grip.data")
-local sql    = require("dadbod-grip.sql")
 local db     = require("dadbod-grip.db")
 local qmod   = require("dadbod-grip.query")
 
@@ -92,7 +91,7 @@ function M.setup(bufnr, ctx)
     aggregate_column(rows_a)
   end, "Aggregate selected rows in column")
 
-  -- gS: column statistics
+  -- gS: column statistics with a distribution histogram
   kmap("grid_col_stats", function()
     local session_cs = ctx.session()
     if not session_cs or not session_cs.state.table_name then
@@ -104,53 +103,32 @@ function M.setup(bufnr, ctx)
       vim.notify("Move cursor to a column", vim.log.levels.INFO)
       return
     end
-    local tbl = session_cs.state.table_name
-    local col_q = sql.quote_ident(cell.col_name)
-    local stats_sql = string.format(
-      "SELECT COUNT(*) AS total, COUNT(DISTINCT %s) AS distinct_count, " ..
-      "COUNT(*) - COUNT(%s) AS null_count, MIN(%s) AS min_val, MAX(%s) AS max_val " ..
-      "FROM %s",
-      col_q, col_q, col_q, col_q, sql.quote_ident(tbl)
-    )
-    local result, err = db.query(stats_sql, session_cs.state.url)
-    if err then
-      vim.notify("Stats query failed: " .. err, vim.log.levels.WARN)
-      return
-    end
-    if not result or #result.rows == 0 then
-      vim.notify("No stats returned", vim.log.levels.INFO)
-      return
-    end
-    local row = result.rows[1]
-    local info = {
-      " " .. cell.col_name .. ": Column Statistics",
-      " " .. string.rep("─", 40),
-      "  Total:    " .. (row[1] or "?"),
-      "  Distinct: " .. (row[2] or "?"),
-      "  Nulls:    " .. (row[3] or "?"),
-      "  Min:      " .. (row[4] or "NULL"),
-      "  Max:      " .. (row[5] or "NULL"),
-    }
+    local st_cs = session_cs.state
 
-    -- Try to get top 5 values
-    local top_sql = string.format(
-      "SELECT %s, COUNT(*) AS cnt FROM %s WHERE %s IS NOT NULL " ..
-      "GROUP BY %s ORDER BY cnt DESC LIMIT 5",
-      col_q, sql.quote_ident(tbl), col_q, col_q
-    )
-    local top_result = db.query(top_sql, session_cs.state.url)
-    if top_result and #top_result.rows > 0 then
-      table.insert(info, "")
-      table.insert(info, "  Top values:")
-      for _, r_top in ipairs(top_result.rows) do
-        local val = r_top[1] or "?"
-        local cnt = r_top[2] or "?"
-        table.insert(info, "    " .. tostring(val):sub(1, 30) .. "  (" .. cnt .. ")")
+    -- The data type decides bucketed-vs-top-values, so fill the session cache
+    -- if some other view has not already (same lazy pattern as K and gy). A
+    -- failure here is not fatal: an unknown type profiles as top values.
+    if not session_cs._column_info then
+      local info, info_err = db.get_column_info(st_cs.table_name, st_cs.url)
+      if not info_err then session_cs._column_info = info end
+    end
+    local data_type
+    for _, ci in ipairs(session_cs._column_info or {}) do
+      if ci.column_name == cell.col_name then
+        data_type = ci.data_type
+        break
       end
     end
 
+    local profile = require("dadbod-grip.profile")
+    local cs, cs_err = profile.gather_column(st_cs.table_name, cell.col_name, data_type, st_cs.url)
+    if not cs then
+      vim.notify("Stats query failed: " .. (cs_err or "unknown error"), vim.log.levels.WARN)
+      return
+    end
+
     local grip_win = vim.api.nvim_get_current_win()
-    open_info_float(grip_win, info, { title = " Column Stats " })
+    open_info_float(grip_win, profile.build_column_lines(cs), { title = " Column Stats " })
   end, "Column statistics")
 
   -- gR: table profile report

--- a/tests/spec/profile_spec.lua
+++ b/tests/spec/profile_spec.lua
@@ -63,6 +63,98 @@ test("sparkline: empty counts returns empty string", function()
   eq(profile.sparkline(nil, 0), "", "nil")
 end)
 
+-- ── hbar ──────────────────────────────────────────────────────────────────────
+
+local FULL = "\xe2\x96\x88"
+local THINNEST = "\xe2\x96\x8f"
+
+--- Count display cells, not bytes: every block glyph is 3 bytes wide.
+local function cells(s) return vim.fn.strdisplaywidth(s) end
+
+test("hbar: a full-scale count fills the whole width", function()
+  eq(cells(profile.hbar(50, 50, 16)), 16, "16 cells")
+  eq(profile.hbar(50, 50, 16), string.rep(FULL, 16), "all full blocks")
+end)
+
+test("hbar: half scale fills half the width", function()
+  eq(profile.hbar(25, 50, 16), string.rep(FULL, 8), "eight full blocks")
+end)
+
+test("hbar: fractional remainder uses an eighth-block", function()
+  -- 1/16 of full scale = one cell = 8 eighths... so take 1/32: half a cell.
+  local bar = profile.hbar(1, 32, 16)
+  eq(cells(bar), 1, "single cell")
+  assert(bar ~= FULL, "a half cell is not a full block")
+end)
+
+test("hbar: a non-zero count is never invisible", function()
+  -- The whole point of the eighth-blocks: one row out of ten million must not
+  -- render as blank, or it is indistinguishable from an empty bucket.
+  local bar = profile.hbar(1, 10000000, 16)
+  assert(bar ~= "", "one-in-ten-million still draws")
+  eq(bar, THINNEST, "thinnest block")
+end)
+
+test("hbar: zero count and zero scale render empty", function()
+  eq(profile.hbar(0, 100, 16), "", "zero count")
+  eq(profile.hbar(0, 0, 16), "", "zero count and scale")
+  eq(profile.hbar(10, 0, 16), "", "zero scale")
+end)
+
+test("hbar: nil and non-numeric input is survivable", function()
+  eq(profile.hbar(nil, nil), "", "both nil")
+  eq(profile.hbar(nil, 100), "", "nil count")
+  eq(profile.hbar(10, nil), "", "nil scale")
+  eq(profile.hbar("abc", 100), "", "garbage count")
+end)
+
+test("hbar: never overflows the requested width", function()
+  -- count > max_count should not happen, but a bar wider than its column would
+  -- shift every count in the popup out of alignment if it did.
+  eq(cells(profile.hbar(500, 50, 16)), 16, "clamped to width")
+  eq(cells(profile.hbar(7, 10, 4)), 3, "narrow width respected")
+end)
+
+-- ── bucket_bounds ─────────────────────────────────────────────────────────────
+
+test("bucket_bounds: 0..100 spans eight contiguous ranges", function()
+  local b = profile.bucket_bounds("0", "100")
+  eq(#b, 8, "eight buckets")
+  eq(b[1].lo, 0, "starts at min")
+  eq(b[8].hi, 100, "ends at max")
+  eq(b[1].hi, 12.5, "step is 12.5")
+  eq(b[2].lo, 12.5, "buckets are contiguous")
+  for i = 1, 7 do
+    eq(b[i].hi, b[i + 1].lo, "bucket " .. i .. " abuts " .. (i + 1))
+  end
+end)
+
+test("bucket_bounds: negative ranges keep their arithmetic", function()
+  local b = profile.bucket_bounds("-40", "40")
+  eq(b[1].lo, -40, "starts at min")
+  eq(b[4].hi, 0, "walks through zero")
+  eq(b[8].hi, 40, "ends at max")
+end)
+
+test("bucket_bounds: unbucketable bounds return nil", function()
+  eq(profile.bucket_bounds(nil, nil), nil, "both nil")
+  eq(profile.bucket_bounds("5", "5"), nil, "min == max")
+  eq(profile.bucket_bounds("", ""), nil, "empty (what gather passes for no data)")
+  eq(profile.bucket_bounds("2024-01-01", "2024-06-01"), nil, "timestamps are not numeric")
+end)
+
+-- ── is_bucketed ───────────────────────────────────────────────────────────────
+
+test("is_bucketed: only numeric and date with numeric bounds", function()
+  eq(profile.is_bucketed("numeric", "0", "100"), true, "numeric")
+  eq(profile.is_bucketed("text", "0", "100"), false, "text never buckets")
+  eq(profile.is_bucketed("boolean", "0", "1"), false, "boolean never buckets")
+  eq(profile.is_bucketed("unknown", "0", "100"), false, "unknown never buckets")
+  eq(profile.is_bucketed("numeric", "7", "7"), false, "single-valued numeric")
+  -- A date's MIN/MAX are timestamp strings, so it always falls back to values.
+  eq(profile.is_bucketed("date", "2024-01-01", "2024-06-01"), false, "date bounds are not numeric")
+end)
+
 -- ── classify_column ───────────────────────────────────────────────────────────
 
 test("classify_column: integer types", function()
@@ -309,6 +401,178 @@ test("build_lines: non-ASCII columns produce equal-width aligned rows", function
   end
 end)
 
+-- ── build_column_lines (the gS popup) ─────────────────────────────────────────
+
+local function bucket_colstats()
+  local bounds = profile.bucket_bounds("18", "79")
+  local counts = { 104, 182, 237, 165, 123, 87, 51, 39 }
+  local buckets = {}
+  for b = 1, 8 do
+    buckets[b] = { lo = bounds[b].lo, hi = bounds[b].hi, count = counts[b] }
+  end
+  return {
+    name = "age", data_type = "integer", category = "numeric",
+    total = "1000", distinct = "62", nulls = "12", min = "18", max = "79",
+    kind = "buckets", buckets = buckets,
+  }
+end
+
+local function values_colstats(top_values)
+  return {
+    name = "status", data_type = "text", category = "text",
+    total = "1000", distinct = "3", nulls = "0", min = "active", max = "pending",
+    kind = "values", top_values = top_values or {
+      { value = "active", count = 620 },
+      { value = "pending", count = 260 },
+      { value = "inactive", count = 120 },
+    },
+  }
+end
+
+--- The rows carrying bars: everything indented four spaces under a header.
+local function bar_lines(lines)
+  local out = {}
+  for _, l in ipairs(lines) do
+    if l:find("^    %S") then table.insert(out, l) end
+  end
+  return out
+end
+
+test("build_column_lines: stats block is unchanged", function()
+  local lines = profile.build_column_lines(bucket_colstats())
+  eq(lines[1], " age: Column Statistics", "title")
+  contains(table.concat(lines, "\n"), "  Total:    1000", "total")
+  contains(table.concat(lines, "\n"), "  Distinct: 62", "distinct")
+  contains(table.concat(lines, "\n"), "  Nulls:    12", "nulls")
+  contains(table.concat(lines, "\n"), "  Min:      18", "min")
+  contains(table.concat(lines, "\n"), "  Max:      79", "max")
+end)
+
+test("build_column_lines: numeric renders eight labelled buckets", function()
+  local lines = profile.build_column_lines(bucket_colstats())
+  local joined = table.concat(lines, "\n")
+  contains(joined, "Distribution (8 buckets)", "distribution header")
+  assert(not joined:find("Top values", 1, true), "numeric shows buckets instead of top values")
+  eq(#bar_lines(lines), 8, "eight bucket rows")
+  contains(joined, FULL, "bars are drawn")
+  -- The tallest bucket (237) gets a full-width bar, so it is all full blocks.
+  contains(joined, string.rep(FULL, 16), "peak bucket is full scale")
+end)
+
+test("build_column_lines: bucket labels are bounds joined by '..'", function()
+  local lines = profile.build_column_lines(bucket_colstats())
+  local joined = table.concat(lines, "\n")
+  -- 18..79 over 8 buckets steps by 7.625, so bounds are fractional throughout.
+  contains(joined, "18.0 .. 25.6", "first bucket")
+  contains(joined, "71.4 .. 79.0", "last bucket ends at max")
+  assert(not joined:find("–", 1, true), "no en dash: it is unreadable with negative bounds")
+end)
+
+test("build_column_lines: integral bounds print without decimals", function()
+  local bounds = profile.bucket_bounds("0", "80")  -- step 10, every bound integral
+  local buckets = {}
+  for b = 1, 8 do
+    buckets[b] = { lo = bounds[b].lo, hi = bounds[b].hi, count = b }
+  end
+  local joined = table.concat(profile.build_column_lines({
+    name = "n", total = "36", distinct = "8", nulls = "0", min = "0", max = "80",
+    kind = "buckets", buckets = buckets,
+  }), "\n")
+  contains(joined, "0 .. 10", "integral bounds")
+  contains(joined, "70 .. 80", "integral bounds, last bucket")
+  assert(not joined:find("0.0 .. 10.0", 1, true), "no gratuitous decimals")
+end)
+
+test("build_column_lines: one fractional bound switches the whole histogram", function()
+  local bounds = profile.bucket_bounds("0", "81")  -- step 10.125
+  local buckets = {}
+  for b = 1, 8 do
+    buckets[b] = { lo = bounds[b].lo, hi = bounds[b].hi, count = b }
+  end
+  local joined = table.concat(profile.build_column_lines({
+    name = "n", total = "36", distinct = "8", nulls = "0", min = "0", max = "81",
+    kind = "buckets", buckets = buckets,
+  }), "\n")
+  contains(joined, "0.0 .. 10.1", "first bound formatted as decimal too, not as '0'")
+end)
+
+test("build_column_lines: text renders top values with bars", function()
+  local lines = profile.build_column_lines(values_colstats())
+  local joined = table.concat(lines, "\n")
+  contains(joined, "Top values", "top values header")
+  assert(not joined:find("Distribution", 1, true), "no bucket header for text")
+  eq(#bar_lines(lines), 3, "one row per value")
+  contains(joined, "active", "value label")
+  contains(joined, "620", "count")
+end)
+
+test("build_column_lines: a failed histogram still yields the stats", function()
+  -- kind = nil is what gather_column returns when the histogram query fails.
+  local cs = bucket_colstats()
+  cs.kind, cs.buckets = nil, nil
+  local lines = profile.build_column_lines(cs)
+  contains(table.concat(lines, "\n"), "Total:    1000", "stats survive")
+  eq(#bar_lines(lines), 0, "no bar rows")
+end)
+
+test("build_column_lines: an all-zero distribution is omitted, not drawn flat", function()
+  local cs = bucket_colstats()
+  for _, b in ipairs(cs.buckets) do b.count = 0 end
+  local joined = table.concat(profile.build_column_lines(cs), "\n")
+  assert(not joined:find("Distribution", 1, true), "eight empty bars would claim a shape that isn't there")
+end)
+
+test("build_column_lines: nil colstats yields no lines", function()
+  eq(#profile.build_column_lines(nil), 0, "nil-safe")
+end)
+
+test("build_column_lines: bucket rows are all the same display width", function()
+  local lines = bar_lines(profile.build_column_lines(bucket_colstats()))
+  local w = vim.fn.strdisplaywidth(lines[1])
+  for i, l in ipairs(lines) do
+    eq(vim.fn.strdisplaywidth(l), w, "row " .. i .. " aligns")
+  end
+end)
+
+test("build_column_lines: non-ASCII value labels stay aligned and valid UTF-8", function()
+  -- The popup used to cut labels with value:sub(1, 30) -- a byte offset applied
+  -- to a display-cell budget -- which corrupted multibyte values outright.
+  local lines = bar_lines(profile.build_column_lines(values_colstats({
+    { value = "категория-которая-заметно-длиннее-тридцати-символов", count = 500 },
+    { value = "日本語テキスト", count = 300 },
+    { value = "🍜ラーメン", count = 100 },
+    { value = "ascii", count = 50 },
+  })))
+  eq(#lines, 4, "four rows")
+  local w = vim.fn.strdisplaywidth(lines[1])
+  for i, l in ipairs(lines) do
+    eq(vim.fn.strdisplaywidth(l), w, "row " .. i .. " aligns")
+    assert(pcall(vim.str_utf_pos, l), "row " .. i .. " is valid UTF-8: " .. l)
+  end
+end)
+
+test("build_column_lines: the label column is sized in cells, not bytes", function()
+  -- "日本語" is 6 display cells but 9 bytes. Sizing the label column off #s
+  -- pads every row three cells wider than the widest label actually needs,
+  -- which the equal-width checks above cannot see -- they only prove the rows
+  -- match each other, and they still would.
+  local lines = bar_lines(profile.build_column_lines(values_colstats({
+    { value = "日本語", count = 10 },
+    { value = "abc", count = 5 },
+  })))
+  eq(#lines, 2, "two rows")
+  -- 4 indent + 6 label + 2 gap + 16 bar + 2 gap + 2 count
+  eq(vim.fn.strdisplaywidth(lines[1]), 32, "row is exactly as wide as its parts")
+end)
+
+test("build_column_lines: a NULL-ish value label does not crash the render", function()
+  local lines = profile.build_column_lines(values_colstats({
+    { value = nil, count = 10 },
+    { value = "x", count = 5 },
+  }))
+  contains(table.concat(lines, "\n"), "Top values", "still renders")
+end)
+
 -- ── SQL generation ────────────────────────────────────────────────────────────
 
 test("build_stats_sql: generates valid SQL structure", function()
@@ -337,6 +601,143 @@ test("build_histogram_sql: numeric column uses CASE buckets", function()
   local result = profile.build_histogram_sql("users", "age", "numeric", "0", "100")
   contains(result, "CASE", "has CASE")
   contains(result, "bucket", "has bucket alias")
+end)
+
+-- The exact thresholds are pinned, not just the presence of "CASE": the CASE
+-- ladder and the bucket labels in the gS popup are generated from the same
+-- bucket_bounds(), and this is what proves the two cannot drift apart. 0..100
+-- over 8 buckets steps by 12.5, and only 7 WHEN arms are emitted -- the eighth
+-- bucket is the ELSE, which is what makes it inclusive of max.
+test("build_histogram_sql: CASE thresholds are exactly min + step*b", function()
+  local result = profile.build_histogram_sql("users", "age", "numeric", "0", "100")
+  for _, threshold in ipairs({ "12.5", "25", "37.5", "50", "62.5", "75", "87.5" }) do
+    contains(result, 'WHEN CAST("age" AS REAL) < ' .. threshold .. " THEN", "threshold " .. threshold)
+  end
+  eq(select(2, result:gsub("WHEN", "")), 7, "seven WHEN arms")
+  contains(result, "ELSE 8", "eighth bucket is the ELSE arm")
+  assert(not result:find("< 100 THEN", 1, true), "max is never itself a threshold")
+end)
+
+test("build_histogram_sql: negative range keeps the step arithmetic", function()
+  -- -40..40 steps by 10; the ladder must walk through zero, not around it.
+  local result = profile.build_histogram_sql("t", "delta", "numeric", "-40", "40")
+  for _, threshold in ipairs({ "-30", "-20", "-10", "0", "10", "20", "30" }) do
+    contains(result, 'WHEN CAST("delta" AS REAL) < ' .. threshold .. " THEN", "threshold " .. threshold)
+  end
+end)
+
+-- ── gather_column against a real database ────────────────────────────────────
+-- Uses the committed tests/seed_sqlite.db, like the other DB-backed specs.
+-- orders.total is REAL over 150 rows (5.0 .. 501.0); orders.status is TEXT with
+-- 5 distinct values. Pure-function tests cannot catch a wrong column order in
+-- the stats SELECT or a bucket index the adapter returns as a string.
+
+local sqlite_url = "sqlite:tests/seed_sqlite.db"
+
+test("gather_column: numeric column buckets a real distribution", function()
+  local cs, err = profile.gather_column("orders", "total", "REAL", sqlite_url)
+  assert(cs, "gather_column failed: " .. tostring(err))
+  eq(cs.category, "numeric", "classified numeric")
+  eq(cs.kind, "buckets", "bucketed")
+  eq(tonumber(cs.total), 150, "row count")
+  eq(#cs.buckets, 8, "eight buckets")
+
+  local summed = 0
+  for _, b in ipairs(cs.buckets) do summed = summed + b.count end
+  eq(summed, 150 - tonumber(cs.nulls), "every non-NULL row lands in exactly one bucket")
+  eq(cs.buckets[1].lo, tonumber(cs.min), "first bucket starts at MIN")
+  eq(cs.buckets[8].hi, tonumber(cs.max), "last bucket ends at MAX")
+
+  local lines = profile.build_column_lines(cs)
+  contains(table.concat(lines, "\n"), "Distribution (8 buckets)", "renders a distribution")
+end)
+
+test("gather_column: every stats field comes from the right SELECT column", function()
+  -- users.age is the one fixture column where total, distinct, nulls, min and
+  -- max are five *different* numbers (15/13/2/19/51), so any two of them
+  -- swapped in the result-row unpacking shows up here. With a column like
+  -- orders.total, distinct and nulls are both plausible and a swap is silent.
+  local cs, err = profile.gather_column("users", "age", "INTEGER", sqlite_url)
+  assert(cs, "gather_column failed: " .. tostring(err))
+  eq(tonumber(cs.total), 15, "total")
+  eq(tonumber(cs.distinct), 13, "distinct")
+  eq(tonumber(cs.nulls), 2, "nulls")
+  eq(tonumber(cs.min), 19, "min")
+  eq(tonumber(cs.max), 51, "max")
+end)
+
+test("gather_column: buckets the query never mentions come back as zero", function()
+  -- products.price is skewed (20 rows, 1.99 .. 499.99, most of them cheap), so
+  -- GROUP BY simply omits the buckets nothing fell into. Those slots must read
+  -- as empty rather than inheriting whatever the counts table was seeded with.
+  local cs, err = profile.gather_column("products", "price", "REAL", sqlite_url)
+  assert(cs, "gather_column failed: " .. tostring(err))
+  eq(cs.kind, "buckets", "bucketed")
+  eq(#cs.buckets, 8, "eight buckets")
+
+  local empty, summed = 0, 0
+  for _, b in ipairs(cs.buckets) do
+    summed = summed + b.count
+    if b.count == 0 then empty = empty + 1 end
+  end
+  assert(empty > 0, "this fixture has gaps in its distribution, got none")
+  eq(summed, 20, "the counts still add up to every row")
+end)
+
+test("gather_column: text column returns top values", function()
+  local cs, err = profile.gather_column("orders", "status", "TEXT", sqlite_url)
+  assert(cs, "gather_column failed: " .. tostring(err))
+  eq(cs.kind, "values", "top values")
+  assert(#cs.top_values > 0 and #cs.top_values <= 8, "between 1 and 8 values, got " .. #cs.top_values)
+
+  local summed = 0
+  for _, tv in ipairs(cs.top_values) do summed = summed + tv.count end
+  eq(summed, 150, "orders.status has 5 distinct values, so all 150 rows are covered")
+
+  local prev = math.huge
+  for _, tv in ipairs(cs.top_values) do
+    assert(tv.count <= prev, "values arrive ordered by descending count")
+    prev = tv.count
+  end
+  contains(table.concat(profile.build_column_lines(cs), "\n"), "Top values", "renders top values")
+end)
+
+test("gather_column: a nil data_type degrades to top values, not an error", function()
+  -- What the popup passes when get_column_info is unavailable.
+  local cs, err = profile.gather_column("orders", "total", nil, sqlite_url)
+  assert(cs, "gather_column failed: " .. tostring(err))
+  eq(cs.category, "unknown", "unknown category")
+  eq(cs.kind, "values", "falls back to top values")
+end)
+
+test("gather_column: a date column returns top values, not a collapsed bucket", function()
+  local cs, err = profile.gather_column("orders", "ordered_at", "DATETIME", sqlite_url)
+  assert(cs, "gather_column failed: " .. tostring(err))
+  eq(cs.category, "date", "classified date")
+  eq(cs.kind, "values", "timestamps cannot be bucketed by the CASE ladder")
+  assert(#cs.top_values > 0, "has values")
+end)
+
+test("gather_column: a missing table reports an error instead of throwing", function()
+  local cs = profile.gather_column("no_such_table_xyz", "id", "INTEGER", sqlite_url)
+  eq(cs, nil, "no colstats for a table that does not exist")
+end)
+
+-- ── gather: date columns keep a meaningful sparkline ─────────────────────────
+
+test("gather: date column carries top values, not a single-spike sparkline", function()
+  local data, err = profile.gather("orders", sqlite_url)
+  assert(data, "gather failed: " .. tostring(err))
+  local ordered_at
+  for _, p in ipairs(data.profiles) do
+    if p.name == "ordered_at" then ordered_at = p end
+  end
+  assert(ordered_at, "found the ordered_at profile")
+  eq(ordered_at.category, "date", "classified date")
+  -- Before is_bucketed() drove this branch, a date fell into the bucketed path,
+  -- where tonumber() on a timestamp yields nil and every row collapsed into
+  -- bucket 1 -- one bar, seven zeros, and no top values to fall back on.
+  assert(ordered_at.top_values and #ordered_at.top_values > 0, "date has top values")
 end)
 
 -- ── summary ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes the `TODO.md` "ASCII histogram for numeric columns" idea, plus four housekeeping ticks found while auditing that backlog against the code.

## What `gS` looks like now

```
 total: Column Statistics
 ────────────────────────────────────────
  Total:    150
  Distinct: 139
  Nulls:    0
  Min:      5.0
  Max:      501.0

  Distribution (8 buckets)
    5 .. 67     ████████████████  25
    67 .. 129   ██████████████▏   22
    129 .. 191  ██████████▉       17
    191 .. 253  ██████████▉       17
    253 .. 315  ██████████▉       17
    315 .. 377  ██████████▉       17
    377 .. 439  ██████████▉       17
    439 .. 501  ███████████▌      18
```

Text, boolean and date columns keep the `Top values` block, now with the same bars.

## Design notes

- **Still exactly two queries.** The distribution replaced the popup's bespoke top-5 `GROUP BY` instead of adding a third query — for a text column that query already *was* the distribution. Consequence: text/boolean/date list 8 values instead of 5, and numeric columns show bucket ranges instead of individual values, since the top values of an `id`-like column are all count 1.
- **Bars resolve to an eighth of a cell,** and a non-zero count is clamped up to the thinnest block rather than rounding to nothing. A bucket holding one row out of ten million must not look identical to an empty one.
- **Bounds are joined with `..`, not an en dash** — a column with negative values would otherwise render `-12.5 - -3.0`. One number format is picked per histogram so integral bounds never sit beside decimal ones in the same block.
- **The logic left the keymap closure.** Nothing can call a local defined inside `M.setup()`, so the old `gS` body was structurally untestable. It now lives in `profile.lua` (`hbar`, `bucket_bounds`, `is_bucketed`, `gather_column`, `build_column_lines`) and `keymaps_aggregate.lua` loses 55 lines.

## Two bugs fixed on the way

- **Date columns produced a meaningless sparkline in `gR`.** A date's `MIN`/`MAX` are timestamp strings, so `build_histogram_sql` always answered it with a top-values `GROUP BY` — but the branch reading the rows back listed `text`, `boolean` and `unknown` and left `date` out. Date rows went down the bucketed path, where `tonumber("2025-01-02 13:13:00")` is `nil`, every value collapsed into bucket 1, and the column drew one bar and seven zeros with no top values to fall back on. Both sides now ask `is_bucketed()`.
- **Multibyte values were corrupted in the popup.** Top values were cut with `value:sub(1, 30)` — a byte offset derived from a display-cell budget — slicing Cyrillic, CJK and emoji mid-character. The same bug class already fixed in `profile._pad`.

## Testing

Suite green, `luacheck` clean, 34 new assertions (61 in `profile_spec`).

- The `CASE` thresholds were pinned by an exact-value test **before** `build_histogram_sql` was refactored onto `bucket_bounds`, which is what proves `gR`'s SQL came out byte-identical.
- Live coverage via the committed `tests/seed_sqlite.db`: numeric bucketing, top values, a `nil` data type, a date column, and a missing table.
- Every new assertion was verified by mutation — 17 deliberate breaks of the production code, each confirmed to turn the spec red. Three survived the first round and were genuine gaps: the stats-column order was only pinned once a fixture with five distinct values (`users.age`) replaced one where `distinct` and `nulls` were both plausible; the zero-fill for absent buckets needed a skewed column (`products.price`) whose `GROUP BY` actually omits slots; and the display-width sizing needed a label narrower than the 30-cell clamp to be observable at all.

## Out of scope

`gS` still does nothing when the cursor sits on the header or type row, while `ga` right next to it has a `view._snap_col` fallback. Real inconsistency, separate fix.

## `TODO.md` housekeeping

Four items were already implemented but never ticked: **MSSQL adapter** (v3.8.0, read-only; `TOP N` and `##temp` still open), **markdown columns** (`cell_buffer.lua` `PROSE_COLUMNS`), **multi-row bulk ops** (v3.4.0 `keymaps_visual_batch.lua`). **Inline column resize** is reworded as solved differently — `=` cycles column width, and `-` is already taken by hide-column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)