### PR TITLE
feat: connection secrets from a project .env, read-only mode, per-connection colour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,9 +57,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reaches `~/.grip/connections.json`. This is arranged so that no write path *can* leak it rather
   than by scrubbing the ones that exist today: `vim.g.db` holds the template, and expansion happens
   at the single dispatch point `db.resolve()`, so nothing that persists, logs, or displays a URL
-  ever holds the expanded one. An unresolved placeholder is always an error, never an empty
-  substitution — a URL quietly missing its password either connects somewhere unintended or hangs
-  on a prompt; such an entry shows `?` in the picker and names the variable it wanted. `.env`
+  ever holds the expanded one. A placeholder that cannot be resolved is an error, and so is one
+  that resolves to an empty value: a bare `KEY=` is the usual shape of a committed `.env` template,
+  and substituting it would hand `psql` a URL with no password, which falls through to `~/.pgpass`
+  and may connect with a *different* credential instead of failing. Either way the entry shows `?`
+  in the picker and names the variable. A literal password containing `${WORD}` is written
+  `$${WORD}`. `.env`
   contents are memoized on the file's mtime, so a rotated password is picked up on the next query,
   and failed reads are deliberately never cached, so `git-crypt unlock` takes effect on the very
   next connect with no restart — a still-locked file is reported as locked rather than as a parse
@@ -149,13 +152,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- **Database passwords no longer travel in the CLI's argv, and no longer appear in error
-  messages.** `psql -P`-style argv is readable by any user on the machine via `ps -eo args`, so the
-  password now reaches the client through its environment instead: `PGPASSWORD` (percent-decoded,
-  as libpq expects), `MYSQL_PWD` and `SQLCMDPASSWORD` (both verbatim — `parse_dadbod_url`
-  deliberately does not decode, and decoding those would break existing passwords containing `%`).
-  To be plain about the limit: this protects against *other users*, not against a process running
-  as you, which can read your environment just as easily as your argv. Separately, URLs in error
+- **`psql`, `mysql` and `sqlcmd` passwords no longer travel in argv, and URLs no longer appear
+  unredacted in error messages.** `psql -P`-style argv is readable by any user on the machine via
+  `ps -eo args`, so the password now reaches those three clients through their environment instead:
+  `PGPASSWORD` (percent-decoded, as libpq expects), `MYSQL_PWD` and `SQLCMDPASSWORD` (both verbatim
+  — `parse_dadbod_url` deliberately does not decode, and decoding those would break existing
+  passwords containing `%`). Two limits, both worth stating plainly. This protects against *other
+  users*, not against a process running as you, which can read your environment just as easily as
+  your argv. And it does **not** cover DuckDB federation: `ATTACH` inlines the attached database's
+  DSN into the SQL string, which grip passes to `duckdb -c`, so an attachment's password is in `ps`
+  output for the lifetime of every query against that connection. Closing that needs DuckDB's
+  secrets manager (`CREATE SECRET`) and is tracked separately. Separately, URLs in error
   text are now redacted through the shared `sql.redact_url`, including the case where the password
   itself contains an `@` — the authority is split on the last `@`, not the first, which previously
   left `p@ssw0rd` masked as `***@ssw0rd`. DuckDB's federation path got the same treatment the hard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,8 +81,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   **This is a guard against accidents, not a security boundary** — every mechanism above is
   reversible from the query pad, and the actual boundary is a database role that cannot write. Two
   limits worth knowing: an `options=` already in a postgres URL beats `PGOPTIONS`, so such a
-  connection reports `RO` while its session is not read-only; and sqlserver is unaffected because it
-  was already read-only. New: `connections.current_mode()`, `connections.deny_if_readonly()`.
+  connection reports `RO` while its session is not read-only — connecting it read-only warns once,
+  because that badge otherwise claims more than the server was told; and sqlserver is unaffected
+  because it was already read-only. New: `connections.current_mode()`,
+  `connections.deny_if_readonly()`, `adapters.readonly_caveat()`.
 
 - **A per-connection accent colour.** `"color"` on an entry takes a palette name (`green`,
   `orange`, `red`, `blue`, `violet`, `yellow`) or `#rrggbb`, and tints the window borders, the grid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A connection can reference its password instead of storing it.** Any `${VAR}` in a connection
+  URL is resolved when you connect, from the `.env` file the new `env_file` entry field points at,
+  falling back to the process environment. The secret stays where it already lives and never
+  reaches `~/.grip/connections.json`. This is arranged so that no write path *can* leak it rather
+  than by scrubbing the ones that exist today: `vim.g.db` holds the template, and expansion happens
+  at the single dispatch point `db.resolve()`, so nothing that persists, logs, or displays a URL
+  ever holds the expanded one. An unresolved placeholder is always an error, never an empty
+  substitution — a URL quietly missing its password either connects somewhere unintended or hangs
+  on a prompt; such an entry shows `?` in the picker and names the variable it wanted. `.env`
+  contents are memoized on the file's mtime, so a rotated password is picked up on the next query,
+  and failed reads are deliberately never cached, so `git-crypt unlock` takes effect on the very
+  next connect with no restart — a still-locked file is reported as locked rather than as a parse
+  error. The one cost: a templated URL is grip-only, because vim-dadbod's `:DB` and any statusline
+  reading `g:db` see the literal `${VAR}`. New module `dadbod-grip.secrets`.
+
+- **Read-only connections.** An entry with `"mode": "ro"` connects through the client's own
+  read-only switch — `PGOPTIONS=-c default_transaction_read_only=on`, `SET SESSION TRANSACTION READ
+  ONLY` merged into mysql's existing `--init-command` (a second `--init-command` flag would silently
+  discard the first, taking `sql_mode` with it), and `-readonly` for sqlite and duckdb, applied only
+  to a file that already exists: the flag aborts `duckdb::memory:` outright and turns "create it"
+  into an error for a new sqlite file. Grid editing is off and the DDL entry points — `:GripCreate`,
+  `:GripDrop`, `:GripRename`, `:GripFill`, the sidebar's create/drop, and the four column operations
+  — decline locally instead of prompting you and then failing at the server. Press `r` in the
+  connection picker to connect in the opposite mode for one session; the file is not touched.
+  **This is a guard against accidents, not a security boundary** — every mechanism above is
+  reversible from the query pad, and the actual boundary is a database role that cannot write. Two
+  limits worth knowing: an `options=` already in a postgres URL beats `PGOPTIONS`, so such a
+  connection reports `RO` while its session is not read-only; and sqlserver is unaffected because it
+  was already read-only. New: `connections.current_mode()`, `connections.deny_if_readonly()`.
+
+- **A per-connection accent colour.** `"color"` on an entry takes a palette name (`green`,
+  `orange`, `red`, `blue`, `violet`, `yellow`) or `#rrggbb`, and tints the window borders, the grid
+  rules and the sidebar title, so a red prod connection does not look like a green local one. The
+  palette reuses hexes already in the theme rather than introducing a second one, every accent
+  carries a `ctermfg` (a user hex is approximated onto the xterm cube and grey ramp) so nothing
+  requires truecolor, and an unknown value is ignored rather than raised. `GripBorder` is now
+  *derived* from the accent, which is what makes leaving a coloured connection restore the default
+  instead of stranding the border red. The groups `GripConnAccent` and `GripConnAccentBold` are
+  redefined on every switch and re-applied from `ensure_highlights`, so they survive `:colorscheme`.
+  New: `view.set_connection_accent()`.
+
 - **ASCII distribution in the `gS` column-statistics popup.** Numeric columns get the eight
   `build_histogram_sql` buckets with their bounds labelled and their counts drawn as horizontal
   bars; every other type gets its top values the same way. Bars resolve to an eighth of a cell,
@@ -105,6 +146,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The two legitimate stubs of read-only fields (`os.exit` in the runner, `os.time` in
   `connections_spec`) carry inline luacheck directives at their site. No production behaviour
   changes.
+
+### Security
+
+- **Database passwords no longer travel in the CLI's argv, and no longer appear in error
+  messages.** `psql -P`-style argv is readable by any user on the machine via `ps -eo args`, so the
+  password now reaches the client through its environment instead: `PGPASSWORD` (percent-decoded,
+  as libpq expects), `MYSQL_PWD` and `SQLCMDPASSWORD` (both verbatim — `parse_dadbod_url`
+  deliberately does not decode, and decoding those would break existing passwords containing `%`).
+  To be plain about the limit: this protects against *other users*, not against a process running
+  as you, which can read your environment just as easily as your argv. Separately, URLs in error
+  text are now redacted through the shared `sql.redact_url`, including the case where the password
+  itself contains an `@` — the authority is split on the last `@`, not the first, which previously
+  left `p@ssw0rd` masked as `***@ssw0rd`. DuckDB's federation path got the same treatment the hard
+  way: it rewrites the DSN you hand it before echoing it back in an error, so masking the DSN
+  *string* could not work and the password *value* is masked wherever it appears, across all four
+  places grip spawns the duckdb CLI.
 
 ## [3.9.0] - 2026-07-28
 

--- a/KEYMAPS.md
+++ b/KEYMAPS.md
@@ -240,6 +240,27 @@ Note: explain query plan is accessible via `gQ` (removed from tab system).
 | `4` | ER diagram float |
 | `5-9` | Open table under cursor in that view (5=Stats, 6=Columns, 7=FK, 8=Indexes, 9=Constraints) |
 
+## Connection Picker (`:GripConnect`, `gC`, `<C-g>`)
+
+Actions on the entry under the cursor. Each is shown in the picker's footer only
+when it applies to that entry.
+
+| Key | Action |
+|-----|--------|
+| `<CR>` | Connect |
+| `r` | Connect in the opposite mode (ro ↔ rw) for this session only; the file is not modified |
+| `!` | Connect a file-backed database in write mode (apply overwrites the file) |
+| `W` | Connect with watch mode on (auto-refresh every 5s) |
+| `M` | Toggle password masking in the picker row |
+| `a` | Attach this database to the current DuckDB connection |
+| `T` | Retest connection health |
+| `G` | Promote a project connection to global (`~/.grip/connections.json`) |
+| `s` | Save the local file under the cursor as a named connection |
+
+Entries default to read-only when their connections.json entry has `"mode": "ro"`;
+those rows show `RO`. `r` inverts that default for one session. See
+`:help grip-readonly`.
+
 ## Free `g` Keymaps (as of v1.5)
 
 Available for future features. Check this list before assigning a new `g` keymap:

--- a/README.md
+++ b/README.md
@@ -135,13 +135,19 @@ resolved when you connect, from the `.env` file the entry points at:
 with `url` written as `postgresql://api:${DEV_DB_PASSWORD}@dev.internal:5432/app?sslmode=require`.
 
 Values come from `env_file` first and fall back to the process environment, so `${PGPASSWORD}`
-alone works with no `env_file` at all. An unresolved placeholder is an error, never an empty
-substitution — a URL quietly missing its password either connects somewhere unintended or hangs
-on a prompt. Such an entry shows as `?` in the picker and reports the missing variable when you
-try to connect.
+alone works with no `env_file` at all. A placeholder that cannot be resolved is an error, and so is
+one that resolves to an *empty* value — a bare `KEY=` is the usual shape of a committed `.env`
+template, and substituting it would hand `psql` a URL with no password, which falls through to
+`~/.pgpass` and may connect with a different credential instead of failing. Either way the entry
+shows as `?` in the picker and names the variable when you try to connect.
+
+If a literal password happens to contain `${WORD}`, write `$${WORD}` — a doubled dollar produces
+the literal text and resolves nothing. The escape is only special immediately before `{NAME}`, so
+`pa$$word` is left alone.
 
 The `.env` file is parsed for `KEY=value` and `export KEY=value` lines, one pair of surrounding
-quotes is stripped, `#` comments and blank lines are ignored. It is read at connect time and
+quotes is stripped, whole-line `#` comments and blank lines are ignored. A `#` *within* a value is
+part of the value, not the start of a comment — a password may legitimately contain one. It is read at connect time and
 memoized on the file's mtime, so a password a teammate rotates mid-session is picked up on the
 next query. If the file is still git-crypt-locked, grip says so by name instead of failing with a
 parse error, and — because failed reads are never cached — `git-crypt unlock` takes effect on the
@@ -150,8 +156,14 @@ very next connect, with no restart.
 What this buys you: the secret lives in exactly one place you already control, and
 `~/.grip/connections.json` never receives it. `vim.g.db` holds the *template*, and expansion
 happens at a single point on the way to the database client, so no code path that writes to disk
-ever sees the expanded URL. Passwords also travel to the client process in its environment rather
-than in `argv`, so they do not show up in another user's `ps`.
+ever sees the expanded URL. Passwords also travel to `psql`, `mysql` and `sqlcmd` in the process
+environment rather than in `argv`, so they do not show up in another user's `ps`.
+
+**The exception is DuckDB federation.** `ATTACH` inlines the attached database's DSN into the SQL
+string, and grip passes that string to `duckdb -c`, so an attachment's password *is* visible in
+`ps` for the lifetime of every query against that connection — including one that came from
+`${VAR}`. If that matters to you, do not attach a credentialed database into DuckDB until this is
+moved onto DuckDB's secrets manager.
 
 **One limit, stated plainly:** a templated URL in `vim.g.db` is grip-only. vim-dadbod's `:DB`
 command and any statusline that reads that variable will see the literal `${NAME}`. If you rely on

--- a/README.md
+++ b/README.md
@@ -119,6 +119,68 @@ https://host/data.parquet  ← remote file via httpfs
 duckdb::memory:            ← single-query scratch (tables don't persist between queries)
 ```
 
+### Keeping the password out of the connection file
+
+A connection entry can reference its password instead of storing it. Any `${NAME}` in the URL is
+resolved when you connect, from the `.env` file the entry points at:
+
+```json
+{
+  "name": "dev",
+  "url": "postgresql://api@dev.internal:5432/app?sslmode=require",
+  "env_file": "~/work/api/.env"
+}
+```
+
+with `url` written as `postgresql://api:${DEV_DB_PASSWORD}@dev.internal:5432/app?sslmode=require`.
+
+Values come from `env_file` first and fall back to the process environment, so `${PGPASSWORD}`
+alone works with no `env_file` at all. An unresolved placeholder is an error, never an empty
+substitution — a URL quietly missing its password either connects somewhere unintended or hangs
+on a prompt. Such an entry shows as `?` in the picker and reports the missing variable when you
+try to connect.
+
+The `.env` file is parsed for `KEY=value` and `export KEY=value` lines, one pair of surrounding
+quotes is stripped, `#` comments and blank lines are ignored. It is read at connect time and
+memoized on the file's mtime, so a password a teammate rotates mid-session is picked up on the
+next query. If the file is still git-crypt-locked, grip says so by name instead of failing with a
+parse error, and — because failed reads are never cached — `git-crypt unlock` takes effect on the
+very next connect, with no restart.
+
+What this buys you: the secret lives in exactly one place you already control, and
+`~/.grip/connections.json` never receives it. `vim.g.db` holds the *template*, and expansion
+happens at a single point on the way to the database client, so no code path that writes to disk
+ever sees the expanded URL. Passwords also travel to the client process in its environment rather
+than in `argv`, so they do not show up in another user's `ps`.
+
+**One limit, stated plainly:** a templated URL in `vim.g.db` is grip-only. vim-dadbod's `:DB`
+command and any statusline that reads that variable will see the literal `${NAME}`. If you rely on
+either, keep those connections un-templated.
+
+### Read-only connections
+
+An entry can carry `"mode": "ro"`, and grip then connects with the client's own read-only switch:
+`PGOPTIONS=-c default_transaction_read_only=on` for postgres, a `SET SESSION TRANSACTION READ ONLY`
+merged into mysql's init command, `-readonly` for sqlite and duckdb. Grid editing is off, and the
+DDL commands (`:GripCreate`, `:GripDrop`, `:GripRename`, `:GripFill`, the sidebar's create/drop and
+the column operations) decline up front instead of prompting and failing at the server.
+
+Press `r` in the connection picker to connect in the opposite mode for this session only — the
+file is not modified.
+
+**This is a guard against accidents, not a security boundary.** Every one of those mechanisms is
+reversible from the query pad: `begin; set transaction read write; …` on postgres, and its
+equivalents elsewhere. If a connection must not be able to write, give it a database role that
+cannot — that is the boundary; `mode` is the seatbelt.
+
+Two more limits worth knowing:
+
+- If the postgres URL already carries its own `options=` parameter, that wins over `PGOPTIONS`, so
+  the session is not actually read-only even though grip shows it as `RO`.
+- `-readonly` is applied only to a database file that already exists. `duckdb::memory:` and a
+  not-yet-created sqlite file connect normally — the flag would abort the former outright and turn
+  "create it" into an error for the latter.
+
 ### Cross-database federation (DuckDB as hub)
 
 ```vim

--- a/README.md
+++ b/README.md
@@ -188,7 +188,9 @@ cannot — that is the boundary; `mode` is the seatbelt.
 Two more limits worth knowing:
 
 - If the postgres URL already carries its own `options=` parameter, that wins over `PGOPTIONS`, so
-  the session is not actually read-only even though grip shows it as `RO`.
+  the session is not actually read-only even though grip shows it as `RO`. Connecting such an entry
+  read-only warns you once, since this is the one case where the `RO` badge overstates what the
+  server was told.
 - `-readonly` is applied only to a database file that already exists. `duckdb::memory:` and a
   not-yet-created sqlite file connect normally — the flag would abort the former outright and turn
   "create it" into an error for the latter.

--- a/doc/dadbod-grip.txt
+++ b/doc/dadbod-grip.txt
@@ -968,9 +968,119 @@ Each saved connection shows a session-scoped status indicator:
   *   connected this session (set automatically on successful switch)
       unknown (no indicator shown; not yet connected this session)
   x   failed (last attempt did not succeed)
+  ?   unresolved (the entry's ${VAR} could not be expanded; see below)
 
 Press `T` on any file-based connection in the picker to retest it instantly.
 The indicator updates in place. Health state is session-only and never persisted.
+
+Entry fields ~
+
+Beyond `name` and `url`, an entry in either connections.json may carry:
+
+  env_file   path to a .env file supplying ${VAR} values for the url
+  mode       "ro" to connect read-only, "rw" (or absent) to connect writable
+  color      accent colour for this connection: a palette name
+             (green, orange, red, blue, violet, yellow) or "#rrggbb"
+
+All three are optional. An entry without them behaves exactly as before.
+
+                                                          *grip-secrets*
+Secrets: ${VAR} in a connection URL ~
+
+Any `${NAME}` in a url is resolved when you connect, so the password never
+has to be stored in connections.json: >
+
+  {
+    "name": "dev",
+    "url": "postgresql://api:${DEV_DB_PASSWORD}@dev.internal:5432/app",
+    "env_file": "~/work/api/.env"
+  }
+<
+Values come from `env_file` first and fall back to the process environment,
+so `${PGPASSWORD}` works with no env_file at all. An unresolved placeholder
+is always an error, never an empty substitution -- a url quietly missing its
+password either connects somewhere unintended or hangs on a prompt. Such an
+entry shows `?` in the picker and names the missing variable when you try to
+connect.
+
+The .env file is parsed for `KEY=value` and `export KEY=value` lines; one
+pair of surrounding quotes is stripped; `#` comments and blank lines are
+ignored. It is read at connect time and memoized on the file's mtime, so a
+rotated password is picked up on the next query. A git-crypt-locked file is
+reported as such by name rather than as a parse error, and because failed
+reads are never cached, `git-crypt unlock` takes effect on the very next
+connect with no restart.
+
+Grip stores and exposes the *template*: `vim.g.db` holds the url with the
+placeholder still in it, and expansion happens at a single point on the way
+to the database client. No code path that writes to disk ever sees the
+expanded url. Passwords also reach the client process through its
+environment rather than its argv, so they are not visible in `ps`.
+
+Limit: a templated url is grip-only. vim-dadbod's `:DB` and any statusline
+reading `g:db` see the literal `${NAME}`. Keep such connections un-templated
+if you depend on either.
+
+                                                          *grip-readonly*
+Read-only mode ~
+
+With `"mode": "ro"` grip connects using the client's own read-only switch:
+
+  postgresql   PGOPTIONS=-c default_transaction_read_only=on
+  mysql        SET SESSION TRANSACTION READ ONLY, merged into --init-command
+  sqlite       sqlite3 -readonly
+  duckdb       duckdb -readonly
+  sqlserver    already read-only; `mode` does not apply
+
+Grid editing is disabled, and the DDL entry points (|:GripCreate|,
+|:GripDrop|, |:GripRename|, |:GripFill|, the sidebar's create/drop, and the
+column operations) decline up front instead of prompting and then failing at
+the server. The winbar shows `RO` while connected read-only.
+
+Press `r` in the connection picker to connect in the opposite mode for this
+session only. The connections file is not modified.
+
+This is a guard against accidents, NOT a security boundary. Each mechanism
+above is reversible from the query pad -- on postgres, `begin; set
+transaction read write; ...` is enough. If a connection must not be able to
+write, give it a database role that cannot. That is the boundary; `mode` is
+the seatbelt.
+
+Two further limits:
+
+- An `options=` already present in a postgres url wins over PGOPTIONS, so
+  such a connection reports `RO` while its session is not read-only.
+- `-readonly` is applied only to a database file that already exists.
+  `duckdb::memory:` and a not-yet-created sqlite file connect normally: the
+  flag aborts the former outright and turns "create it" into an error for
+  the latter.
+
+                                                          *grip-accent*
+Connection colour ~
+
+`"color"` takes a palette name -- green, orange, red, blue, violet,
+yellow -- or a `#rrggbb` value, and tints the window borders, the grid
+rules and the schema sidebar title, so a red production connection does not
+look like a green local one. An unknown value is ignored, not raised.
+
+The palette reuses colours already in grip's theme, and every accent also
+carries a `ctermfg` (a `#rrggbb` value is approximated onto the nearest
+xterm palette entry), so none of this needs a truecolor terminal.
+
+Three highlight groups carry it:
+
+  GripConnAccent       the connection's colour
+  GripConnAccentBold   the same, bold; used for the sidebar title
+  GripBorder           window borders and grid rules; DERIVED from the
+                       accent, which is what makes an entry without a
+                       `color` restore the default #cba6f7 / ctermfg=147
+                       instead of leaving the last connection's tint behind
+
+All three are redefined on every connection switch and re-applied whenever
+highlights are rebuilt, so they survive a `:colorscheme` change. Because
+they are redefined rather than merged, defining any of them yourself in your
+config will not stick -- this is unchanged from how grip's other groups have
+always behaved.
 
 ==============================================================================
 14. EXPORT                                                   *grip-export*

--- a/doc/dadbod-grip.txt
+++ b/doc/dadbod-grip.txt
@@ -997,15 +997,25 @@ has to be stored in connections.json: >
   }
 <
 Values come from `env_file` first and fall back to the process environment,
-so `${PGPASSWORD}` works with no env_file at all. An unresolved placeholder
-is always an error, never an empty substitution -- a url quietly missing its
-password either connects somewhere unintended or hangs on a prompt. Such an
-entry shows `?` in the picker and names the missing variable when you try to
-connect.
+so `${PGPASSWORD}` works with no env_file at all.
+
+A placeholder that cannot be resolved is an error, and so is one that
+resolves to an EMPTY value: a bare `KEY=` is the usual shape of a committed
+.env template, and substituting it would hand psql a url with no password,
+which falls through to ~/.pgpass and may connect with a different credential
+instead of failing. Either way the entry shows `?` in the picker and names
+the variable when you try to connect.
+
+If a literal password contains `${WORD}`, write `$${WORD}`: a doubled dollar
+produces the literal text and resolves nothing. The escape is only special
+immediately before `{NAME}`, so `pa$$word` is left alone.
 
 The .env file is parsed for `KEY=value` and `export KEY=value` lines; one
-pair of surrounding quotes is stripped; `#` comments and blank lines are
-ignored. It is read at connect time and memoized on the file's mtime, so a
+pair of surrounding quotes is stripped; whole-line `#` comments and blank
+lines are ignored. A `#` inside a value is part of the value, not the start
+of a comment -- a password may legitimately contain one.
+
+It is read at connect time and memoized on the file's mtime, so a
 rotated password is picked up on the next query. A git-crypt-locked file is
 reported as such by name rather than as a parse error, and because failed
 reads are never cached, `git-crypt unlock` takes effect on the very next
@@ -1014,8 +1024,14 @@ connect with no restart.
 Grip stores and exposes the *template*: `vim.g.db` holds the url with the
 placeholder still in it, and expansion happens at a single point on the way
 to the database client. No code path that writes to disk ever sees the
-expanded url. Passwords also reach the client process through its
-environment rather than its argv, so they are not visible in `ps`.
+expanded url. Passwords also reach psql, mysql and sqlcmd through the
+process environment rather than argv, so they are not visible in `ps`.
+
+Exception: DuckDB federation. ATTACH inlines the attached database's DSN
+into the SQL string, which grip passes to `duckdb -c`, so an attachment's
+password IS visible in `ps` for the lifetime of every query against that
+connection -- including one that came from ${VAR}. Moving that onto
+DuckDB's secrets manager is tracked separately.
 
 Limit: a templated url is grip-only. vim-dadbod's `:DB` and any statusline
 reading `g:db` see the literal `${NAME}`. Keep such connections un-templated

--- a/doc/dadbod-grip.txt
+++ b/doc/dadbod-grip.txt
@@ -1066,6 +1066,8 @@ Two further limits:
 
 - An `options=` already present in a postgres url wins over PGOPTIONS, so
   such a connection reports `RO` while its session is not read-only.
+  Connecting it read-only warns once: it is the one case where the `RO`
+  badge claims more than the server was actually told.
 - `-readonly` is applied only to a database file that already exists.
   `duckdb::memory:` and a not-yet-created sqlite file connect normally: the
   flag aborts the former outright and turns "create it" into an error for

--- a/doc/tags
+++ b/doc/tags
@@ -22,6 +22,7 @@
 :GripTables	dadbod-grip.txt	/*:GripTables*
 :GripToggle	dadbod-grip.txt	/*:GripToggle*
 dadbod-grip.txt	dadbod-grip.txt	/*dadbod-grip.txt*
+grip-accent	dadbod-grip.txt	/*grip-accent*
 grip-adapters	dadbod-grip.txt	/*grip-adapters*
 grip-advanced	dadbod-grip.txt	/*grip-advanced*
 grip-ai	dadbod-grip.txt	/*grip-ai*
@@ -58,10 +59,12 @@ grip-picker	dadbod-grip.txt	/*grip-picker*
 grip-pinned-max	dadbod-grip.txt	/*grip-pinned-max*
 grip-profiling	dadbod-grip.txt	/*grip-profiling*
 grip-query-pad	dadbod-grip.txt	/*grip-query-pad*
+grip-readonly	dadbod-grip.txt	/*grip-readonly*
 grip-requirements	dadbod-grip.txt	/*grip-requirements*
 grip-s3-files	dadbod-grip.txt	/*grip-s3-files*
 grip-saved-queries	dadbod-grip.txt	/*grip-saved-queries*
 grip-schema	dadbod-grip.txt	/*grip-schema*
+grip-secrets	dadbod-grip.txt	/*grip-secrets*
 grip-sort-filter	dadbod-grip.txt	/*grip-sort-filter*
 grip-sort-filter-page	dadbod-grip.txt	/*grip-sort-filter-page*
 grip-sticky-header	dadbod-grip.txt	/*grip-sticky-header*

--- a/lua/dadbod-grip/adapters/duckdb.lua
+++ b/lua/dadbod-grip/adapters/duckdb.lua
@@ -29,6 +29,148 @@ local _catalog_cache = {}
 --- Forward declaration: body assigned after duckdb() is defined (Lua scoping).
 local get_catalog_set
 
+-- ── credential masking ────────────────────────────────────────────────────
+-- Defined up here, above everything that spawns the CLI, because every one of
+-- those paths carries an attachment DSN into DuckDB and can get it echoed
+-- back in stderr. See redact_query_error at the end of this block.
+
+--- Keys whose value is a credential in a "key=value ..." DSN.
+---
+--- Audited against the DSN dialects DuckDB's scanners actually accept rather
+--- than grown one entry at a time:
+---   * libpq (postgres_scanner) -- `password` and `sslpassword`, the client
+---     key passphrase. Deliberately NOT `passfile` or `sslkey`: those are
+---     paths, and masking a path only makes the error unactionable without
+---     protecting anything.
+---   * mysql_scanner and the other key=value dialects -- `passwd`, `pwd`.
+---   * token-bearing DSNs (MotherDuck, DuckDB secrets, object stores).
+local DSN_SECRET_KEYS = {
+  password = true, sslpassword = true, passwd = true, pwd = true,
+  token = true, motherduck_token = true, access_token = true,
+  auth_token = true, session_token = true,
+  api_key = true, apikey = true,
+  secret = true, secret_access_key = true,
+}
+
+--- Walk the `key=value` pairs of a libpq/DuckDB-style DSN, calling
+--- fn(key, raw_value) for each. `raw_value` is the span exactly as it appears
+--- in the DSN, backslash escapes included, because that is the form the CLI
+--- echoes back and therefore the form that has to be masked.
+---
+--- Not a gmatch("([%w_]+)=(%S+)"): libpq conninfo lets a value be quoted and
+--- contain spaces, and lets a quote inside a quoted value be backslash
+--- escaped. :GripAttach hands the DSN through verbatim (init.lua rejoins its
+--- argv with spaces), so both forms are two keystrokes away. A
+--- whitespace-terminated scan truncates `password='hun ter2'` to `'hun`, and
+--- a scan that stops at the first quote truncates `password='hun\'ter2'` to
+--- `hun\` -- both verified against DuckDB v1.5.5, which echoes the whole
+--- quoted value back.
+--- @param dsn string
+--- @param fn fun(key: string, raw_value: string)
+local function each_dsn_pair(dsn, fn)
+  local pos = 1
+  while pos <= #dsn do
+    local s, e, key = dsn:find("([%w_]+)=", pos)
+    if not s then return end
+    local quote = dsn:sub(e + 1, e + 1)
+    local value
+    if quote == "'" or quote == '"' then
+      -- Scan to the real closing quote, stepping over "\<any>" escapes.
+      local i = e + 2
+      while i <= #dsn do
+        local ch = dsn:sub(i, i)
+        if ch == "\\" then
+          i = i + 2
+        elseif ch == quote then
+          break
+        else
+          i = i + 1
+        end
+      end
+      -- Unterminated quote: the rest of the DSN is the value. Erring long is
+      -- the safe direction -- it can only mask more, never less.
+      value = dsn:sub(e + 2, math.min(i, #dsn + 1) - 1)
+      pos = i + 1
+    else
+      value = dsn:match("^%S*", e + 1) or ""
+      pos = e + 1 + #value
+    end
+    fn(key, value)
+    pos = math.max(pos, e + 1)
+  end
+end
+
+--- Strip the credentials of `dsn` out of a DuckDB error message.
+---
+--- The CLI echoes the DSN back in its own stderr, so a credentialed
+--- postgres/mysql/MotherDuck DSN reappears in the error text we hand to
+--- vim.notify(). What it echoes is NOT the string we passed, though: DuckDB
+--- v1.5.5 rewrites it first. "postgresql://u:pw@h/db" comes back as
+---
+---   IO Error: Cannot open file "<cwd>/postgresql:/u:pw@h/db": ...
+---
+--- -- one slash gone, the process cwd prepended -- and a "postgres:k=v ..."
+--- DSN comes back with the "postgres:" prefix stripped. So masking by
+--- whole-DSN substitution does not fire on the messages that actually occur.
+---
+--- This masks the credential *values* instead, wherever they appear and
+--- whatever surrounds them, which survives that rewriting as well as
+--- re-quoting, line-splitting and truncation:
+---   1. the password out of a URL-shaped DSN's authority (sql_util shares the
+---      last-"@" authority rule with redact_url and url_to_dsn);
+---   2. every `password=` / `token=`-style value of a key=value DSN --
+---      redact_url cannot see those at all, since a DuckDB DSN has no
+---      "user:pass@" run for it to match. Both the raw span and its
+---      backslash-unescaped form are masked, since which one the CLI echoes
+---      depends on how far into libpq the DSN got before it failed.
+---
+--- The message as a whole is deliberately NOT run through redact_url(): its
+--- doc comment warns that a free-form message can over-mask on an incidental
+--- "word:word@word". Working from the known secret material instead means a
+--- genuine diagnostic ("Extension not found") survives untouched.
+--- @param msg string
+--- @param dsn string|nil
+--- @return string
+local function redact_attach_error(msg, dsn)
+  if not dsn or dsn == "" then return msg end
+  local function mask(value)
+    if value and value ~= "" then
+      -- Function replacement, so a "%1" in a password is not expanded.
+      msg = msg:gsub(vim.pesc(value), function() return "***" end)
+    end
+  end
+  mask(sql_util.url_password(dsn))
+  each_dsn_pair(dsn, function(key, value)
+    if DSN_SECRET_KEYS[key:lower()] then
+      mask(value)
+      local unescaped = value:gsub("\\(.)", "%1")
+      if unescaped ~= value then mask(unescaped) end
+    end
+  end)
+  return msg
+end
+
+--- Strip the credentials of every DSN attached to `url` out of a DuckDB
+--- error message.
+---
+--- redact_attach_error only guards M.attach(). But build_attach_prefix() puts
+--- those same DSNs at the head of *every* query, so the moment an attached
+--- server becomes unreachable -- a restart, a dropped VPN -- the password
+--- comes back in the stderr of an ordinary SELECT and goes to vim.notify via
+--- view.lua. Applied inside the three functions that spawn the CLI with a
+--- prefix (duckdb, duckdb_async, duckdb_exec), so no individual error-return
+--- site has to remember.
+--- @param msg string|nil
+--- @param url string|nil
+--- @return string
+local function redact_query_error(msg, url)
+  if not msg or msg == "" or not url then return msg or "" end
+  for _, a in ipairs(_attachments[url] or {}) do
+    msg = redact_attach_error(msg, a.dsn)
+  end
+  return msg
+end
+
 --- Map DSN scheme prefix to the DuckDB extension that handles it.
 local function detect_extension(dsn)
   if dsn:find("^postgres:") or dsn:find("^postgresql:") then return "postgres_scanner" end
@@ -164,7 +306,10 @@ local function duckdb(db_path, sql_str, timeout_ms, url)
     end
   end
 
-  return stdout, stderr, code
+  -- The ATTACH prefix carried the attachment DSNs into this process; a failing
+  -- attachment gets them quoted back. Masked here rather than at each of the
+  -- ~15 places that return this stderr onwards.
+  return stdout, redact_query_error(stderr, url), code
 end
 
 --- Assigned here (after duckdb() is in scope) so the upvalue resolves correctly.
@@ -196,7 +341,8 @@ local function duckdb_async(db_path, sql_str, timeout_ms, url, callback)
   args[#args + 1] = effective_sql
   vim.system(args, { text = true, timeout = timeout_ms or 8000 }, function(out)
     vim.schedule(function()
-      callback(out.stdout or "", out.stderr or "", out.code)
+      -- Same reason as in duckdb(): the ATTACH prefix is in this SQL.
+      callback(out.stdout or "", redact_query_error(out.stderr or "", url), out.code)
     end)
   end)
 end
@@ -215,7 +361,9 @@ local function duckdb_exec(db_path, sql_str, timeout_ms, url)
   args[#args + 1] = "-c"
   args[#args + 1] = effective_sql
 
-  return adapters.run_cmd(args, timeout_ms or DEFAULT_TIMEOUT)
+  -- Same reason as in duckdb(): the ATTACH prefix is in this SQL.
+  local stdout, stderr, code = adapters.run_cmd(args, timeout_ms or DEFAULT_TIMEOUT)
+  return stdout, redact_query_error(stderr, url), code
 end
 
 --- Statement kinds a subquery can hold. Everything else -- DESCRIBE (db.describe_file
@@ -800,6 +948,30 @@ local function resolve_dsn_path(dsn)
   return prefix .. path
 end
 
+--- Split "user:pass@host:port/dbname" into its pieces, using the shared
+--- last-"@" authority rule from sql_util.
+---
+--- Emphatically NOT a `([^:@]+):?([^@]*)@([^:/]+)` pattern, which is what this
+--- used to be: that splits on the FIRST "@", so a perfectly legal password
+--- containing "@" ("P@ssw0rd") came out as password=P with the rest of the
+--- password stuffed into host=. Besides producing a DSN that cannot connect,
+--- it defeated redact_attach_error downstream -- the mask dutifully masked
+--- "P" and DuckDB echoed the remaining seven characters to the screen.
+--- @param rest string  everything after "scheme://"
+--- @return string|nil user
+--- @return string password  "" when absent
+--- @return string host
+--- @return string port  "" when absent
+--- @return string dbname  "" when absent
+local function split_url_rest(rest)
+  local authority = rest:match("^([^/]*)") or ""
+  local dbname = rest:match("^[^/]*/(.*)") or ""
+  local user, password, hostport = sql_util.split_authority(authority)
+  local host, port = hostport:match("^([^:]*):?(%d*)$")
+  if not host or host == "" then return nil end
+  return user, password or "", host, port or "", dbname
+end
+
 --- Convert a dadbod URL to a DuckDB ATTACH-compatible DSN.
 --- "postgresql://user:pass@host:port/dbname" -> "postgres:dbname=dbname user=user password=pass host=host port=port"
 --- "sqlite:path/to/db" -> "sqlite:path/to/db" (unchanged)
@@ -812,38 +984,37 @@ function M.url_to_dsn(url)
   -- so we match both schemes explicitly
   local pg_rest = url:match("^postgresql://(.+)") or url:match("^postgres://(.+)")
   if pg_rest then
-    -- With credentials: user:pass@host:port/db
-    local pg_user, pg_pass, pg_host, pg_port, pg_db =
-      pg_rest:match("^([^:@]+):?([^@]*)@([^:/]+):?(%d*)/?(.*)")
-    if pg_user then
-      local parts = { "postgres:dbname=" .. (pg_db ~= "" and pg_db or pg_user) }
-      table.insert(parts, "user=" .. pg_user)
-      if pg_pass ~= "" then table.insert(parts, "password=" .. pg_pass) end
+    local pg_user, pg_pass, pg_host, pg_port, pg_db = split_url_rest(pg_rest)
+    if pg_host then
+      -- With credentials: user[:pass]@host[:port]/db
+      if pg_user then
+        local parts = { "postgres:dbname=" .. (pg_db ~= "" and pg_db or pg_user) }
+        table.insert(parts, "user=" .. pg_user)
+        if pg_pass ~= "" then table.insert(parts, "password=" .. pg_pass) end
+        table.insert(parts, "host=" .. pg_host)
+        if pg_port ~= "" then table.insert(parts, "port=" .. pg_port) end
+        return table.concat(parts, " ")
+      end
+      -- Without credentials: host:port/db
+      local parts = { "postgres:dbname=" .. (pg_db ~= "" and pg_db or "postgres") }
       table.insert(parts, "host=" .. pg_host)
       if pg_port ~= "" then table.insert(parts, "port=" .. pg_port) end
-      return table.concat(parts, " ")
-    end
-    -- Without credentials: host:port/db
-    local pg_host_only, pg_port_only, pg_db_only =
-      pg_rest:match("^([^:/]+):?(%d*)/?(.*)")
-    if pg_host_only then
-      local parts = { "postgres:dbname=" .. (pg_db_only ~= "" and pg_db_only or "postgres") }
-      table.insert(parts, "host=" .. pg_host_only)
-      if pg_port_only ~= "" then table.insert(parts, "port=" .. pg_port_only) end
       return table.concat(parts, " ")
     end
   end
 
   -- MySQL URL -> mysql_scanner DSN
-  local my_user, my_pass, my_host, my_port, my_db =
-    url:match("^mysql://([^:@]+):?([^@]*)@([^:/]+):?(%d*)/?(.*)")
-  if my_user then
-    local parts = { "mysql:host=" .. my_host }
-    table.insert(parts, "user=" .. my_user)
-    if my_pass ~= "" then table.insert(parts, "password=" .. my_pass) end
-    if my_db ~= "" then table.insert(parts, "database=" .. my_db) end
-    if my_port ~= "" then table.insert(parts, "port=" .. my_port) end
-    return table.concat(parts, " ")
+  local my_rest = url:match("^mysql://(.+)")
+  if my_rest then
+    local my_user, my_pass, my_host, my_port, my_db = split_url_rest(my_rest)
+    if my_user then
+      local parts = { "mysql:host=" .. my_host }
+      table.insert(parts, "user=" .. my_user)
+      if my_pass ~= "" then table.insert(parts, "password=" .. my_pass) end
+      if my_db ~= "" then table.insert(parts, "database=" .. my_db) end
+      if my_port ~= "" then table.insert(parts, "port=" .. my_port) end
+      return table.concat(parts, " ")
+    end
   end
 
   -- Fallback: return as-is
@@ -851,7 +1022,11 @@ function M.url_to_dsn(url)
 end
 
 --- Store an attachment without validation (used by tests and load_attachments).
-local function store_attachment(url, dsn, alias)
+--- `template` is the still-templated form of the DSN, when the caller
+--- resolved a "${VAR}" placeholder to build `dsn`. It is carried purely so
+--- connections.save_attachments() can write the placeholder back to disk
+--- instead of the expanded, password-bearing DSN; nothing here reads it.
+local function store_attachment(url, dsn, alias, template)
   dsn = resolve_dsn_path(dsn)
   local ext = detect_extension(dsn)
   _attachments[url] = _attachments[url] or {}
@@ -859,21 +1034,56 @@ local function store_attachment(url, dsn, alias)
     if a.alias == alias then
       a.dsn = dsn
       a.extension = ext
+      a.template = template
       _catalog_cache[url] = nil  -- attachment list changed; re-query on next use
       return
     end
   end
-  table.insert(_attachments[url], { dsn = dsn, alias = alias, extension = ext })
+  table.insert(_attachments[url], { dsn = dsn, alias = alias, extension = ext, template = template })
   _catalog_cache[url] = nil  -- attachment list changed; re-query on next use
+end
+
+
+--- URL schemes a DuckDB scanner can be pointed at. url_to_dsn() rewrites the
+--- postgres/mysql URL forms into scanner DSNs; sqlite/duckdb/motherduck URLs
+--- it hands through because ATTACH takes those as-is.
+local ATTACHABLE_SCHEMES = {
+  postgres = true, postgresql = true, mysql = true,
+  sqlite = true, duckdb = true, md = true, motherduck = true,
+}
+
+--- Reject a DSN whose scheme has no DuckDB scanner behind it, before it ever
+--- reaches the CLI. Returns an error string, or nil when the DSN is fine.
+---
+--- DuckDB does not fail such an ATTACH with "unknown scheme": it falls
+--- through to its file reader and reports `Cannot open file
+--- "<cwd>/sqlserver:/sa:hunter2@host/db"` -- an error that says nothing
+--- useful and quotes the credentials back. The picker offers `a:attach` on
+--- every non-DuckDB connection (SQL Server included) and :GripAttach takes
+--- whatever is typed, so this is two keystrokes away; catching it here keeps
+--- both paths honest. The message names only the scheme -- never the DSN.
+--- @param dsn string
+--- @return string|nil err
+local function unsupported_attach_scheme(dsn)
+  local scheme = dsn:match("^(%a[%w%+%.%-]*)://")
+  if not scheme or ATTACHABLE_SCHEMES[scheme:lower()] then return nil end
+  return string.format(
+    "DuckDB has no scanner for %s:// -- it cannot ATTACH that database. "
+    .. "Attachable: postgres, mysql, sqlite, motherduck.", scheme)
 end
 
 --- Attach an external database to a DuckDB session.
 --- Validates the connection before storing. Returns nil on success, error string on failure.
 --- The attachment is prepended to every query via build_attach_prefix().
-function M.attach(url, dsn, alias)
+--- `url` and `dsn` must both already be expanded (callers of this function
+--- bypass db.resolve()); `template` is the pre-expansion DSN, kept only so
+--- the placeholder is what gets persisted. See store_attachment().
+function M.attach(url, dsn, alias, template)
   dsn = resolve_dsn_path(dsn)
   local db_path = extract_path(url)
   if not db_path then return "Invalid DuckDB URL" end
+  local scheme_err = unsupported_attach_scheme(dsn)
+  if scheme_err then return scheme_err end
 
   -- Validate: try the ATTACH before storing (a broken attachment kills all queries)
   local ext = detect_extension(dsn)
@@ -891,11 +1101,13 @@ function M.attach(url, dsn, alias)
 
   local _, stderr_attach, code_attach = adapters.run_cmd(args, 10000)
   if code_attach ~= 0 then
-    local msg = stderr_attach:gsub("%s+$", "")
+    -- The DSN is in the SQL the CLI just rejected, so its stderr can quote
+    -- the credentials straight back at us. Never return it raw.
+    local msg = redact_attach_error(stderr_attach:gsub("%s+$", ""), dsn)
     return msg ~= "" and msg or "Failed to attach database"
   end
 
-  store_attachment(url, dsn, alias)
+  store_attachment(url, dsn, alias, template)
   -- warm_schema is NOT scheduled here: the caller (connections.switch or GripAttach)
   -- is responsible, so only one async duckdb process opens the file after connect.
   return nil
@@ -922,6 +1134,8 @@ end
 --- Bulk-load attachments (called on connection switch from persisted data).
 --- Runs DSNs through url_to_dsn and validates each via M.attach().
 --- Skips attachments that fail validation (stale/unreachable).
+--- Each entry is { dsn, alias, template? }; connections.switch() has already
+--- resolved any "${VAR}" in dsn and put the original in template.
 function M.load_attachments(url, attachments)
   if not attachments or #attachments == 0 then
     _attachments[url] = nil
@@ -932,7 +1146,7 @@ function M.load_attachments(url, attachments)
   _catalog_cache[url] = nil
   for _, a in ipairs(attachments) do
     local dsn = M.url_to_dsn(a.dsn)
-    local err = M.attach(url, dsn, a.alias)
+    local err = M.attach(url, dsn, a.alias, a.template)
     if err then
       vim.notify(string.format("Skipped attachment '%s': %s", a.alias, err), vim.log.levels.WARN)
     end
@@ -1070,6 +1284,10 @@ M._extract_path = extract_path
 M._build_attach_prefix = build_attach_prefix
 M._detect_extension = detect_extension
 M._attach_unchecked = store_attachment
+M._redact_attach_error = redact_attach_error
+M._redact_query_error = redact_query_error
+M._dsn_secret_keys = DSN_SECRET_KEYS
+M._unsupported_attach_scheme = unsupported_attach_scheme
 M._make_schema_batch_sql = _make_schema_batch_sql
 M._main_catalog_name = main_catalog_name
 M._nested_json_sql = nested_json_sql

--- a/lua/dadbod-grip/adapters/duckdb.lua
+++ b/lua/dadbod-grip/adapters/duckdb.lua
@@ -267,6 +267,40 @@ local function split_catalog_schema_table(url, table_name)
   return nil, prefix, tbl
 end
 
+--- argv prefix for one duckdb invocation: the executable, the caller's output
+--- flags, an optional -readonly, and the database path. Callers append their
+--- own "-c <sql>".
+---
+--- `db` may be a duckdb: URL or an already-extracted path, so the three spawn
+--- sites (which hold a path) and the tests (which hold a URL) share one
+--- builder. A path never starts with "duckdb:".
+---
+--- -readonly is applied only to a file-backed database that already exists,
+--- and both halves of that condition are load-bearing rather than defensive:
+---   * "duckdb -readonly" on :memory: aborts with "Cannot launch in-memory
+---     database in read-only mode!", and :memory: is both the default starter
+---     connection and the engine behind file-as-table;
+---   * on a not-yet-existing file it aborts with "Cannot open database ... in
+---     read-only mode: database does not exist" rather than creating it.
+--- @param db string  a duckdb: URL or a database path
+--- @param opts table|nil  { readonly = boolean }
+--- @param flags string[]|nil  output flags for this call site
+local function duckdb_args(db, opts, flags)
+  local db_path = (type(db) == "string" and db:match("^duckdb:")) and extract_path(db) or db
+  local args = { "duckdb" }
+  for _, f in ipairs(flags or {}) do
+    args[#args + 1] = f
+  end
+  local file_backed = db_path and db_path ~= ":memory:"
+  if opts and opts.readonly and file_backed and vim.fn.filereadable(db_path) == 1 then
+    args[#args + 1] = "-readonly"
+  end
+  if file_backed then
+    args[#args + 1] = db_path
+  end
+  return args
+end
+
 local function duckdb(db_path, sql_str, timeout_ms, url)
   local effective_sql = sql_str
   local effective_timeout = timeout_ms or DEFAULT_TIMEOUT
@@ -288,10 +322,7 @@ local function duckdb(db_path, sql_str, timeout_ms, url)
     effective_timeout = math.max(effective_timeout, HTTP_TIMEOUT)
   end
 
-  local args = { "duckdb", "-csv", "-header" }
-  if db_path ~= ":memory:" then
-    args[#args + 1] = db_path
-  end
+  local args = duckdb_args(db_path, adapters.session_opts(), { "-csv", "-header" })
   args[#args + 1] = "-c"
   args[#args + 1] = effective_sql
 
@@ -333,10 +364,7 @@ end
 --- from the main Neovim loop via vim.schedule. Used for schema pre-warming.
 local function duckdb_async(db_path, sql_str, timeout_ms, url, callback)
   local effective_sql = url and (build_attach_prefix(url) .. sql_str) or sql_str
-  local args = { "duckdb", "-csv", "-header" }
-  if db_path ~= ":memory:" then
-    args[#args + 1] = db_path
-  end
+  local args = duckdb_args(db_path, adapters.session_opts(), { "-csv", "-header" })
   args[#args + 1] = "-c"
   args[#args + 1] = effective_sql
   vim.system(args, { text = true, timeout = timeout_ms or 8000 }, function(out)
@@ -354,10 +382,7 @@ local function duckdb_exec(db_path, sql_str, timeout_ms, url)
     effective_sql = build_attach_prefix(url) .. effective_sql
   end
 
-  local args = { "duckdb" }
-  if db_path ~= ":memory:" then
-    args[#args + 1] = db_path
-  end
+  local args = duckdb_args(db_path, adapters.session_opts())
   args[#args + 1] = "-c"
   args[#args + 1] = effective_sql
 
@@ -1281,6 +1306,7 @@ function M.ping(url)
 end
 
 M._extract_path = extract_path
+M._args = duckdb_args
 M._build_attach_prefix = build_attach_prefix
 M._detect_extension = detect_extension
 M._attach_unchecked = store_attachment

--- a/lua/dadbod-grip/adapters/init.lua
+++ b/lua/dadbod-grip/adapters/init.lua
@@ -25,9 +25,12 @@ M._exit_grace_ms = 3000
 ---
 --- @param args  string[]   argv for vim.system
 --- @param timeout_ms number|nil  process timeout in ms (default 30000)
---- @param opts table|nil  { stdin = string } to feed the process on stdin; the
----   sqlserver adapter needs it for GO-separated batches, which cannot be
----   expressed as a single command-line statement.
+--- @param opts table|nil  { stdin = string, env = table<string,string> } stdin
+---   to feed the process; the sqlserver adapter needs it for GO-separated
+---   batches, which cannot be expressed as a single command-line statement.
+---   env is merged into the inherited environment (vim.system's default
+---   behavior when clear_env is not set) -- used to pass secrets like
+---   PGPASSWORD without putting them on the command line.
 --- @return string stdout
 --- @return string stderr
 --- @return number exit_code
@@ -38,7 +41,12 @@ function M.run_cmd(args, timeout_ms, opts)
   -- vim.system() raises on spawn failure (ENOENT when the CLI is not installed).
   -- Adapters promise never to throw, and only query/execute/ping pre-check
   -- vim.fn.executable(), so swallow it here and report it like a failed exit.
-  local sys_opts = { text = true, timeout = t, stdin = opts and opts.stdin or nil }
+  local sys_opts = {
+    text = true,
+    timeout = t,
+    stdin = opts and opts.stdin or nil,
+    env = opts and opts.env or nil,
+  }
   local ok, err = pcall(vim.system, args, sys_opts, function(r)
     out = r
     done = true
@@ -73,7 +81,9 @@ end
 --- @param args  string[]   argv for vim.system
 --- @param timeout_ms number|nil  process timeout in ms (default 30000)
 --- @param callback fun(stdout: string, stderr: string, code: number)
-function M.run_cmd_async(args, timeout_ms, callback)
+--- @param opts table|nil  { env = table<string,string> } merged into the
+---   inherited environment, same contract as M.run_cmd's opts.env.
+function M.run_cmd_async(args, timeout_ms, callback, opts)
   local t = timeout_ms or 30000
   local watchdog
   local delivered = false
@@ -94,7 +104,8 @@ function M.run_cmd_async(args, timeout_ms, callback)
     deliver(TIMED_OUT.stdout, TIMED_OUT.stderr, TIMED_OUT.code)
   end, t + M._exit_grace_ms)
 
-  local ok, err = pcall(vim.system, args, { text = true, timeout = t }, function(r)
+  local sys_opts = { text = true, timeout = t, env = opts and opts.env or nil }
+  local ok, err = pcall(vim.system, args, sys_opts, function(r)
     vim.schedule(function()
       deliver(r.stdout or "", r.stderr or "", r.code)
     end)

--- a/lua/dadbod-grip/adapters/init.lua
+++ b/lua/dadbod-grip/adapters/init.lua
@@ -168,6 +168,25 @@ function M.session_opts()
   return { readonly = require("dadbod-grip.connections").current_mode() == "ro" }
 end
 
+--- Why this URL's session would not actually be read-only, or nil when the
+--- guard takes. The string completes the sentence "read-only is not enforced
+--- on this connection -- ..." and must never contain the URL, which can carry
+--- a password.
+---
+--- Optional per adapter: an adapter without a `readonly_caveat` has none, so
+--- an unknown scheme and a fully-guarded one answer the same. Only postgres
+--- defines one today. sqlite and duckdb have a comparable hole -- no
+--- `-readonly` for a file that does not exist yet -- but a database that has
+--- never existed has nothing to protect, so warning there would only teach
+--- people to ignore the warning.
+--- @param url string  a resolved (expanded) URL
+--- @return string|nil
+function M.readonly_caveat(url)
+  local adapter = M.resolve(url)
+  if not adapter or type(adapter.readonly_caveat) ~= "function" then return nil end
+  return adapter.readonly_caveat(url)
+end
+
 --- Resolve the adapter module for a given connection URL.
 --- @param url string
 --- @return table|nil adapter module

--- a/lua/dadbod-grip/adapters/init.lua
+++ b/lua/dadbod-grip/adapters/init.lua
@@ -126,6 +126,48 @@ local SCHEME_MAP = {
   ["mssql://"]      = "dadbod-grip.adapters.sqlserver",
 }
 
+--- The read-only decision for the db.* call currently in flight, or nil when
+--- there is none.
+---
+--- An adapter cannot work its own mode out. It is handed the *expanded* URL,
+--- while a connection's mode lives on its saved entry, which is keyed by the
+--- *template* -- and several adapters do not even carry the URL down to their
+--- argv builder (sqlite and duckdb pass a bare path). So db.lua decides it in
+--- the last frame that still holds the template and publishes it here for
+--- exactly the duration of the adapter call; see db.lua's via_adapter.
+---
+--- nil does not mean "rw": it means no db.* call is in flight -- a module
+--- reaching into an adapter directly -- and session_opts falls back to the
+--- ambient connection, which is the only guess available at that point.
+local _call_readonly = nil
+
+--- Publish `readonly`, and return whatever it displaced.
+---
+--- Returning the old value is what lets db.lua's via_adapter restore the
+--- frame it interrupted instead of clearing to nil. That is not theoretical
+--- nesting: run_cmd blocks in vim.wait, which pumps the main loop, so any
+--- scheduled db.* call runs *inside* an adapter call that is mid-spawn. A
+--- clear-to-nil there silently un-published the outer call's mode for every
+--- spawn it had left to make.
+--- @param readonly boolean|nil
+--- @return boolean|nil  the previously published value
+function M.set_call_readonly(readonly)
+  local previous = _call_readonly
+  _call_readonly = readonly
+  return previous
+end
+
+--- The per-spawn options every CLI adapter passes to its argv/env builder.
+--- Today that is only `readonly`.
+---
+--- Returned as a table rather than a boolean so a second flag does not change
+--- five signatures, and kept here rather than duplicated in four adapters.
+--- @return table  { readonly = boolean }
+function M.session_opts()
+  if _call_readonly ~= nil then return { readonly = _call_readonly } end
+  return { readonly = require("dadbod-grip.connections").current_mode() == "ro" }
+end
+
 --- Resolve the adapter module for a given connection URL.
 --- @param url string
 --- @return table|nil adapter module

--- a/lua/dadbod-grip/adapters/mysql.lua
+++ b/lua/dadbod-grip/adapters/mysql.lua
@@ -46,9 +46,6 @@ local function mysql_args(parsed, sql_str)
     args[#args + 1] = "-u"
     args[#args + 1] = parsed.user
   end
-  if parsed.pass and parsed.pass ~= "" then
-    args[#args + 1] = "-p" .. parsed.pass
-  end
   if parsed.dbname then
     args[#args + 1] = parsed.dbname
   end
@@ -57,23 +54,28 @@ local function mysql_args(parsed, sql_str)
   return args
 end
 
---- Strip the known password-on-CLI warning mysql writes to stderr on every run.
-local function scrub_stderr(stderr)
-  return (stderr:gsub("mysql: %[Warning%][^\n]*command line interface can be insecure%.?\n?", ""))
+--- opts.env for one mysql invocation: MYSQL_PWD carrying the password so it
+--- never appears in argv (visible via `ps`). No percent-decoding -- sql.lua's
+--- parse_dadbod_url hands mysql URLs to the CLI verbatim, and MYSQL_PWD is
+--- just the argv `-p<pass>` this replaces, so it gets the same verbatim value.
+--- Returns an empty table -- not a MYSQL_PWD key -- when there is no password,
+--- matching mysql_args' old behavior of omitting -p entirely (falls through
+--- to any password configured in a defaults file).
+local function mysql_env(parsed)
+  if not parsed.pass or parsed.pass == "" then return {} end
+  return { MYSQL_PWD = parsed.pass }
 end
 
 --- Run a statement, blocking.
 local function mysql_query(parsed, sql_str, timeout_ms)
-  local stdout, stderr, code = adapters.run_cmd(mysql_args(parsed, sql_str), timeout_ms or DEFAULT_TIMEOUT)
-  return stdout, scrub_stderr(stderr), code
+  return adapters.run_cmd(mysql_args(parsed, sql_str), timeout_ms or DEFAULT_TIMEOUT,
+    { env = mysql_env(parsed) })
 end
 
---- Run a statement without blocking; same argv and same stderr scrub as mysql_query.
+--- Run a statement without blocking; same argv and same env as mysql_query.
 local function mysql_query_async(parsed, sql_str, timeout_ms, callback)
-  adapters.run_cmd_async(mysql_args(parsed, sql_str), timeout_ms or DEFAULT_TIMEOUT,
-    function(stdout, stderr, code)
-      callback(stdout, scrub_stderr(stderr), code)
-    end)
+  adapters.run_cmd_async(mysql_args(parsed, sql_str), timeout_ms or DEFAULT_TIMEOUT, callback,
+    { env = mysql_env(parsed) })
 end
 
 function M.query(sql_str, url)
@@ -82,7 +84,7 @@ function M.query(sql_str, url)
   end
 
   local parsed = parse_url(url)
-  if not parsed then return nil, "Invalid MySQL URL: " .. url end
+  if not parsed then return nil, "Invalid MySQL URL: " .. sql_util.redact_url(url) end
 
   local stdout, stderr, code = mysql_query(parsed, sql_str)
   if code ~= 0 then
@@ -102,7 +104,7 @@ end
 
 function M.get_primary_keys(table_name, url)
   local parsed = parse_url(url)
-  if not parsed then return {}, "Invalid MySQL URL: " .. url end
+  if not parsed then return {}, "Invalid MySQL URL: " .. sql_util.redact_url(url) end
 
   local schema, tbl = split_table_name(table_name, parsed.dbname)
 
@@ -134,7 +136,7 @@ end
 
 function M.get_column_info(table_name, url)
   local parsed = parse_url(url)
-  if not parsed then return nil, "Invalid MySQL URL: " .. url end
+  if not parsed then return nil, "Invalid MySQL URL: " .. sql_util.redact_url(url) end
 
   local schema, tbl = split_table_name(table_name, parsed.dbname)
 
@@ -185,7 +187,7 @@ end
 
 function M.get_foreign_keys(table_name, url)
   local parsed = parse_url(url)
-  if not parsed then return {}, "Invalid MySQL URL: " .. url end
+  if not parsed then return {}, "Invalid MySQL URL: " .. sql_util.redact_url(url) end
 
   local schema, tbl = split_table_name(table_name, parsed.dbname)
 
@@ -225,7 +227,7 @@ end
 --- Returns { {table, column, ref_column, composite?}, ... }, err.
 function M.get_referencing_foreign_keys(table_name, url)
   local parsed_url = parse_url(url)
-  if not parsed_url then return {}, "Invalid MySQL URL: " .. url end
+  if not parsed_url then return {}, "Invalid MySQL URL: " .. sql_util.redact_url(url) end
 
   local schema, tbl = split_table_name(table_name, parsed_url.dbname)
 
@@ -323,7 +325,7 @@ end
 
 function M.explain(sql_str, url)
   local parsed = parse_url(url)
-  if not parsed then return nil, "Invalid MySQL URL: " .. url end
+  if not parsed then return nil, "Invalid MySQL URL: " .. sql_util.redact_url(url) end
 
   -- Try FORMAT=TREE (MySQL 8.0.16+), fallback to plain EXPLAIN. This stderr is
   -- dropped on purpose: a failure here only means the server predates 8.0.16, and
@@ -358,7 +360,7 @@ end
 
 function M.list_tables(url)
   local parsed = parse_url(url)
-  if not parsed then return nil, "Invalid MySQL URL: " .. url end
+  if not parsed then return nil, "Invalid MySQL URL: " .. sql_util.redact_url(url) end
   local sql_str = [[
     SELECT table_name,
       CASE table_type WHEN 'BASE TABLE' THEN 'table' ELSE 'view' END AS table_type
@@ -381,7 +383,7 @@ end
 
 function M.get_indexes(table_name, url)
   local parsed_url = parse_url(url)
-  if not parsed_url then return {}, "Invalid MySQL URL: " .. url end
+  if not parsed_url then return {}, "Invalid MySQL URL: " .. sql_util.redact_url(url) end
 
   local schema, tbl = split_table_name(table_name, parsed_url.dbname)
 
@@ -425,7 +427,7 @@ end
 
 function M.get_constraints(table_name, url)
   local parsed = parse_url(url)
-  if not parsed then return {}, "Invalid MySQL URL: " .. url end
+  if not parsed then return {}, "Invalid MySQL URL: " .. sql_util.redact_url(url) end
 
   local schema, tbl = split_table_name(table_name, parsed.dbname)
 
@@ -476,7 +478,7 @@ end
 
 function M.get_table_stats(table_name, url)
   local parsed_url = parse_url(url)
-  if not parsed_url then return nil, "Invalid MySQL URL: " .. url end
+  if not parsed_url then return nil, "Invalid MySQL URL: " .. sql_util.redact_url(url) end
 
   local schema, tbl = split_table_name(table_name, parsed_url.dbname)
 
@@ -508,7 +510,7 @@ function M.execute(sql_str, url)
   end
 
   local parsed = parse_url(url)
-  if not parsed then return nil, "Invalid MySQL URL: " .. url end
+  if not parsed then return nil, "Invalid MySQL URL: " .. sql_util.redact_url(url) end
 
   -- MySQL doesn't support DEFAULT VALUES; rewrite for compatibility
   sql_str = sql_str:gsub("DEFAULT VALUES", "() VALUES ()")
@@ -552,5 +554,7 @@ end
 
 -- Exposed for testing
 M._parse_url = parse_url
+M._mysql_args = mysql_args
+M._mysql_env = mysql_env
 
 return M

--- a/lua/dadbod-grip/adapters/mysql.lua
+++ b/lua/dadbod-grip/adapters/mysql.lua
@@ -32,8 +32,18 @@ end
 --- execute() asks for ROW_COUNT() explicitly.
 --- Split out from mysql_query() so the blocking and non-blocking spawns run
 --- byte-identical command lines.
-local function mysql_args(parsed, sql_str)
-  local args = { "mysql", "--batch", "--init-command=SET sql_mode='ANSI_QUOTES,NO_BACKSLASH_ESCAPES'" }
+---
+--- opts.readonly is merged *into* the existing --init-command rather than
+--- added as a second one: the mysql CLI keeps only the last --init-command it
+--- is given, so a second flag would silently drop the sql_mode the whole
+--- adapter depends on (ANSI_QUOTES) instead of adding to it.
+--- @param opts table|nil  { readonly = boolean }
+local function mysql_args(parsed, sql_str, opts)
+  local init = { "SET sql_mode='ANSI_QUOTES,NO_BACKSLASH_ESCAPES'" }
+  if opts and opts.readonly then
+    init[#init + 1] = "SET SESSION TRANSACTION READ ONLY"
+  end
+  local args = { "mysql", "--batch", "--init-command=" .. table.concat(init, "; ") }
   if parsed.host then
     args[#args + 1] = "-h"
     args[#args + 1] = parsed.host
@@ -68,14 +78,14 @@ end
 
 --- Run a statement, blocking.
 local function mysql_query(parsed, sql_str, timeout_ms)
-  return adapters.run_cmd(mysql_args(parsed, sql_str), timeout_ms or DEFAULT_TIMEOUT,
-    { env = mysql_env(parsed) })
+  return adapters.run_cmd(mysql_args(parsed, sql_str, adapters.session_opts()),
+    timeout_ms or DEFAULT_TIMEOUT, { env = mysql_env(parsed) })
 end
 
 --- Run a statement without blocking; same argv and same env as mysql_query.
 local function mysql_query_async(parsed, sql_str, timeout_ms, callback)
-  adapters.run_cmd_async(mysql_args(parsed, sql_str), timeout_ms or DEFAULT_TIMEOUT, callback,
-    { env = mysql_env(parsed) })
+  adapters.run_cmd_async(mysql_args(parsed, sql_str, adapters.session_opts()),
+    timeout_ms or DEFAULT_TIMEOUT, callback, { env = mysql_env(parsed) })
 end
 
 function M.query(sql_str, url)

--- a/lua/dadbod-grip/adapters/postgresql.lua
+++ b/lua/dadbod-grip/adapters/postgresql.lua
@@ -16,14 +16,66 @@ local function split_table_name(table_name)
   return sql_util.split_table_name(table_name, "public")
 end
 
+--- Percent-decode a password component. libpq decodes URI percent-escapes
+--- itself when a password is embedded in the connection string; once
+--- strip_password below pulls the password out of the URL and hands it to
+--- psql via PGPASSWORD instead, this restores that same decoding so libpq
+--- still sees the password it would have seen (sql.lua:80-82 documents that
+--- URLs otherwise go to CLI clients verbatim -- this is the one exception).
+local function percent_decode(s)
+  return (s:gsub("%%(%x%x)", function(hex)
+    return string.char(tonumber(hex, 16))
+  end))
+end
+
+--- Split url into (url-with-password-removed, percent-encoded-password-or-nil).
+--- Same authority-parsing rule as sql_util.redact_url: the authority runs up
+--- to the next "/", and inside it the split is on the LAST "@" so a password
+--- that itself contains "@" is not mistaken for the host separator.
+local function strip_password(url)
+  local scheme, rest = url:match("^(%w+://)(.*)$")
+  if not scheme then return url, nil end
+  local authority, tail = rest:match("^([^/]*)(/.*)$")
+  if not authority then authority, tail = rest, "" end
+
+  local at = nil
+  for i = #authority, 1, -1 do
+    if authority:sub(i, i) == "@" then at = i; break end
+  end
+  if not at then return url, nil end
+
+  local userpass, host = authority:sub(1, at - 1), authority:sub(at + 1)
+  local colon = userpass:find(":", 1, true)
+  if not colon then return url, nil end
+
+  local user, pass = userpass:sub(1, colon - 1), userpass:sub(colon + 1)
+  if pass == "" then return scheme .. user .. "@" .. host .. tail, nil end
+  return scheme .. user .. "@" .. host .. tail, pass
+end
+
 --- argv for one psql invocation. Split out from psql() so the blocking and
---- non-blocking spawns run byte-identical command lines.
+--- non-blocking spawns run byte-identical command lines. The password never
+--- appears here: strip_password removes it from the URL, and psql_env below
+--- delivers it via PGPASSWORD instead, so it never shows up in a `ps` listing.
 local function psql_args(url, sql_str)
-  return { "psql", url, "-X", "--no-password", "--csv", "-c", sql_str }
+  local stripped_url = strip_password(url)
+  return { "psql", stripped_url, "-X", "--no-password", "--csv", "-c", sql_str }
+end
+
+--- opts.env for one psql invocation: PGPASSWORD carrying whatever
+--- strip_password pulled out of the URL, decoded exactly once (see
+--- percent_decode above). Returns an empty table -- not a PGPASSWORD key --
+--- when the URL has no password, so --no-password falls through to
+--- ~/.pgpass instead of authenticating with an empty password.
+local function psql_env(url)
+  local _, pass = strip_password(url)
+  if not pass then return {} end
+  return { PGPASSWORD = percent_decode(pass) }
 end
 
 local function psql(url, sql_str, timeout_ms)
-  return adapters.run_cmd(psql_args(url, sql_str), timeout_ms or DEFAULT_TIMEOUT)
+  return adapters.run_cmd(psql_args(url, sql_str), timeout_ms or DEFAULT_TIMEOUT,
+    { env = psql_env(url) })
 end
 
 local function split_routine_name(routine_name)
@@ -279,7 +331,7 @@ function M.get_schema_batch_async(url, callback)
   adapters.run_cmd_async(psql_args(url, SCHEMA_BATCH_SQL), DEFAULT_TIMEOUT, function(stdout, _, code)
     if code ~= 0 then callback(nil); return end
     callback(parse_schema_batch(stdout))
-  end)
+  end, { env = psql_env(url) })
 end
 
 function M.explain(sql_str, url)
@@ -555,9 +607,11 @@ end
 --- Ping the server by running SELECT 1. Returns true on success, false on any error.
 function M.ping(url)
   if vim.fn.executable("psql") == 0 then return false end
-  local _, _, code = adapters.run_cmd(
-    { "psql", url, "-X", "--no-password", "--csv", "-c", "SELECT 1" }, 5000)
+  local _, _, code = adapters.run_cmd(psql_args(url, "SELECT 1"), 5000, { env = psql_env(url) })
   return code == 0
 end
+
+M._psql_args = psql_args
+M._psql_env = psql_env
 
 return M

--- a/lua/dadbod-grip/adapters/postgresql.lua
+++ b/lua/dadbod-grip/adapters/postgresql.lua
@@ -62,20 +62,36 @@ local function psql_args(url, sql_str)
   return { "psql", stripped_url, "-X", "--no-password", "--csv", "-c", sql_str }
 end
 
---- opts.env for one psql invocation: PGPASSWORD carrying whatever
---- strip_password pulled out of the URL, decoded exactly once (see
---- percent_decode above). Returns an empty table -- not a PGPASSWORD key --
---- when the URL has no password, so --no-password falls through to
---- ~/.pgpass instead of authenticating with an empty password.
-local function psql_env(url)
+--- opts.env for one psql invocation.
+---
+--- PGPASSWORD carries whatever strip_password pulled out of the URL, decoded
+--- exactly once (see percent_decode above). It is omitted -- an empty table,
+--- not an empty PGPASSWORD key -- when the URL has no password, so
+--- --no-password falls through to ~/.pgpass instead of authenticating with an
+--- empty password.
+---
+--- PGOPTIONS puts the session in read-only mode when opts.readonly is set.
+--- Not spliced into the URL as "?options=...": psql rejects that outright
+--- ('extra key/value separator "=" in URI query parameter'), and the
+--- percent-encoded form would mean decode-append-re-encode whenever a URL
+--- already carries its own options=. Caveat of using the env var instead: an
+--- options= already in the URL wins over PGOPTIONS, so such a connection is
+--- not put into read-only mode by this.
+--- @param url string
+--- @param opts table|nil  { readonly = boolean }
+local function psql_env(url, opts)
+  local env = {}
   local _, pass = strip_password(url)
-  if not pass then return {} end
-  return { PGPASSWORD = percent_decode(pass) }
+  if pass then env.PGPASSWORD = percent_decode(pass) end
+  if opts and opts.readonly then
+    env.PGOPTIONS = "-c default_transaction_read_only=on"
+  end
+  return env
 end
 
 local function psql(url, sql_str, timeout_ms)
   return adapters.run_cmd(psql_args(url, sql_str), timeout_ms or DEFAULT_TIMEOUT,
-    { env = psql_env(url) })
+    { env = psql_env(url, adapters.session_opts()) })
 end
 
 local function split_routine_name(routine_name)
@@ -331,7 +347,7 @@ function M.get_schema_batch_async(url, callback)
   adapters.run_cmd_async(psql_args(url, SCHEMA_BATCH_SQL), DEFAULT_TIMEOUT, function(stdout, _, code)
     if code ~= 0 then callback(nil); return end
     callback(parse_schema_batch(stdout))
-  end, { env = psql_env(url) })
+  end, { env = psql_env(url, adapters.session_opts()) })
 end
 
 function M.explain(sql_str, url)
@@ -607,7 +623,8 @@ end
 --- Ping the server by running SELECT 1. Returns true on success, false on any error.
 function M.ping(url)
   if vim.fn.executable("psql") == 0 then return false end
-  local _, _, code = adapters.run_cmd(psql_args(url, "SELECT 1"), 5000, { env = psql_env(url) })
+  local _, _, code = adapters.run_cmd(psql_args(url, "SELECT 1"), 5000,
+    { env = psql_env(url, adapters.session_opts()) })
   return code == 0
 end
 

--- a/lua/dadbod-grip/adapters/postgresql.lua
+++ b/lua/dadbod-grip/adapters/postgresql.lua
@@ -89,6 +89,32 @@ local function psql_env(url, opts)
   return env
 end
 
+--- Why the read-only session guard does not take on this URL, or nil when it
+--- does. See adapters.readonly_caveat for the dispatcher and the contract.
+---
+--- libpq prefers a connection string's own `options` keyword over PGOPTIONS --
+--- it does not merge the two -- so the env var psql_env sets above is simply
+--- ignored for such a URL and the session opens writable. The caveat is
+--- documented, but a connection marked "mode": "ro" whose server would still
+--- accept a DELETE is worth saying out loud at connect time: the RO badge and
+--- the DDL refusals key off the entry, so this connection looks *more*
+--- protected than an ordinary one, not less.
+---
+--- An explicitly empty `options=` counts. libpq falls back to PGOPTIONS only
+--- when the keyword is absent altogether, so `?options=` defeats it too.
+--- @param url string  a resolved (expanded) postgres URL
+--- @return string|nil
+function M.readonly_caveat(url)
+  local query = (url or ""):match("^[^#]*%?([^#]*)")
+  if not query then return nil end
+  for _, pair in ipairs(vim.split(query, "&", { plain = true })) do
+    if pair == "options" or pair:match("^options=") then
+      return "the URL carries its own options= parameter, which overrides PGOPTIONS"
+    end
+  end
+  return nil
+end
+
 local function psql(url, sql_str, timeout_ms)
   return adapters.run_cmd(psql_args(url, sql_str), timeout_ms or DEFAULT_TIMEOUT,
     { env = psql_env(url, adapters.session_opts()) })

--- a/lua/dadbod-grip/adapters/sqlite.lua
+++ b/lua/dadbod-grip/adapters/sqlite.lua
@@ -41,12 +41,26 @@ end
 
 --- argv for one sqlite3 invocation. Split out from sqlite3() so the blocking
 --- and non-blocking spawns run byte-identical command lines.
-local function sqlite3_args(db_path, sql_str)
-  return { "sqlite3", "-init", "", "-csv", "-header", db_path, sql_str }
+---
+--- -readonly is added for opts.readonly, but only when the file is already
+--- there: sqlite3 creates a missing database on open, and -readonly turns
+--- that into a hard "unable to open database file" instead. A connection
+--- pointing at a not-yet-created file therefore behaves exactly as it does in
+--- rw mode -- there is nothing to protect in a database that does not exist.
+--- @param opts table|nil  { readonly = boolean }
+local function sqlite3_args(db_path, sql_str, opts)
+  local args = { "sqlite3", "-init", "", "-csv", "-header" }
+  if opts and opts.readonly and vim.fn.filereadable(db_path) == 1 then
+    args[#args + 1] = "-readonly"
+  end
+  args[#args + 1] = db_path
+  args[#args + 1] = sql_str
+  return args
 end
 
 local function sqlite3(db_path, sql_str, timeout_ms)
-  return adapters.run_cmd(sqlite3_args(db_path, sql_str), timeout_ms or DEFAULT_TIMEOUT)
+  return adapters.run_cmd(sqlite3_args(db_path, sql_str, adapters.session_opts()),
+    timeout_ms or DEFAULT_TIMEOUT)
 end
 
 function M.query(sql_str, url)
@@ -259,10 +273,11 @@ function M.get_schema_batch_async(url, callback)
   -- be able to tell a bad URL from a spawn failure by that timing difference.
   if not db_path then vim.schedule(function() callback(nil) end); return end
 
-  adapters.run_cmd_async(sqlite3_args(db_path, SCHEMA_BATCH_SQL), DEFAULT_TIMEOUT, function(stdout, _, code)
-    if code ~= 0 then callback(nil); return end
-    callback(parse_schema_batch(stdout))
-  end)
+  adapters.run_cmd_async(sqlite3_args(db_path, SCHEMA_BATCH_SQL, adapters.session_opts()),
+    DEFAULT_TIMEOUT, function(stdout, _, code)
+      if code ~= 0 then callback(nil); return end
+      callback(parse_schema_batch(stdout))
+    end)
 end
 
 function M.explain(sql_str, url)
@@ -458,5 +473,6 @@ end
 
 -- Exposed for testing
 M._extract_path = extract_path
+M._sqlite3_args = sqlite3_args
 
 return M

--- a/lua/dadbod-grip/adapters/sqlserver.lua
+++ b/lua/dadbod-grip/adapters/sqlserver.lua
@@ -62,8 +62,6 @@ local function sqlcmd_args(parsed, sql_str, opts)
   end
 
   if parsed.user and parsed.user ~= "" then
-    table.insert(args, 4, parsed.pass or "")
-    table.insert(args, 4, "-P")
     table.insert(args, 4, parsed.user)
     table.insert(args, 4, "-U")
   else
@@ -73,16 +71,29 @@ local function sqlcmd_args(parsed, sql_str, opts)
   return args
 end
 
+--- opts.env for one sqlcmd invocation: SQLCMDPASSWORD carrying the password so
+--- it never appears in argv (visible via `ps`) -- the env-var equivalent of the
+--- -P flag this replaces. No percent-decoding, same verbatim contract as
+--- sqlcmd_args. Set (even to "") whenever a user is given, mirroring the old
+--- -P/-P "" pairing with -U; empty when there is no user, since that means
+--- -E integrated auth, which ignores any password.
+local function sqlcmd_env(parsed)
+  if not parsed.user or parsed.user == "" then return {} end
+  return { SQLCMDPASSWORD = parsed.pass or "" }
+end
+
 --- Build and run the sqlcmd command, blocking.
 local function sqlcmd(parsed, sql_str, timeout_ms, opts)
-  return adapters.run_cmd(sqlcmd_args(parsed, sql_str, opts), timeout_ms or DEFAULT_TIMEOUT)
+  return adapters.run_cmd(sqlcmd_args(parsed, sql_str, opts), timeout_ms or DEFAULT_TIMEOUT,
+    { env = sqlcmd_env(parsed) })
 end
 
 --- Run GO-separated batches by feeding them to sqlcmd on stdin. `-Q` can only
 --- carry one batch, and SET SHOWPLAN_TEXT has to be alone in its own.
 local function sqlcmd_batch(parsed, batches, timeout_ms)
   local script = table.concat(batches, "\nGO\n") .. "\nGO\n"
-  return adapters.run_cmd(sqlcmd_args(parsed, nil), timeout_ms or DEFAULT_TIMEOUT, { stdin = script })
+  return adapters.run_cmd(sqlcmd_args(parsed, nil), timeout_ms or DEFAULT_TIMEOUT,
+    { stdin = script, env = sqlcmd_env(parsed) })
 end
 
 --- Message for a non-zero sqlcmd exit. With -b the server's "Msg 208, ..." text
@@ -150,7 +161,7 @@ local function run_query(sql_str, url, timeout_ms)
   end
 
   local parsed = parse_url(url)
-  if not parsed then return nil, "Invalid SQL Server URL: " .. url end
+  if not parsed then return nil, "Invalid SQL Server URL: " .. sql_util.redact_url(url) end
 
   local stdout, stderr, code = sqlcmd(parsed, sql_str, timeout_ms)
   if code ~= 0 then
@@ -175,7 +186,7 @@ local function run_query_async(sql_str, url, timeout_ms, callback)
 
   local parsed = parse_url(url)
   if not parsed then
-    vim.schedule(function() callback(nil, "Invalid SQL Server URL: " .. url) end)
+    vim.schedule(function() callback(nil, "Invalid SQL Server URL: " .. sql_util.redact_url(url)) end)
     return
   end
 
@@ -186,7 +197,7 @@ local function run_query_async(sql_str, url, timeout_ms, callback)
         return
       end
       callback(parse_sqlcmd_table(stdout), nil)
-    end)
+    end, { env = sqlcmd_env(parsed) })
 end
 
 function M.query(sql_str, url)
@@ -204,7 +215,7 @@ function M.execute(sql_str, url)
     return nil, "sqlcmd not found. Install Microsoft sqlcmd tools."
   end
   local parsed = parse_url(url)
-  if not parsed then return nil, "Invalid SQL Server URL: " .. url end
+  if not parsed then return nil, "Invalid SQL Server URL: " .. sql_util.redact_url(url) end
   local stdout, stderr, code = sqlcmd(parsed, sql_str, nil, { nocount = false })
   if code ~= 0 then
     return nil, sqlcmd_error(stdout, stderr, code)
@@ -528,7 +539,7 @@ function M.explain(sql_str, url)
     return nil, "sqlcmd not found. Install Microsoft sqlcmd tools."
   end
   local parsed = parse_url(url)
-  if not parsed then return nil, "Invalid SQL Server URL: " .. url end
+  if not parsed then return nil, "Invalid SQL Server URL: " .. sql_util.redact_url(url) end
 
   local stdout, stderr, code = sqlcmd_batch(parsed, { "SET SHOWPLAN_TEXT ON", sql_str })
   if code ~= 0 then
@@ -549,5 +560,7 @@ end
 
 M._parse_url = parse_url
 M._parse_sqlcmd_table = parse_sqlcmd_table
+M._sqlcmd_args = sqlcmd_args
+M._sqlcmd_env = sqlcmd_env
 
 return M

--- a/lua/dadbod-grip/ai.lua
+++ b/lua/dadbod-grip/ai.lua
@@ -242,8 +242,11 @@ function M.build_schema_context(url, question)
   local tables = db.list_tables(url)
   if not tables then return "", "unknown" end
 
-  -- Detect adapter name (generic "SQL" when no adapter claims the scheme)
-  local adapter_name = require("dadbod-grip.adapters").display_name(url) or "SQL"
+  -- Detect adapter name (generic "SQL" when no adapter claims the scheme).
+  -- A "${VAR}" template is resolved first: this name goes into the LLM prompt
+  -- as the target dialect, and the SQL that comes back is run.
+  local adapter_name = require("dadbod-grip.adapters")
+    .display_name(db.resolved_url(url)) or "SQL"
 
   -- Extract table names (adapters return different formats)
   local table_names = {}

--- a/lua/dadbod-grip/completion.lua
+++ b/lua/dadbod-grip/completion.lua
@@ -364,7 +364,10 @@ function M.complete(before, url, aliases)
       if not found_in_cache then
         local ok, duckdb = pcall(require, "dadbod-grip.adapters.duckdb")
         if ok then
-          local atts = duckdb.get_attachments(url)
+          -- The attachment registry is keyed by the expanded URL (that is
+          -- what db.resolve hands the adapter on every query), while `url`
+          -- here is vim.b.db/vim.g.db -- the template.
+          local atts = duckdb.get_attachments(require("dadbod-grip.db").resolved_url(url))
           for _, att in ipairs(atts) do
             if att.alias == q then
               local db = require("dadbod-grip.db")

--- a/lua/dadbod-grip/connections.lua
+++ b/lua/dadbod-grip/connections.lua
@@ -653,6 +653,13 @@ function M.switch(url, name, conn_type, opts)
   -- needed by the DuckDB attachment paths below, which bypass db.resolve().
   local conn_url, secret_err = M.expand_url(url)
   if not conn_url then
+    -- Same distinct marker T:test sets, for the same reason: the picker has
+    -- to say "this one could not resolve its secret" rather than the generic
+    -- "x" of a database that is genuinely unreachable. Connecting is how most
+    -- people meet this failure, so the attempt has to record it too --
+    -- otherwise the user presses <CR>, reads an error, reopens the picker and
+    -- finds nothing to show for it.
+    M.set_health(url, "unresolved")
     vim.notify("Grip: " .. (secret_err or "could not resolve connection secrets"),
       vim.log.levels.ERROR)
     return false
@@ -1258,7 +1265,14 @@ function M.pick(opts)
             local path = extract_local_path(conn_url)
             M.set_health(c.url, vim.fn.filereadable(path) == 1 and "ok" or "fail")
           else
-            local ok = require("dadbod-grip.db").ping(conn_url)
+            -- db.ping is given the URL *as stored*, not the expansion above:
+            -- it resolves internally, and everything else it consults keys on
+            -- the template. Handing it the expanded URL made
+            -- current_mode(expanded) find no entry and report "rw", so a
+            -- connection saved "mode": "ro" got pinged with a writable
+            -- session -- the one place in this feature that looked a
+            -- connection up by anything but the template.
+            local ok = require("dadbod-grip.db").ping(c.url)
             M.set_health(c.url, ok and "ok" or "fail")
           end
         end,

--- a/lua/dadbod-grip/connections.lua
+++ b/lua/dadbod-grip/connections.lua
@@ -726,6 +726,23 @@ function M.switch(url, name, conn_type, opts)
     _mode_override[url] = opts.mode
   end
 
+  -- Say so, once per connect, when this particular connection cannot keep the
+  -- read-only promise the rest of the UI is about to make for it. Everything
+  -- downstream -- the RO badge, the DDL refusals -- reads the entry rather
+  -- than what the server was actually told, so silence here leaves the one
+  -- connection with a writable session looking the most protected of all.
+  --
+  -- Below the override, so an `r`-toggle to ro warns and a toggle to rw does
+  -- not. Asked of conn_url, not the template: the `options=` can arrive inside
+  -- a ${VAR}. Lazy require -- adapters reaches back into this module.
+  if M.current_mode(url) == "ro" then
+    local caveat = require("dadbod-grip.adapters").readonly_caveat(conn_url)
+    if caveat then
+      vim.notify("Grip: read-only is not enforced on this connection -- " .. caveat,
+        vim.log.levels.WARN)
+    end
+  end
+
   -- Re-tint the accent groups for the connection being switched to. Read
   -- after the write above so a just-added entry is found, and passed
   -- unconditionally: an entry with no `color` (or no entry at all) has to

--- a/lua/dadbod-grip/connections.lua
+++ b/lua/dadbod-grip/connections.lua
@@ -4,17 +4,23 @@
 
 local paths = require("dadbod-grip.paths")
 local ui = require("dadbod-grip.ui")
+local secrets = require("dadbod-grip.secrets")
 
 local M = {}
 
 -- Session-scoped connection health state (never persisted).
--- Values: "ok" | "fail" | "unknown" (default when absent)
+-- Values: "ok" | "fail" | "unresolved" | "unknown" (default when absent).
+-- "unresolved" is distinct from "fail": the connection was never attempted --
+-- its ${VAR} placeholder(s) couldn't be expanded (missing .env, still
+-- git-crypt-locked, renamed variable), so a scheme/network failure would be
+-- a meaningless report.
 local _health = {}
 
 local function health_char(url)
   local s = _health[url] or "unknown"
-  if s == "ok"   then return "*" end
-  if s == "fail" then return "x" end
+  if s == "ok"         then return "*" end
+  if s == "fail"       then return "x" end
+  if s == "unresolved" then return "?" end
   return " "
 end
 
@@ -182,6 +188,9 @@ local function read_json_connections(path, source)
                   type = entry.type, source = source or "file" }
       if entry.attachments then c.attachments = entry.attachments end
       if entry.last_used then c.last_used = entry.last_used end
+      if entry.env_file then c.env_file = entry.env_file end
+      if entry.mode then c.mode = entry.mode end
+      if entry.color then c.color = entry.color end
       table.insert(result, c)
     end
   end
@@ -213,6 +222,64 @@ local function read_file_connections()
   return result
 end
 
+-- ── secret expansion ──────────────────────────────────────────────────────
+
+--- Find the saved entry for a connection URL, or nil when the URL is not a
+--- saved connection (an ad-hoc :GripConnect URL, a g:dbs entry, ...).
+---
+--- Exists so db.lua can reach an entry's env_file without knowing where
+--- connections are stored. Deliberately reads the JSON files directly rather
+--- than going through M.list(): list() also runs Docker discovery, and this
+--- sits on the query path -- db.resolve() calls it for every templated URL.
+--- @param url string|nil
+--- @return table|nil entry
+function M.entry_for(url)
+  if type(url) ~= "string" or url == "" then return nil end
+  for _, c in ipairs(read_file_connections()) do
+    if c.url == url then return c end
+  end
+  return nil
+end
+
+--- Resolve the ${VAR} placeholders in a connection URL against the env_file
+--- of its saved entry (falling back to the process environment).
+---
+--- The expanded URL carries the live password, so it exists in exactly two
+--- kinds of place: the argv/env of the database CLI, and the local variable
+--- that got it there. vim.g.db, vim.b.db, connections.json and the query
+--- history all keep the *template* -- db.resolve() calls this at the single
+--- point where a URL is handed to an adapter, which is why no write path in
+--- the plugin can spill a secret. Do not push the expansion outward.
+---
+--- A URL with no placeholder is returned unchanged without touching the
+--- filesystem, so ordinary literal connections cost exactly what they did
+--- before.
+--- @param url string|nil
+--- @return string|nil expanded  nil only when expansion failed
+--- @return string|nil err
+function M.expand_url(url)
+  if type(url) ~= "string" or not secrets.has_template(url) then return url end
+  return secrets.expand(url, M.entry_for(url))
+end
+
+--- Resolve the ${VAR} placeholders in a persisted DuckDB attachment DSN.
+---
+--- Attachment DSNs are stored templated (see M.save_attachments), so the
+--- password of an attached postgres/mysql database never lands in
+--- connections.json either. Variables resolve against the attached
+--- connection's own entry when the stored string is itself a saved
+--- connection URL -- how the `a:attach` picker action stores it -- and
+--- otherwise against the entry of the DuckDB connection the attachment hangs
+--- off, which is what a DSN typed straight into :GripAttach gets.
+--- @param dsn string|nil
+--- @param host_url string|nil the DuckDB connection URL, as stored (templated)
+--- @return string|nil expanded
+--- @return string|nil err
+function M.expand_dsn(dsn, host_url)
+  if type(dsn) ~= "string" or not secrets.has_template(dsn) then return dsn end
+  return secrets.expand(dsn, M.entry_for(dsn) or M.entry_for(host_url))
+end
+
 --- Write connections to .grip/connections.json.
 --- Deduplicates by URL before writing, keeping the entry with the highest
 --- last_used timestamp. This self-heals files bloated by historical bugs.
@@ -236,6 +303,9 @@ local function write_file_connections(conns)
     if c.type then entry.type = c.type end
     if c.attachments and #c.attachments > 0 then entry.attachments = c.attachments end
     if c.last_used then entry.last_used = c.last_used end
+    if c.env_file then entry.env_file = c.env_file end
+    if c.mode then entry.mode = c.mode end
+    if c.color then entry.color = c.color end
     table.insert(data, entry)
   end
   local json = vim.fn.json_encode(data)
@@ -328,6 +398,9 @@ function M.list()
     for _, gc in ipairs(global_existing) do
       local gentry = { name = gc.name, url = gc.url }
       if gc.type then gentry.type = gc.type end
+      if gc.env_file then gentry.env_file = gc.env_file end
+      if gc.mode then gentry.mode = gc.mode end
+      if gc.color then gentry.color = gc.color end
       table.insert(gdata, gentry)
     end
     vim.fn.writefile({ vim.fn.json_encode(gdata) }, global_connections_path())
@@ -419,7 +492,7 @@ function M.set_health(url, status)
   _health[url] = status
 end
 
---- Return the current session health for a URL: "ok" | "fail" | "unknown".
+--- Return the current session health for a URL: "ok" | "fail" | "unresolved" | "unknown".
 function M.get_health(url)
   return _health[url] or "unknown"
 end
@@ -501,6 +574,19 @@ function M.switch(url, name, conn_type, opts)
   -- Strip session-only flags: they must never reach the connection registry
   url = strip_flags(url)
 
+  -- Resolve ${VAR} placeholders up front, before anything is mutated or
+  -- written: a connection whose .env is missing or still git-crypt-locked
+  -- must fail cleanly instead of leaving a half-switched session behind.
+  -- `url` itself stays the template -- that is what gets persisted, what
+  -- vim.g.db holds, and what every later lookup keys on. conn_url is only
+  -- needed by the DuckDB attachment paths below, which bypass db.resolve().
+  local conn_url, secret_err = M.expand_url(url)
+  if not conn_url then
+    vim.notify("Grip: " .. (secret_err or "could not resolve connection secrets"),
+      vim.log.levels.ERROR)
+    return
+  end
+
   -- Single read of the local file; everything below (type resolution,
   -- rename/insert, MRU touch) mutates this same in-memory list, and it is
   -- written back at most once at the end instead of once per mutation.
@@ -552,8 +638,12 @@ function M.switch(url, name, conn_type, opts)
     M.set_health(url, "ok")
     -- Compute the DuckDB connection that will actually run queries against this file.
     -- Mirrors the logic in init.lua so the query pad is wired to the same connection.
+    -- The scheme test needs the resolved URL (a whole-URL template hides it);
+    -- the pad is still bound to the template, which db.resolve() expands.
     local active = vim.g.db
-    local db_url = (active and active:match("^duckdb:")) and active or "duckdb::memory:"
+    local active_resolved = active and (M.expand_url(active) or active)
+    local db_url = (active_resolved and active_resolved:match("^duckdb:")) and active
+      or "duckdb::memory:"
     vim.schedule(function()
       -- No reuse_win: let find_content_win() place the grid correctly.
       -- Passing cur_win risks putting the grid in the sidebar if that window was focused.
@@ -580,7 +670,12 @@ function M.switch(url, name, conn_type, opts)
 
   -- Restore persisted attachments for DuckDB connections (local file only;
   -- attachments are always saved to local by M.save_attachments).
-  if url:find("^duckdb:") then
+  --
+  -- One of the four paths that bypass db.resolve(), so it expands by hand:
+  -- the adapter's attachment registry is keyed by the URL the adapter is
+  -- called with, which is the *expanded* one on every query, and the stored
+  -- DSNs are templates that only become connectable here.
+  if conn_url:find("^duckdb:") then
     local stored_atts
     for _, c in ipairs(local_conns) do
       if c.url == url and c.attachments then
@@ -589,7 +684,28 @@ function M.switch(url, name, conn_type, opts)
       end
     end
     if stored_atts then
-      require("dadbod-grip.adapters.duckdb").load_attachments(url, stored_atts)
+      local live_atts = {}
+      for _, a in ipairs(stored_atts) do
+        local stored_dsn = type(a) == "table" and a.dsn or nil
+        if type(stored_dsn) ~= "string" then
+          -- Nothing to expand: hand the record on exactly as it was read and
+          -- let load_attachments deal with whatever shape it is, as before.
+          table.insert(live_atts, a)
+        else
+          local dsn, dsn_err = M.expand_dsn(stored_dsn, url)
+          if dsn then
+            -- template is carried through so the next save_attachments()
+            -- writes the placeholder back, not what it resolved to.
+            table.insert(live_atts, {
+              dsn = dsn, alias = a.alias, template = dsn ~= stored_dsn and stored_dsn or nil,
+            })
+          else
+            vim.notify(string.format("Skipped attachment '%s': %s", a.alias, dsn_err),
+              vim.log.levels.WARN)
+          end
+        end
+      end
+      require("dadbod-grip.adapters.duckdb").load_attachments(conn_url, live_atts)
     end
   end
 
@@ -646,6 +762,16 @@ end
 
 --- Persist attachments for a DuckDB connection URL.
 --- Called after attach/detach to update .grip/connections.json.
+---
+--- `url` is the connection URL as stored (templated), since that is the key
+--- the entry lives under on disk; the live adapter registry is keyed by the
+--- expanded URL, so callers pass the two separately.
+---
+--- Each record is persisted as `a.template or a.dsn`: a live attachment
+--- record carries the expanded, password-bearing DSN, and writing that here
+--- would put the password on disk through a field nothing else covers. The
+--- template is resolved again on replay by M.switch/expand_dsn. Records with
+--- no template (a literal DSN) round-trip byte-identically, as before.
 function M.save_attachments(url, attachments)
   local file_conns = read_local_connections()
   local found = false
@@ -654,7 +780,7 @@ function M.save_attachments(url, attachments)
       c.attachments = attachments and #attachments > 0 and {} or nil
       if attachments then
         for _, a in ipairs(attachments) do
-          table.insert(c.attachments, { dsn = a.dsn, alias = a.alias })
+          table.insert(c.attachments, { dsn = a.template or a.dsn, alias = a.alias })
         end
       end
       found = true
@@ -912,18 +1038,39 @@ function M.pick(opts)
         close_on_select = true,
         when           = function(c)
           if c._new or c._temp or c._section_header or c._local_file then return false end
-          -- Show on non-DuckDB connections when current connection is DuckDB
+          -- Show on non-DuckDB connections when current connection is DuckDB.
+          -- Both URLs are resolved first: a whole-URL template hides the
+          -- scheme, and without this the action is hidden on a templated
+          -- DuckDB connection even though its fn below handles one.
           local cur = vim.g.db
-          return cur and cur:find("^duckdb:") and not c.url:find("^duckdb:")
+          cur = cur and (M.expand_url(cur) or cur)
+          local target = M.expand_url(c.url) or c.url
+          if not (cur and cur:find("^duckdb:")) or target:find("^duckdb:") then return false end
+          -- Hide it outright for databases DuckDB has no scanner for (SQL
+          -- Server, Oracle, ...) rather than offering an action that can only
+          -- fail. M.attach refuses those too, for the :GripAttach path.
+          local duckdb_adapter = require("dadbod-grip.adapters.duckdb")
+          return duckdb_adapter._unsupported_attach_scheme(duckdb_adapter.url_to_dsn(target)) == nil
         end,
         fn             = function(c)
           if c._new or c._temp or c._section_header or c._local_file then return end
           -- Guard: grip_picker fires fn regardless of `when` predicate label
+          -- url is the active connection as stored (templated: the key on
+          -- disk); conn_url is what the adapter registry is keyed by. One of
+          -- the four paths that bypass db.resolve(), so both the DuckDB URL
+          -- and the target's URL are expanded by hand here.
           local url = vim.g.db
-          if not url or not url:find("^duckdb:") then
+          local conn_url = M.expand_url(url)
+          if not conn_url or not conn_url:find("^duckdb:") then
             vim.notify(
               "Attach requires an active DuckDB connection. Switch to DuckDB with gc first.",
               vim.log.levels.WARN)
+            return
+          end
+          local target_url, target_err = M.expand_url(c.url)
+          if not target_url then
+            vim.notify("Attach failed: " .. (target_err or "unresolved connection secrets"),
+              vim.log.levels.ERROR)
             return
           end
           local default_alias = c.name:lower():gsub("[^%w_]", "_"):gsub("_+", "_"):gsub("^_", ""):gsub("_$", "")
@@ -931,13 +1078,17 @@ function M.pick(opts)
           if not alias then return end
           local duckdb_adapter = require("dadbod-grip.adapters.duckdb")
           local schema_mod = require("dadbod-grip.schema")
-          local dsn = duckdb_adapter.url_to_dsn(c.url)
-          local err = duckdb_adapter.attach(url, dsn, alias)
+          local dsn = duckdb_adapter.url_to_dsn(target_url)
+          -- Persist the connection's own URL template, not the DSN derived
+          -- from it: M.expand_dsn() finds this entry's env_file by that URL,
+          -- and load_attachments() runs url_to_dsn() again on replay.
+          local template = target_url ~= c.url and c.url or nil
+          local err = duckdb_adapter.attach(conn_url, dsn, alias, template)
           if err then
             vim.notify("Attach failed: " .. err, vim.log.levels.ERROR)
             return
           end
-          M.save_attachments(url, duckdb_adapter.get_attachments(url))
+          M.save_attachments(url, duckdb_adapter.get_attachments(conn_url))
           schema_mod.refresh(url)
           vim.notify(string.format("Attached '%s' as %s", c.name, alias), vim.log.levels.INFO)
         end,
@@ -950,11 +1101,25 @@ function M.pick(opts)
         when  = function(c) return not (c._new or c._temp or c._section_header) end,
         fn    = function(c)
           if c._new or c._temp or c._section_header then return end
-          if is_testable_locally(c) then
-            local path = extract_local_path(c.url)
+          -- A templated entry must report *why* it can't be tested, not a
+          -- meaningless "Unsupported database scheme: ${VAR}" from handing
+          -- the literal placeholder to the adapter.
+          local conn_url, secret_err = M.expand_url(c.url)
+          if not conn_url then
+            M.set_health(c.url, "unresolved")
+            vim.notify("Grip: " .. (secret_err or "could not resolve connection secrets"),
+              vim.log.levels.ERROR)
+            return
+          end
+          -- Scheme detection (is_testable_locally) needs the resolved URL for
+          -- a whole-URL template, same reasoning as a:attach above.
+          local test_target = conn_url == c.url and c
+            or vim.tbl_extend("force", {}, c, { url = conn_url })
+          if is_testable_locally(test_target) then
+            local path = extract_local_path(conn_url)
             M.set_health(c.url, vim.fn.filereadable(path) == 1 and "ok" or "fail")
           else
-            local ok = require("dadbod-grip.db").ping(c.url)
+            local ok = require("dadbod-grip.db").ping(conn_url)
             M.set_health(c.url, ok and "ok" or "fail")
           end
         end,
@@ -982,11 +1147,16 @@ function M.pick(opts)
               return
             end
           end
-          table.insert(global_conns, { name = c.name, url = c.url })
+          local promoted = { name = c.name, url = c.url, type = c.type,
+                              env_file = c.env_file, mode = c.mode, color = c.color }
+          table.insert(global_conns, promoted)
           local gdata = {}
           for _, gc in ipairs(global_conns) do
             local entry = { name = gc.name, url = gc.url }
             if gc.type then entry.type = gc.type end
+            if gc.env_file then entry.env_file = gc.env_file end
+            if gc.mode then entry.mode = gc.mode end
+            if gc.color then entry.color = gc.color end
             table.insert(gdata, entry)
           end
           vim.fn.writefile({ vim.fn.json_encode(gdata) }, global_path)

--- a/lua/dadbod-grip/connections.lua
+++ b/lua/dadbod-grip/connections.lua
@@ -16,6 +16,18 @@ local M = {}
 -- a meaningless report.
 local _health = {}
 
+-- Session-scoped read/write mode overrides, keyed by connection URL as stored
+-- (the template -- the same key entries live under on disk). Set only by
+-- M.switch(url, ..., { mode = ... }), which the picker's r:ro/rw action uses
+-- to connect once in the mode opposite to the entry's default.
+--
+-- Deliberately never written to connections.json: the entry's own `mode` is
+-- the user's standing decision about that database, and a keypress in a
+-- picker is not a request to rewrite their file. Every ordinary switch of a
+-- connection clears its override again, so the override lasts exactly from
+-- one connect to the next.
+local _mode_override = {}
+
 local function health_char(url)
   local s = _health[url] or "unknown"
   if s == "ok"         then return "*" end
@@ -239,6 +251,63 @@ function M.entry_for(url)
     if c.url == url then return c end
   end
   return nil
+end
+
+--- The read/write mode of a connection: "ro" or "rw", never nil.
+---
+--- "ro" only when the saved entry explicitly says `"mode": "ro"`. No entry
+--- (an ad-hoc URL, a g:dbs entry), no `mode` field, or any other value all
+--- mean "rw", so every connections.json written before this option existed
+--- keeps behaving exactly as it did.
+---
+--- Called with no argument -- the adapters and the mode badge do -- it asks
+--- about the connection currently in vim.b.db / vim.g.db, via the same
+--- precedence db.get_url() uses. That is deliberately the *template* URL:
+--- entries are keyed by the template on disk, so looking up an expanded
+--- "${VAR}" URL would find nothing and silently downgrade a ro connection to
+--- rw. Callers that already hold a stored URL (db.is_readonly) pass it in.
+--- A session override set by the picker's r:ro/rw action wins over the stored
+--- field, for that connection only and only until it is switched to again.
+--- @param url string|nil  a stored (templated) URL; defaults to the current connection
+--- @return string  "ro" or "rw"
+function M.current_mode(url)
+  -- Lazy require: db.lua reaches back into this module for expand_url.
+  local conn = require("dadbod-grip.db").get_url(url)
+  local override = conn and _mode_override[conn]
+  if override then return override end
+  local entry = M.entry_for(conn)
+  return (entry and entry.mode == "ro") and "ro" or "rw"
+end
+
+--- Refuse a schema-modifying action on a connection saved with "mode": "ro".
+--- Returns true when the caller must stop.
+---
+--- This is the layer that refuses *before* the prompt: every DDL path in the
+--- plugin opens an interactive form or a typed confirmation first, and walking
+--- a user through one only to have it fail at the end is a worse answer than
+--- declining up front.
+---
+--- It is a guard, not a boundary, and the difference matters. The adapters do
+--- put the CLI session itself in read-only mode, which usually means the
+--- server would refuse the statement even if this returned false -- but not
+--- always: a postgres URL that already carries its own `options=` overrides
+--- PGOPTIONS (see psql_env), and sqlite/duckdb pointed at a not-yet-existing
+--- file get no `-readonly` at all, by design. Treat this as the thing that
+--- keeps a read-only connection honest in ordinary use, not as something a
+--- caller may rely on to make a write impossible.
+---
+--- Lives here rather than in init.lua because the DDL entry points are spread
+--- across the command layer, the schema sidebar, the properties float and the
+--- grid's inspect keymaps; one wording for all of them is the point.
+---
+--- The message names the mode and never the URL -- it can carry a password.
+--- @param label string  the command or action name to prefix the message with
+--- @param url string|nil  defaults to the current connection
+--- @return boolean
+function M.deny_if_readonly(label, url)
+  if M.current_mode(url) ~= "ro" then return false end
+  vim.notify(label .. ": Connection is read-only (mode = ro)", vim.log.levels.WARN)
+  return true
 end
 
 --- Resolve the ${VAR} placeholders in a connection URL against the env_file
@@ -569,7 +638,9 @@ end
 --- Switch active connection. Routes file connections through grip.open(),
 --- DB connections through vim.g.db + workspace open.
 --- Auto-saves to .grip/connections.json if not already persisted.
---- opts: { write = bool, watch_ms = number }: session-only, never persisted.
+--- opts: { write = bool, watch_ms = number, mode = "ro"|"rw" }: session-only,
+--- never persisted.
+--- @return boolean committed  false when the switch aborted and nothing changed
 function M.switch(url, name, conn_type, opts)
   -- Strip session-only flags: they must never reach the connection registry
   url = strip_flags(url)
@@ -584,7 +655,7 @@ function M.switch(url, name, conn_type, opts)
   if not conn_url then
     vim.notify("Grip: " .. (secret_err or "could not resolve connection secrets"),
       vim.log.levels.ERROR)
-    return
+    return false
   end
 
   -- Single read of the local file; everything below (type resolution,
@@ -633,6 +704,34 @@ function M.switch(url, name, conn_type, opts)
     write_file_connections(local_conns)
   end
 
+  -- The one place a mode override is set or cleared. Connecting the ordinary
+  -- way always returns a connection to the mode its entry asks for, so an
+  -- override taken by mistake is undone by reconnecting rather than by
+  -- editing connections.json.
+  --
+  -- Below the expansion check above, deliberately: a switch that aborted did
+  -- not happen, and must leave the mode of that URL exactly as it found it.
+  -- Set any earlier and an `r` on an entry whose ${VAR} does not resolve
+  -- would flip a read-only connection the user is still on to writable, with
+  -- only a "could not resolve secrets" message to go on.
+  _mode_override[url] = nil
+  if opts and (opts.mode == "ro" or opts.mode == "rw") then
+    _mode_override[url] = opts.mode
+  end
+
+  -- Re-tint the accent groups for the connection being switched to. Read
+  -- after the write above so a just-added entry is found, and passed
+  -- unconditionally: an entry with no `color` (or no entry at all) has to
+  -- restore the default look, not inherit the previous connection's.
+  local view = require("dadbod-grip.view")
+  local switched_entry = M.entry_for(url)
+  view.set_connection_accent(switched_entry and switched_entry.color)
+  -- A switch changes what current_mode() answers, so every grid still open
+  -- has to ask again. Their badges are cached per session precisely because
+  -- the winbar is rebuilt on every cursor move; a switch is the one other
+  -- moment the cached answer can be wrong.
+  view.invalidate_mode_cache()
+
   if resolved_type == "file" then
     vim.notify("Grip: opening " .. (name or url), vim.log.levels.INFO)
     M.set_health(url, "ok")
@@ -662,7 +761,7 @@ function M.switch(url, name, conn_type, opts)
         require("dadbod-grip.query_pad").open(db_url)
       end)
     end)
-    return
+    return true
   end
 
   -- Regular DB connection: set vim.g.db and open full workspace
@@ -741,6 +840,7 @@ function M.switch(url, name, conn_type, opts)
     end)
 
   end)
+  return true
 end
 
 --- Get current connection info.
@@ -793,6 +893,26 @@ function M.save_attachments(url, attachments)
 end
 
 --- Prompt user to enter a new connection URL + name, then switch to it.
+--- True when the picker's `r` (ro/rw) action applies to this row.
+---
+--- Shared by the action's `when` and its `fn`: grip_picker fires `fn`
+--- regardless of `when`, so both need the same answer, and a second
+--- hand-written copy of these conditions is how the two drift apart.
+--- @param c table picker item
+--- @return boolean
+local function ro_toggle_applies(c)
+  if c._new or c._temp or c._section_header or c._local_file then return false end
+  -- A file connection has no server session to put in read-only mode;
+  -- !:write is the flag that matters there.
+  if c.type == "file" or (not c.type and is_file_url(c.url)) then return false end
+  -- SQL Server is read-only at the adapter (adapters/sqlserver.lua:9), so
+  -- offering to toggle its mode would promise a write path that does not
+  -- exist. Resolved first: a whole-URL template hides the scheme, and an
+  -- unresolvable one falls back to the template, which simply does not match.
+  local target = M.expand_url(c.url) or c.url
+  return not target:find("^sqlserver:")
+end
+
 local function prompt_new_connection()
   local url = ui.input({ prompt = "Connection URL, file path, or s3://: " })
   if not url then
@@ -859,6 +979,11 @@ function M.pick(opts)
   local new_sentinel  = { name = "+ New connection...",          url = "", _new  = true }
   local temp_sentinel = { name = "~ Connect once (no save)...", url = "", _temp = true }
 
+  -- Does any listed entry default to read-only? Set by build_picker_items and
+  -- read by display: the RO column only exists when something is in it, so a
+  -- picker with no ro entry renders byte-identically to how it always has.
+  local any_ro = false
+
   -- Build the full item list with scope sections.
   -- When at least one global connection exists and connections_path is not set,
   -- connections are grouped under "global" and "project" section headers so the
@@ -913,6 +1038,10 @@ function M.pick(opts)
     end
     table.insert(out, new_sentinel)
     table.insert(out, temp_sentinel)
+    any_ro = false
+    for _, c in ipairs(out) do
+      if c.mode == "ro" then any_ro = true; break end
+    end
     return out
   end
 
@@ -939,7 +1068,17 @@ function M.pick(opts)
       local dot = health_char(c.url)
       local pad = string.rep(" ", max_name - vim.fn.strdisplaywidth(c.name))
       local url_display = show_pass[c.url] and c.url or short_url(c.url)
-      return dot .. " " .. c.name .. pad .. "  " .. url_display
+      -- The entry's stored default, not what r:ro/rw may have overridden for
+      -- this session: this row answers "how does this connection open", and
+      -- the winbar answers "how is it open right now".
+      --
+      -- Its own column, ahead of the URL, because it is a property of the
+      -- entry like the health dot -- and because grip_picker truncates a row
+      -- that overruns the float, which ate the marker outright when it
+      -- trailed the URL: long production names and long hosts are exactly the
+      -- rows most likely to be read-only, and M:mask lengthens them further.
+      local ro = any_ro and (c.mode == "ro" and "RO " or "   ") or ""
+      return dot .. " " .. c.name .. pad .. "  " .. ro .. url_display
     end,
     on_select = function(c)
       if c._section_header then return end
@@ -1161,6 +1300,34 @@ function M.pick(opts)
           end
           vim.fn.writefile({ vim.fn.json_encode(gdata) }, global_path)
           vim.notify("'" .. c.name .. "' saved to ~/.grip/connections.json", vim.log.levels.INFO)
+        end,
+      },
+      {
+        -- r: connect in the mode opposite to the entry's default -- a ro entry
+        -- opened writable for one fix, a rw entry opened read-only before
+        -- poking at production. Session-only: nothing is written to
+        -- connections.json, and selecting the connection normally afterwards
+        -- puts it back on its own mode (see _mode_override).
+        key            = "r",
+        label          = "r:ro/rw",
+        close_on_select = true,
+        when           = function(c)
+          return ro_toggle_applies(c)
+        end,
+        fn             = function(c)
+          -- grip_picker fires fn regardless of the `when` predicate (see the
+          -- same guard on a:attach), so this is the check that actually
+          -- prevents an override being set on an entry the action was hidden
+          -- for -- not a restatement of the line above.
+          if not ro_toggle_applies(c) then return end
+          local mode = c.mode == "ro" and "rw" or "ro"
+          -- Only claim the override on a switch that committed: one that
+          -- aborted (unresolvable ${VAR}) leaves the connection exactly as it
+          -- was, and has already said why.
+          if M.switch(c.url, c.name, c.type, { mode = mode }) then
+            vim.notify("Grip: connected " .. (mode == "ro" and "read-only" or "writable")
+              .. " for this session (mode = " .. mode .. ")", vim.log.levels.INFO)
+          end
         end,
       },
       {

--- a/lua/dadbod-grip/data.lua
+++ b/lua/dadbod-grip/data.lua
@@ -82,11 +82,16 @@ local function edit_copy(state)
 end
 
 -- M.new(query_result) → State
--- query_result = { rows, columns, primary_keys, table_name, url, sql }
+-- query_result = { rows, columns, primary_keys, table_name, url, sql, readonly }
+-- query_result.readonly is the caller saying so outright (a read-only adapter,
+-- a connection saved with "mode": "ro"). Those callers also hand over an empty
+-- primary_keys, which already produced a read-only state on its own -- this
+-- makes the reason explicit instead of leaving it to be inferred from the
+-- absence of a key, so a future PK-less-but-editable grid cannot undo it.
 function M.new(query_result)
   local pks = query_result.primary_keys or {}
   local table_name = query_result.table_name
-  local readonly = (#pks == 0) or (table_name == nil)
+  local readonly = (#pks == 0) or (table_name == nil) or query_result.readonly == true
   return {
     rows = deep_copy(query_result.rows or {}),
     columns = deep_copy(query_result.columns or {}),

--- a/lua/dadbod-grip/db.lua
+++ b/lua/dadbod-grip/db.lua
@@ -3,6 +3,7 @@
 -- All functions return (result, err). Never throw.
 
 local adapters = require("dadbod-grip.adapters")
+local secrets = require("dadbod-grip.secrets")
 local esc = require("dadbod-grip.sql").escape_literal
 
 local M = {}
@@ -17,6 +18,24 @@ function M.get_url(url)
   local global_url = vim.g.db
   if type(global_url) == "string" and global_url ~= "" then return global_url end
   return nil, "No database connection. Use :GripConnect or set vim.g.db."
+end
+
+--- The connectable form of a URL, for callers that need its *scheme* rather
+--- than a connection: adapters.kind() / display_name() dispatch on the
+--- scheme, and a whole-URL template ("${DATABASE_URL}") has none to dispatch
+--- on. Getting nil back there is not cosmetic -- it silently drops CASCADE
+--- from generated DDL, discards FK dependents, degrades Query Doctor, and
+--- feeds the wrong dialect to the LLM.
+---
+--- Best-effort by design: an unresolvable template comes back unchanged, so
+--- those callers degrade to exactly what they did before this feature instead
+--- of erroring. Anything that actually opens a connection must go through the
+--- db.* API, where resolve() surfaces the expansion error.
+--- @param url string|nil
+--- @return string|nil
+function M.resolved_url(url)
+  if type(url) ~= "string" or not secrets.has_template(url) then return url end
+  return (require("dadbod-grip.connections").expand_url(url)) or url
 end
 
 --- Group flat referencing-FK rows into one entry per constraint.
@@ -212,9 +231,32 @@ end
 
 -- ── resolve adapter from URL ──────────────────────────────────────────────
 
+--- Pick the adapter for a URL and turn that URL into a connectable one.
+---
+--- Every public db.* function funnels through here, which makes this the one
+--- and only place where a "${VAR}" template becomes a real URL carrying a
+--- real password. vim.g.db, vim.b.db, .grip/connections.json and the query
+--- history all keep the template, so no write path anywhere in the plugin is
+--- ever handed a secret it could spill -- not because each of them scrubs,
+--- but because none of them ever holds one. Keep it that way: expanding
+--- further out (in M.get_url, in connections.switch, in a caller) puts the
+--- password back into everything downstream of it.
+---
+--- The has_template() check comes first so a literal URL -- the overwhelming
+--- majority -- does not even load connections.lua, let alone read a file.
+--- @return table|nil adapter
+--- @return string|nil conn  the expanded URL to hand the adapter
+--- @return string|nil err
 local function resolve(url)
   local conn, conn_err = M.get_url(url)
   if not conn then return nil, nil, conn_err end
+  if secrets.has_template(conn) then
+    -- Lazy require: connections.lua pulls in the UI stack, and db.lua is
+    -- loaded by every adapter.
+    local expanded, exp_err = require("dadbod-grip.connections").expand_url(conn)
+    if not expanded then return nil, nil, exp_err end
+    conn = expanded
+  end
   local adapter, adapt_err = adapters.resolve(conn)
   if not adapter then return nil, nil, adapt_err end
   return adapter, conn, nil

--- a/lua/dadbod-grip/db.lua
+++ b/lua/dadbod-grip/db.lua
@@ -262,30 +262,75 @@ local function resolve(url)
   return adapter, conn, nil
 end
 
+--- Publish `url`'s read/write mode to the adapter layer, run the adapter
+--- call, and unpublish it again.
+---
+--- This is the only correct place for that decision. The mode lives on the
+--- connection *entry*, which is keyed by the template URL; resolve() above
+--- hands the adapter the *expanded* one, from which the entry can no longer
+--- be found. Reading vim.g.db down in the adapter instead is what this
+--- replaces, and it was wrong in both directions: a query against an
+--- explicitly passed ro URL spawned without the read-only flag whenever the
+--- ambient connection was a different one, and -- worse -- an unrelated rw
+--- connection was spawned read-only whenever the ambient one happened to be
+--- ro. Both are ordinary sequences: :GripConnect with a grid or sidebar still
+--- open, whose closures captured the URL they were opened with.
+---
+--- `url` is passed through exactly as the caller gave it, nil included:
+--- current_mode falls back to vim.b.db/vim.g.db through the same get_url()
+--- resolve() uses, so the two always agree on which connection this is.
+---
+--- Restores the previous value rather than clearing to nil, and does so on the
+--- error path too. Both halves are load-bearing:
+---
+---   * Nesting is real. run_cmd blocks in vim.wait, which pumps the main loop,
+---     so a scheduled db.* call (init.lua's column-info auto-fetch, view.lua's
+---     on_refresh) runs *inside* an adapter call that is between two spawns.
+---     Clearing to nil on the way out of the inner one left every later spawn
+---     of the outer one falling back to the ambient connection -- the same
+---     defect this function exists to fix, just harder to see.
+---   * "Adapters return (result, err)" is a statement about their return
+---     convention, not a promise that no Lua error is ever raised inside one;
+---     init.lua:2329 pcalls a db_mod call for exactly that reason. Without the
+---     pcall here a throw would strand the published value, and with a bare
+---     save/restore it would strand the *inner* frame's value, which is worse.
+---     So the restore runs either way and the error is re-raised unchanged --
+---     error(err, 0) adds no position of its own, so nothing is hidden.
+---
+--- Two values because that is the adapters' whole contract.
+local function via_adapter(url, fn, ...)
+  local previous = adapters.set_call_readonly(
+    require("dadbod-grip.connections").current_mode(url) == "ro")
+  local ok, result, err = pcall(fn, ...)
+  adapters.set_call_readonly(previous)
+  if not ok then error(result, 0) end
+  return result, err
+end
+
 -- ── public interface (unchanged signatures) ───────────────────────────────
 
 function M.query(sql, url)
   local adapter, conn, err = resolve(url)
   if not adapter then return nil, err end
-  return adapter.query(sql, conn)
+  return via_adapter(url, adapter.query, sql, conn)
 end
 
 function M.get_primary_keys(table_name, url)
   local adapter, conn, err = resolve(url)
   if not adapter then return {}, err end
-  return adapter.get_primary_keys(table_name, conn)
+  return via_adapter(url, adapter.get_primary_keys, table_name, conn)
 end
 
 function M.get_column_info(table_name, url)
   local adapter, conn, err = resolve(url)
   if not adapter then return nil, err end
-  return adapter.get_column_info(table_name, conn)
+  return via_adapter(url, adapter.get_column_info, table_name, conn)
 end
 
 function M.execute(sql, url)
   local adapter, conn, err = resolve(url)
   if not adapter then return nil, err end
-  return adapter.execute(sql, conn)
+  return via_adapter(url, adapter.execute, sql, conn)
 end
 
 --- Ping a connection. Returns true on success, false on any error.
@@ -293,7 +338,7 @@ end
 function M.ping(url)
   local adapter, conn = resolve(url)
   if not adapter then return false end
-  if adapter.ping then return adapter.ping(conn) end
+  if adapter.ping then return via_adapter(url, adapter.ping, conn) end
   return false
 end
 
@@ -301,14 +346,14 @@ function M.get_foreign_keys(table_name, url)
   local adapter, conn, err = resolve(url)
   if not adapter then return {}, err end
   if not adapter.get_foreign_keys then return {}, "Adapter does not support FK lookup" end
-  return adapter.get_foreign_keys(table_name, conn)
+  return via_adapter(url, adapter.get_foreign_keys, table_name, conn)
 end
 
 function M.list_tables(url)
   local adapter, conn, err = resolve(url)
   if not adapter then return nil, err end
   if not adapter.list_tables then return nil, "Adapter does not support list_tables" end
-  return adapter.list_tables(conn)
+  return via_adapter(url, adapter.list_tables, conn)
 end
 
 --- Reverse FK lookup: which tables have FKs pointing at table_name?
@@ -321,29 +366,33 @@ function M.get_referencing_foreign_keys(table_name, url)
   local adapter, conn, err = resolve(url)
   if not adapter then return {}, err end
   if adapter.get_referencing_foreign_keys then
-    return adapter.get_referencing_foreign_keys(table_name, conn)
+    return via_adapter(url, adapter.get_referencing_foreign_keys, table_name, conn)
   end
   if not (adapter.list_tables and adapter.get_foreign_keys) then
     return {}, "Adapter does not support FK lookup"
   end
-  local tables, terr = adapter.list_tables(conn)
-  if not tables then return {}, terr end
-  local bare_target = table_name:match("([^.]+)$")
-  local refs = {}
-  for _, t in ipairs(tables) do
-    if t.type ~= "view" then
-      local fks = adapter.get_foreign_keys(t.name, conn)
-      for _, fk in ipairs(fks or {}) do
-        local bare_ref = (fk.ref_table or ""):match("([^.]+)$")
-        if fk.ref_table == table_name or bare_ref == bare_target then
-          table.insert(refs, {
-            table = t.name, column = fk.column, ref_column = fk.ref_column,
-          })
+  -- The fallback spawns the CLI once per table, so the whole scan goes inside
+  -- one via_adapter rather than each call getting its own.
+  return via_adapter(url, function()
+    local tables, terr = adapter.list_tables(conn)
+    if not tables then return {}, terr end
+    local bare_target = table_name:match("([^.]+)$")
+    local refs = {}
+    for _, t in ipairs(tables) do
+      if t.type ~= "view" then
+        local fks = adapter.get_foreign_keys(t.name, conn)
+        for _, fk in ipairs(fks or {}) do
+          local bare_ref = (fk.ref_table or ""):match("([^.]+)$")
+          if fk.ref_table == table_name or bare_ref == bare_target then
+            table.insert(refs, {
+              table = t.name, column = fk.column, ref_column = fk.ref_column,
+            })
+          end
         end
       end
     end
-  end
-  return refs, nil
+    return refs, nil
+  end)
 end
 
 --- Fetch all table columns in a single batch query (adapter-specific optimisation).
@@ -353,7 +402,7 @@ function M.get_schema_batch(url)
   local adapter, conn = resolve(url)
   if not adapter then return nil end
   if not adapter.get_schema_batch then return nil end
-  return adapter.get_schema_batch(conn)
+  return via_adapter(url, adapter.get_schema_batch, conn)
 end
 
 --- Async variant of get_schema_batch. Calls callback(tables) when done, or callback(nil) on error.
@@ -361,41 +410,48 @@ end
 function M.get_schema_batch_async(url, callback)
   local adapter, conn = resolve(url)
   if not adapter or not adapter.get_schema_batch_async then callback(nil); return end
-  adapter.get_schema_batch_async(conn, callback)
+  via_adapter(url, adapter.get_schema_batch_async, conn, callback)
 end
 
 function M.get_indexes(table_name, url)
   local adapter, conn, err = resolve(url)
   if not adapter then return {}, err end
   if not adapter.get_indexes then return {}, "Adapter does not support get_indexes" end
-  return adapter.get_indexes(table_name, conn)
+  return via_adapter(url, adapter.get_indexes, table_name, conn)
 end
 
 function M.get_table_stats(table_name, url)
   local adapter, conn, err = resolve(url)
   if not adapter then return nil, err end
   if not adapter.get_table_stats then return nil, "Adapter does not support get_table_stats" end
-  return adapter.get_table_stats(table_name, conn)
+  return via_adapter(url, adapter.get_table_stats, table_name, conn)
 end
 
 function M.explain(sql_str, url)
   local adapter, conn, err = resolve(url)
   if not adapter then return nil, err end
   if not adapter.explain then return nil, "Adapter does not support EXPLAIN" end
-  return adapter.explain(sql_str, conn)
+  return via_adapter(url, adapter.explain, sql_str, conn)
 end
 
 function M.get_constraints(table_name, url)
   local adapter, conn, err = resolve(url)
   if not adapter then return {}, err end
   if not adapter.get_constraints then return {}, "Adapter does not support get_constraints" end
-  return adapter.get_constraints(table_name, conn)
+  return via_adapter(url, adapter.get_constraints, table_name, conn)
 end
 
---- Returns true when an adapter intentionally exposes read-only grids.
+--- Returns true when the grid must not be editable: either the adapter
+--- intentionally exposes read-only grids (sqlserver), or the connection is
+--- saved with `"mode": "ro"`.
+---
+--- `url` is passed through as given -- the stored, possibly templated form --
+--- because that is the key connection entries live under; see
+--- connections.current_mode.
 function M.is_readonly(url)
   local adapter = resolve(url)
-  return adapter and adapter.readonly == true or false
+  if adapter and adapter.readonly == true then return true end
+  return require("dadbod-grip.connections").current_mode(url) == "ro"
 end
 
 --- List database routines for schema browsers.
@@ -404,7 +460,7 @@ function M.list_routines(url)
   local adapter, conn, err = resolve(url)
   if not adapter then return {}, err end
   if not adapter.list_routines then return {}, nil end
-  return adapter.list_routines(conn)
+  return via_adapter(url, adapter.list_routines, conn)
 end
 
 --- Fetch a routine's source/definition text. Unsupported adapters return an error.
@@ -412,7 +468,7 @@ function M.get_routine_source(routine_name, url)
   local adapter, conn, err = resolve(url)
   if not adapter then return nil, err end
   if not adapter.get_routine_source then return nil, "Adapter does not support routine source" end
-  return adapter.get_routine_source(routine_name, conn)
+  return via_adapter(url, adapter.get_routine_source, routine_name, conn)
 end
 
 --- Describe the columns of a local/remote file via DuckDB DESCRIBE.

--- a/lua/dadbod-grip/ddl.lua
+++ b/lua/dadbod-grip/ddl.lua
@@ -322,7 +322,12 @@ local function build_drop_sql(table_name, kind, has_referencing)
 end
 
 function M.drop_table(table_name, url, on_done)
-  local kind = adapters.kind(url)
+  -- Dialect decisions need the real scheme, so a "${DATABASE_URL}" template
+  -- has to be resolved first: a nil kind would silently drop CASCADE from the
+  -- generated SQL, discard every schema-qualified FK dependent below, and
+  -- print "This adapter doesn't support CASCADE" about PostgreSQL.
+  local dialect_url = db.resolved_url(url)
+  local kind = adapters.kind(dialect_url)
 
   -- Check for FK dependents: one query instead of a get_foreign_keys() spawn
   -- per other table in the schema (see filter_referencing above for the two
@@ -337,7 +342,7 @@ function M.drop_table(table_name, url, on_done)
   -- server error (or, on MySQL, a silently ignored keyword) after the fact.
   local note
   if has_referencing and not CASCADE_KINDS[kind] then
-    local name = adapters.display_name(url) or "This adapter"
+    local name = adapters.display_name(dialect_url) or "This adapter"
     note = name .. " doesn't support CASCADE: dependent foreign keys won't be"
       .. " dropped, so this may fail or leave dangling references."
   end

--- a/lua/dadbod-grip/explain.lua
+++ b/lua/dadbod-grip/explain.lua
@@ -7,8 +7,12 @@
 local M = {}
 
 --- Detect adapter type from connection URL.
+--- Resolves a "${VAR}" template first: parse_nodes gates every extraction on
+--- this value, so an unresolved template would silently return a plan with no
+--- cost, rows or time.
 function M.detect_adapter(url)
-  return require("dadbod-grip.adapters").kind(url) or "unknown"
+  local resolved = require("dadbod-grip.db").resolved_url(url)
+  return require("dadbod-grip.adapters").kind(resolved) or "unknown"
 end
 
 --- Parse EXPLAIN output into structured nodes.

--- a/lua/dadbod-grip/history.lua
+++ b/lua/dadbod-grip/history.lua
@@ -2,6 +2,7 @@
 -- Stores in .grip/history.jsonl. Picker uses grip_picker (zero external deps).
 
 local paths = require("dadbod-grip.paths")
+local sql_util = require("dadbod-grip.sql")
 
 local M = {}
 
@@ -23,9 +24,10 @@ local function ensure_dir()
 end
 
 --- Redact password from connection URL. Mockable via M._redact_url.
+--- Delegates to sql.redact_url, the single copy of this pattern shared with
+--- the adapters' error messages.
 function M._redact_url(url)
-  if not url then return "" end
-  return url:gsub("://([^:]+):[^@]+@", "://%1:***@")
+  return sql_util.redact_url(url)
 end
 
 --- Read all history entries from disk. Mockable via M._read_all.

--- a/lua/dadbod-grip/init.lua
+++ b/lua/dadbod-grip/init.lua
@@ -933,8 +933,12 @@ function M.open(arg, url, opts)
   -- File-as-table: use the active DuckDB connection so ATTACHed databases
   -- remain accessible. Fall back to duckdb::memory: when no DuckDB session exists.
   if file_path then
+    -- The scheme test needs the resolved URL (a whole-URL template hides it),
+    -- but `conn` stays the template: everything downstream of here expands via
+    -- db.resolve(), and history/view must not record the expansion.
     local active = vim.g.db
-    conn = (active and active:match("^duckdb:")) and active or "duckdb::memory:"
+    local resolved = db.resolved_url(active)
+    conn = (resolved and resolved:match("^duckdb:")) and active or "duckdb::memory:"
   end
 
   if not conn or conn == "" then
@@ -2015,8 +2019,13 @@ function M.setup(opts)
     local duckdb_adapter = require("dadbod-grip.adapters.duckdb")
     local schema_mod = require("dadbod-grip.schema")
 
+    -- url is the active connection as stored (templated: the key its entry
+    -- lives under in connections.json); conn_url is the expanded form the
+    -- adapter's attachment registry is keyed by. This command bypasses
+    -- db.resolve(), so it expands by hand.
     local url = vim.g.db
-    if not url or not url:find("^duckdb:") then
+    local conn_url = connections.expand_url(url)
+    if not conn_url or not conn_url:find("^duckdb:") then
       vim.notify("GripAttach: requires a DuckDB connection. Use :GripConnect to switch.", vim.log.levels.WARN)
       return
     end
@@ -2035,12 +2044,19 @@ function M.setup(opts)
       alias = a
     end
 
-    local err = duckdb_adapter.attach(url, dsn, alias)
+    -- A hand-typed DSN may reference ${VAR} too; resolve it against the
+    -- active connection's env_file and keep the placeholder for persistence.
+    local live_dsn, dsn_err = connections.expand_dsn(dsn, url)
+    if not live_dsn then
+      vim.notify("GripAttach: " .. (dsn_err or "unresolved secrets in DSN"), vim.log.levels.ERROR)
+      return
+    end
+    local err = duckdb_adapter.attach(conn_url, live_dsn, alias, live_dsn ~= dsn and dsn or nil)
     if err then
       vim.notify("GripAttach: " .. err, vim.log.levels.ERROR)
       return
     end
-    connections.save_attachments(url, duckdb_adapter.get_attachments(url))
+    connections.save_attachments(url, duckdb_adapter.get_attachments(conn_url))
     require("dadbod-grip.completion").invalidate(url)
     schema_mod.refresh(url)
     -- Pre-warm completion cache after manual attach (M.attach no longer does this).
@@ -2059,15 +2075,17 @@ function M.setup(opts)
     local duckdb_adapter = require("dadbod-grip.adapters.duckdb")
     local schema_mod = require("dadbod-grip.schema")
 
+    -- Same template/expanded split as :GripAttach above.
     local url = vim.g.db
-    if not url or not url:find("^duckdb:") then
+    local conn_url = connections.expand_url(url)
+    if not conn_url or not conn_url:find("^duckdb:") then
       vim.notify("GripDetach: requires a DuckDB connection.", vim.log.levels.WARN)
       return
     end
 
     local alias = vim.trim(cmd_opts.args or "")
     if alias == "" then
-      local atts = duckdb_adapter.get_attachments(url)
+      local atts = duckdb_adapter.get_attachments(conn_url)
       if #atts == 0 then
         vim.notify("GripDetach: no databases attached.", vim.log.levels.INFO)
         return
@@ -2079,8 +2097,8 @@ function M.setup(opts)
       alias = val
     end
 
-    duckdb_adapter.detach(url, alias)
-    connections.save_attachments(url, duckdb_adapter.get_attachments(url))
+    duckdb_adapter.detach(conn_url, alias)
+    connections.save_attachments(url, duckdb_adapter.get_attachments(conn_url))
     require("dadbod-grip.completion").invalidate(url)
     schema_mod.refresh(url)
     vim.notify(string.format("Detached '%s'", alias), vim.log.levels.INFO)
@@ -2285,8 +2303,10 @@ function M.do_fill_rows(n)
   local ddl     = ai_mod._format_ddl_line(tbl, cols or {}, pks or {}, fks)
 
   -- Detect adapter for value-format hints. SQLite stays the fallback for
-  -- URLs no adapter claims (its value syntax is the most permissive).
-  local adapter = require("dadbod-grip.adapters").display_name(db_url) or "SQLite"
+  -- URLs no adapter claims (its value syntax is the most permissive) -- which
+  -- is why a "${VAR}" template is resolved first: the generated rows are
+  -- executed, so falling back to the wrong dialect is not a cosmetic miss.
+  local adapter = require("dadbod-grip.adapters").display_name(db_mod.resolved_url(db_url)) or "SQLite"
 
   ui.blocking("Generating " .. n .. " row(s)...", function()
     local done = false

--- a/lua/dadbod-grip/init.lua
+++ b/lua/dadbod-grip/init.lua
@@ -113,6 +113,13 @@ local function resolve_target(cmd_opts, cmd_name, no_table_msg)
   return table_name, url
 end
 
+--- Shorthand for the shared read-only guard; see connections.deny_if_readonly.
+--- @param cmd_name string
+--- @param url string|nil  defaults to the current connection
+local function deny_if_readonly(cmd_name, url)
+  return require("dadbod-grip.connections").deny_if_readonly(cmd_name, url)
+end
+
 -- Decide the query spec for a given :Grip argument.
 -- Returns (spec, table_name, file_path) or (nil, err_string).
 local function resolve_query(arg, page_size)
@@ -488,7 +495,8 @@ local function do_refresh(bufnr, url, query_sql, table_name)
   end
 
   -- Re-fetch primary keys
-  if table_name and not db.is_readonly(url) then
+  result.readonly = db.is_readonly(url)
+  if table_name and not result.readonly then
     local pks, pk_err = db.get_primary_keys(table_name, url)
     result.primary_keys = (pk_err == nil) and pks or {}
   else
@@ -751,7 +759,8 @@ function M._mutation_preview(mutation_sql, url, stmt_type, caller_opts)
   end
 
   -- Fetch PKs
-  local pks = db.is_readonly(url) and {} or (db.get_primary_keys(table_name, url) or {})
+  result.readonly = db.is_readonly(url)
+  local pks = result.readonly and {} or (db.get_primary_keys(table_name, url) or {})
   result.primary_keys = pks
   result.table_name = table_name
   result.url = url
@@ -975,7 +984,8 @@ function M.open(arg, url, opts)
   end
 
   -- Fetch primary keys if we have a table name
-  if table_name_arg and not db.is_readonly(conn) then
+  result.readonly = db.is_readonly(conn)
+  if table_name_arg and not result.readonly then
     local pks, _ = db.get_primary_keys(table_name_arg, conn)
     result.primary_keys = pks or {}
   else
@@ -1902,6 +1912,7 @@ function M.setup(opts)
 
   -- Register :GripCreate command
   vim.api.nvim_create_user_command("GripCreate", function()
+    if deny_if_readonly("GripCreate") then return end
     local url = db.get_url()
     if not url then
       vim.notify("GripCreate: no database connection. Use :GripConnect.", vim.log.levels.WARN)
@@ -1922,6 +1933,7 @@ function M.setup(opts)
 
   -- Register :GripDrop command
   vim.api.nvim_create_user_command("GripDrop", function(cmd_opts)
+    if deny_if_readonly("GripDrop") then return end
     local table_name, url = resolve_target(cmd_opts, "GripDrop", "provide a table name")
     if not table_name then return end
     local ddl_mod = require("dadbod-grip.ddl")
@@ -1952,6 +1964,11 @@ function M.setup(opts)
       vim.notify("GripRename: no database connection", vim.log.levels.WARN)
       return
     end
+    -- Guarded on the URL the ALTER below actually runs against, not on the
+    -- ambient one: this command is the only one whose action reads
+    -- session.url, and guarding the ambient connection instead let a rename
+    -- through against a ro connection whenever the two had drifted apart.
+    if deny_if_readonly("GripRename", url) then return end
 
     local ddl_mod = require("dadbod-grip.ddl")
     if #args >= 2 then
@@ -2242,6 +2259,13 @@ function M.setup(opts)
 
   -- :GripFill [N]: stage N AI-generated realistic rows (default 1, max 50)
   vim.api.nvim_create_user_command("GripFill", function(cmd_opts)
+    -- do_fill_rows works on the session's connection, so guard on that one and
+    -- not on the ambient one, which can be a different connection entirely
+    -- after a :GripConnect. With no session there is nothing to fill and no
+    -- URL to check; nil falls back to the ambient connection so the refusal
+    -- still names the mode rather than the missing session.
+    local fill_session = view._sessions[vim.api.nvim_get_current_buf()]
+    if deny_if_readonly("GripFill", fill_session and fill_session.url) then return end
     local n = math.max(1, math.min(50, tonumber(cmd_opts.args) or 1))
     M.do_fill_rows(n)
   end, { nargs = "?", desc = "Stage N AI-generated rows for current table (default 1, max 50)" })
@@ -2292,6 +2316,10 @@ function M.do_fill_rows(n)
 
   -- Build single-table DDL so the AI knows exactly what to fill.
   local db_mod = require("dadbod-grip.db")
+  -- Checked here too, not only in :GripFill: the AI keymap calls this
+  -- directly, and the adapter check below would refuse a read-only *connection*
+  -- with the wrong reason when its adapter is perfectly writable.
+  if deny_if_readonly("GripFill", db_url) then return end
   if db_mod.is_readonly(db_url) then
     vim.notify("GripFill: this adapter is read-only", vim.log.levels.WARN)
     return

--- a/lua/dadbod-grip/properties.lua
+++ b/lua/dadbod-grip/properties.lua
@@ -268,6 +268,13 @@ function M.open(table_name, url, grip_win)
     return col_line_map[row]
   end
 
+  -- The four DDL keymaps below decline on a read-only connection (see
+  -- connections.deny_if_readonly) rather than closing the float, opening a
+  -- prompt and letting the statement fail at the end of it. The float stays
+  -- open: nothing happened. The guard sits after each keymap's own
+  -- precondition, so "move the cursor to a column row" still wins where that
+  -- is the actual problem.
+
   -- R: rename column under cursor
   vim.keymap.set("n", "R", function()
     local col_name = cursor_column()
@@ -275,6 +282,7 @@ function M.open(table_name, url, grip_win)
       vim.notify("Move cursor to a column row", vim.log.levels.INFO)
       return
     end
+    if require("dadbod-grip.connections").deny_if_readonly("Rename column", url) then return end
     -- close() (not a bare nvim_win_close) so the buffer is gone before the
     -- blocking ddl prompt below opens: WinLeave's own deferred cleanup runs
     -- via vim.schedule, which a blocking prompt can starve until it returns,
@@ -292,6 +300,7 @@ function M.open(table_name, url, grip_win)
 
   -- +: add column
   vim.keymap.set("n", "+", function()
+    if require("dadbod-grip.connections").deny_if_readonly("Add column", url) then return end
     -- See the R handler above for why close() replaces a bare nvim_win_close.
     close()
     local ddl = require("dadbod-grip.ddl")
@@ -303,6 +312,7 @@ function M.open(table_name, url, grip_win)
 
   -- T: rename table
   vim.keymap.set("n", "T", function()
+    if require("dadbod-grip.connections").deny_if_readonly("Rename table", url) then return end
     -- See the R handler above for why close() replaces a bare nvim_win_close.
     close()
     if vim.api.nvim_win_is_valid(caller_win) then
@@ -321,6 +331,7 @@ function M.open(table_name, url, grip_win)
       vim.notify("Move cursor to a column row", vim.log.levels.INFO)
       return
     end
+    if require("dadbod-grip.connections").deny_if_readonly("Drop column", url) then return end
     -- See the R handler above for why close() replaces a bare nvim_win_close.
     close()
     local ddl = require("dadbod-grip.ddl")

--- a/lua/dadbod-grip/schema.lua
+++ b/lua/dadbod-grip/schema.lua
@@ -418,7 +418,10 @@ local function render(state)
     title = current and current.name or state.url:match("^%w+://[^/]*/?([^?]*)") or state.url
   end
   table.insert(lines, " " .. title)
-  table.insert(highlights, { line = 0, col = 0, end_col = #lines[1], hl = "GripBorder" })
+  -- The connection accent, so a connection saved with "color" is identifiable
+  -- from the sidebar title alone. Unaccented it is GripBorder's violet, which
+  -- is what this line has always been.
+  table.insert(highlights, { line = 0, col = 0, end_col = #lines[1], hl = "GripConnAccentBold" })
 
   table.insert(lines, "")
 
@@ -916,6 +919,7 @@ local function setup_keymaps(url)
       vim.notify("Move cursor to a table", vim.log.levels.INFO)
       return
     end
+    if require("dadbod-grip.connections").deny_if_readonly("Drop table", url) then return end
     local ddl = require("dadbod-grip.ddl")
     ddl.drop_table(node.name, url, function()
       state.items = nil
@@ -929,6 +933,7 @@ local function setup_keymaps(url)
 
   -- sidebar_create: create table
   kmap("sidebar_create", function()
+    if require("dadbod-grip.connections").deny_if_readonly("Create table", url) then return end
     local ddl = require("dadbod-grip.ddl")
     ddl.create_table(url, function()
       state.items = nil

--- a/lua/dadbod-grip/secrets.lua
+++ b/lua/dadbod-grip/secrets.lua
@@ -138,11 +138,21 @@ function M.parse_env_file(path)
   return vars
 end
 
+-- One placeholder, escaped or not: "$" then an optional second "$" (the
+-- escape), then {NAME}. M.expand is the only reader; M.has_template shares
+-- the pattern so the two can never disagree about what a template is.
+local PLACEHOLDER = "%$(%$?){([%w_]+)}"
+
 --- True when `url` contains at least one ${NAME} placeholder.
+---
+--- The escaped form `$${NAME}` counts too, even though it resolves to
+--- nothing: it still has to reach M.expand, which is what turns the `$$`
+--- back into a single `$`. A URL that skipped expansion would connect with
+--- the escape still in it.
 --- @param url string
 --- @return boolean
 function M.has_template(url)
-  return url:find("%${[%w_]+}") ~= nil
+  return url:find(PLACEHOLDER) ~= nil
 end
 
 --- Resolve every ${NAME} placeholder in `url`.
@@ -150,7 +160,17 @@ end
 --- Values come from `entry.env_file` (if set) first, falling back to the
 --- process environment. An unresolved placeholder is always an error --
 --- never an empty substitution, since a URL quietly missing its password
---- either connects somewhere unintended or hangs on a prompt.
+--- either connects somewhere unintended or hangs on a prompt. "Unresolved"
+--- includes a variable that exists but is empty (`KEY=` with nothing after
+--- it, the usual shape of a committed .env template): substituting it
+--- leaves a URL with no password, and psql/mysql then fall through to
+--- ~/.pgpass or a defaults file and may authenticate as somebody else.
+--- Vim's getenv() already reports an empty *process* variable as unset, so
+--- this only makes the .env path agree with it.
+---
+--- `$${NAME}` is the escape: it produces the literal text `${NAME}` and
+--- resolves nothing, for the connection whose password genuinely contains
+--- `${WORD}`.
 --- @param url string
 --- @param entry table connection entry; may carry `env_file`
 --- @return string|nil resolved
@@ -168,15 +188,18 @@ function M.expand(url, entry)
   end
 
   local first_err
-  local resolved = url:gsub("%${([%w_]+)}", function(name)
+  local resolved = url:gsub(PLACEHOLDER, function(escape, name)
+    if escape == "$" then
+      return "${" .. name .. "}"
+    end
     if first_err then
       return ""
     end
-    local value = vars and vars[name]
+    local value, source = vars and vars[name], entry.env_file
     if value == nil then
       local env_value = vim.fn.getenv(name)
       if env_value ~= vim.NIL then
-        value = env_value
+        value, source = env_value, "the process environment"
       end
     end
     if value == nil then
@@ -185,6 +208,11 @@ function M.expand(url, entry)
         .. "} (checked"
         .. (entry.env_file and (" " .. entry.env_file .. " and") or "")
         .. " the process environment)"
+      return ""
+    end
+    if value == "" then
+      first_err = "secrets: ${" .. name .. "} is empty in " .. tostring(source)
+        .. " (an empty value is never substituted)"
       return ""
     end
     return value

--- a/lua/dadbod-grip/secrets.lua
+++ b/lua/dadbod-grip/secrets.lua
@@ -1,0 +1,199 @@
+-- secrets.lua: resolves ${VAR} placeholders in connection URLs against a
+-- project-local .env file, so a connection entry can reference its
+-- password without it ever being written into ~/.grip/connections.json.
+--
+-- Zero dependencies on the rest of dadbod-grip: must be requireable in
+-- isolation (see Task 5 of the connection-secrets-mode-color plan).
+
+local M = {}
+
+-- git-crypt's own magic header: https://github.com/AGWA/git-crypt --
+-- an encrypted-at-rest file starts with these exact 10 bytes.
+local GITCRYPT_MAGIC = "\0GITCRYPT\0"
+
+-- path -> { mtime = <getftime() at last read>, vars = <table<string,string>> }
+local cache = {}
+
+--- Discard all cached .env contents.
+--- Test seam, and the escape hatch for anyone who unlocks git-crypt (or
+--- otherwise replaces an env_file) without restarting Neovim.
+function M.clear_cache()
+  cache = {}
+end
+
+--- Strip one matching pair of surrounding quotes from a raw assignment
+--- value. Unquoted values are returned unchanged.
+--- @param raw string
+--- @return string
+local function unquote(raw)
+  local double = raw:match('^"(.*)"$')
+  if double then
+    return double
+  end
+  local single = raw:match("^'(.*)'$")
+  if single then
+    return single
+  end
+  return raw
+end
+
+--- Parse one line of a .env file. Returns nil for comments, blank lines,
+--- and anything that isn't a recognizable `[export ]KEY=value` assignment.
+--- @param line string
+--- @return string|nil key
+--- @return string|nil value
+local function parse_line(line)
+  local trimmed = line:match("^%s*(.-)%s*$")
+  if trimmed == "" or trimmed:sub(1, 1) == "#" then
+    return nil
+  end
+  trimmed = trimmed:match("^export%s+(.+)$") or trimmed
+  local key, raw = trimmed:match("^([%w_]+)=(.*)$")
+  if not key then
+    return nil
+  end
+  return key, unquote(raw)
+end
+
+--- Detect a git-crypt-locked file from its leading bytes.
+---
+--- Deliberately reads with plain Lua io, not vim.fn.readfile(): Neovim's
+--- List<->String bridge always maps a file's NUL bytes onto NL (this is
+--- true even with the "b" binary flag -- it affects line-splitting, not
+--- the NUL/NL swap), so git-crypt's leading "\0GITCRYPT\0" would arrive
+--- here as "\nGITCRYPT\n" and never match. io.open in "rb" mode returns
+--- the exact bytes.
+--- @param path string
+--- @return boolean
+local function is_git_crypt_locked(path)
+  local f = io.open(path, "rb")
+  if not f then
+    return false
+  end
+  local head = f:read(#GITCRYPT_MAGIC) or ""
+  f:close()
+  return head == GITCRYPT_MAGIC
+end
+
+--- Read and parse a .env file, bypassing the cache.
+--- @param path string
+--- @return table<string,string>|nil vars
+--- @return string|nil err
+local function read_and_parse(path)
+  if vim.fn.filereadable(path) == 0 then
+    return nil, "secrets: .env file not found: " .. path
+  end
+  if is_git_crypt_locked(path) then
+    return nil,
+      "secrets: " .. path .. " is git-crypt encrypted; run `git-crypt unlock` in the repo and retry"
+  end
+  local vars = {}
+  for _, line in ipairs(vim.fn.readfile(path)) do
+    local key, value = parse_line(line)
+    if key then
+      vars[key] = value
+    end
+  end
+  return vars
+end
+
+--- Parse a .env file into a table of assignments.
+---
+--- Memoized per (expanded) path and invalidated when the file's mtime
+--- changes, so a password rotated by a teammate mid-session is picked up
+--- on the next query rather than requiring a restart.
+---
+--- Failed reads (missing file, still git-crypt-locked) are deliberately
+--- never cached -- see the write site below -- so `git-crypt unlock`
+--- takes effect on the very next call, with no clear_cache() needed.
+---
+--- The gap runs the other way: vim.fn.getftime() only has 1-second
+--- resolution, so replacing a file's *contents* within the same second as
+--- a prior successful read is invisible to this cache. A cached plaintext
+--- read stays cached -- including past a same-second git-crypt lock, i.e.
+--- the module keeps serving decrypted values for a file that has since
+--- been re-encrypted -- until an unrelated later write bumps the mtime,
+--- clear_cache() is called, or the process restarts. Accepted: a
+--- hand-edited local secrets file is not realistically rewritten twice
+--- inside one wall-clock second, and closing the gap would mean hashing
+--- the whole file on every call, defeating the point of caching.
+--- @param path string
+--- @return table<string,string>|nil vars
+--- @return string|nil err
+function M.parse_env_file(path)
+  path = vim.fn.expand(path)
+  local mtime = vim.fn.getftime(path)
+  local cached = cache[path]
+  if cached and cached.mtime == mtime then
+    return cached.vars
+  end
+  local vars, err = read_and_parse(path)
+  if not vars then
+    return nil, err
+  end
+  -- Only successful reads are cached: a failure here (missing file,
+  -- still git-crypt-locked) must retry from scratch next call, so an
+  -- unlock is picked up immediately. See the doc comment above.
+  cache[path] = { mtime = mtime, vars = vars }
+  return vars
+end
+
+--- True when `url` contains at least one ${NAME} placeholder.
+--- @param url string
+--- @return boolean
+function M.has_template(url)
+  return url:find("%${[%w_]+}") ~= nil
+end
+
+--- Resolve every ${NAME} placeholder in `url`.
+---
+--- Values come from `entry.env_file` (if set) first, falling back to the
+--- process environment. An unresolved placeholder is always an error --
+--- never an empty substitution, since a URL quietly missing its password
+--- either connects somewhere unintended or hangs on a prompt.
+--- @param url string
+--- @param entry table connection entry; may carry `env_file`
+--- @return string|nil resolved
+--- @return string|nil err
+function M.expand(url, entry)
+  entry = entry or {}
+
+  local vars
+  if entry.env_file then
+    local err
+    vars, err = M.parse_env_file(entry.env_file)
+    if not vars then
+      return nil, err
+    end
+  end
+
+  local first_err
+  local resolved = url:gsub("%${([%w_]+)}", function(name)
+    if first_err then
+      return ""
+    end
+    local value = vars and vars[name]
+    if value == nil then
+      local env_value = vim.fn.getenv(name)
+      if env_value ~= vim.NIL then
+        value = env_value
+      end
+    end
+    if value == nil then
+      first_err = "secrets: unresolved variable ${"
+        .. name
+        .. "} (checked"
+        .. (entry.env_file and (" " .. entry.env_file .. " and") or "")
+        .. " the process environment)"
+      return ""
+    end
+    return value
+  end)
+
+  if first_err then
+    return nil, first_err
+  end
+  return resolved
+end
+
+return M

--- a/lua/dadbod-grip/sql.lua
+++ b/lua/dadbod-grip/sql.lua
@@ -72,6 +72,47 @@ function M.split_table_name(table_name, default_schema)
   return M.unquote_ident(schema), M.unquote_ident(tbl)
 end
 
+--- Mask the password in a connection URL for display in logs, errors, notifications.
+--- The authority component is captured up to the next "/" (so this never
+--- reaches into the path or query — a "/" always ends the search). Inside
+--- that component, the split is on the LAST "@", mirroring
+--- parse_dadbod_url's own rule below: a password may itself contain "@",
+--- and splitting on the first one would leave the rest of the password —
+--- everything between that first "@" and the real one before the host — in
+--- cleartext right next to the mask. See redact_spec.lua for both cases.
+---
+--- Callers also feed this whatever the user typed as a URL even after it has
+--- failed to parse (e.g. "Invalid MySQL URL: " .. redact_url(url)), so a
+--- string with no "://" at all still needs a pass: fall back to masking any
+--- "ident:secret@" run found anywhere in it, as long as neither side contains
+--- whitespace. A real URL never has unescaped whitespace, so that costs
+--- nothing on the input this fallback is actually for; it exists to keep the
+--- fallback from treating an entire free-form sentence as one giant
+--- credential (see redact_spec.lua). It is still just a heuristic scan, not
+--- authority-aware like the "://" branch above: an incidental
+--- whitespace-free "word:word@word" inside non-URL text can still get
+--- masked. Callers should feed it a URL argument, not a full error message
+--- built from other text.
+--- @param url string|nil
+--- @return string
+function M.redact_url(url)
+  if not url then return "" end
+  if url:find("://", 1, true) then
+    return (url:gsub("://([^/]*)", function(authority)
+      local at = nil
+      for i = #authority, 1, -1 do
+        if authority:sub(i, i) == "@" then at = i; break end
+      end
+      if not at then return "://" .. authority end
+      local userpass, host = authority:sub(1, at - 1), authority:sub(at + 1)
+      local colon = userpass:find(":", 1, true)
+      if not colon then return "://" .. authority end
+      return "://" .. userpass:sub(1, colon - 1) .. ":***@" .. host
+    end))
+  end
+  return (url:gsub("([^:/@%s]+):([^@%s]*)@", "%1:***@"))
+end
+
 -- Parse a dadbod-style connection URL into its components.
 -- "scheme://user:pass@host:port/dbname" → {user, pass, host, port, dbname}
 -- The auth part is matched greedily up to the last @ so passwords may contain @.

--- a/lua/dadbod-grip/sql.lua
+++ b/lua/dadbod-grip/sql.lua
@@ -72,6 +72,56 @@ function M.split_table_name(table_name, default_schema)
   return M.unquote_ident(schema), M.unquote_ident(tbl)
 end
 
+--- Split a URL authority ("user:password@host:port") into its three parts.
+--- `user` is nil when there is no "@" at all; `password` is nil when the
+--- userinfo carries no ":". `host` is always the remainder.
+---
+--- The split is on the LAST "@", mirroring parse_dadbod_url's own rule below:
+--- a password may itself contain "@", and splitting on the first one would
+--- leave the rest of the password — everything between that first "@" and the
+--- real one before the host — outside whatever the caller does with it. That
+--- is not academic: adapters/duckdb.lua's url_to_dsn used to split on the
+--- first "@" and put the tail of the password into host=, which then defeated
+--- the ATTACH-error mask downstream.
+---
+--- The single copy of that rule: redact_url, url_password and url_to_dsn all
+--- go through here.
+--- @param authority string
+--- @return string|nil user
+--- @return string|nil password
+--- @return string host
+local function split_authority(authority)
+  local at = nil
+  for i = #authority, 1, -1 do
+    if authority:sub(i, i) == "@" then at = i; break end
+  end
+  if not at then return nil, nil, authority end
+  local userinfo, host = authority:sub(1, at - 1), authority:sub(at + 1)
+  local colon = userinfo:find(":", 1, true)
+  if not colon then return userinfo, nil, host end
+  return userinfo:sub(1, colon - 1), userinfo:sub(colon + 1), host
+end
+M.split_authority = split_authority
+
+--- The password out of a URL's authority, or nil when there is none.
+---
+--- For callers that must scrub a password out of text they did not build —
+--- a CLI's own stderr, say, which may have rewritten the URL past
+--- recognition. redact_url() is the wrong tool there: it rewrites a URL it
+--- can still see, whereas masking the *value* survives re-quoting,
+--- truncation, percent-decoding and path-prefixing. See
+--- adapters/duckdb.lua's redact_attach_error for the case that forced it.
+--- @param url string|nil
+--- @return string|nil password
+function M.url_password(url)
+  if type(url) ~= "string" then return nil end
+  local authority = url:match("://([^/]*)")
+  if not authority then return nil end
+  local _, password = split_authority(authority)
+  if password == nil or password == "" then return nil end
+  return password
+end
+
 --- Mask the password in a connection URL for display in logs, errors, notifications.
 --- The authority component is captured up to the next "/" (so this never
 --- reaches into the path or query — a "/" always ends the search). Inside
@@ -99,15 +149,10 @@ function M.redact_url(url)
   if not url then return "" end
   if url:find("://", 1, true) then
     return (url:gsub("://([^/]*)", function(authority)
-      local at = nil
-      for i = #authority, 1, -1 do
-        if authority:sub(i, i) == "@" then at = i; break end
-      end
-      if not at then return "://" .. authority end
-      local userpass, host = authority:sub(1, at - 1), authority:sub(at + 1)
-      local colon = userpass:find(":", 1, true)
-      if not colon then return "://" .. authority end
-      return "://" .. userpass:sub(1, colon - 1) .. ":***@" .. host
+      local user, password, host = split_authority(authority)
+      -- No "@", or no ":" in the userinfo: nothing that is a password.
+      if not user or not password then return "://" .. authority end
+      return "://" .. user .. ":***@" .. host
     end))
   end
   return (url:gsub("([^:/@%s]+):([^@%s]*)@", "%1:***@"))

--- a/lua/dadbod-grip/view.lua
+++ b/lua/dadbod-grip/view.lua
@@ -123,6 +123,82 @@ local BOT_MID = "╧"
 -- Groups are re-applied on ColorScheme so they survive :colorscheme switches.
 local _hl_ag = vim.api.nvim_create_augroup("DadbodGripHL", { clear = true })
 
+-- Per-connection accent palette. Every hex here is already in use by one of
+-- the groups below, so a coloured connection tints the UI with the plugin's
+-- own colours instead of introducing a second palette:
+--   green  GripBoolTrue/GripInserted   orange GripNullStaged
+--   red    GripNegative/GripDeleted    blue   GripUrl/GripWatch
+--   violet GripBorder (the default)    yellow GripStatusOk
+local ACCENTS = {
+  green  = { hex = "#a6e3a1", cterm = 113 },
+  orange = { hex = "#fab387", cterm = 216 },
+  red    = { hex = "#f38ba8", cterm = 203 },
+  blue   = { hex = "#89b4fa", cterm = 117 },
+  violet = { hex = "#cba6f7", cterm = 147 },
+  yellow = { hex = "#f9e2af", cterm = 229 },
+}
+-- No connection colour, an entry with no `color`, or a value neither this
+-- palette nor #rrggbb: the UI looks exactly as it did before the option
+-- existed. This is GripBorder's historical definition.
+local DEFAULT_ACCENT = ACCENTS.violet
+
+--- Nearest xterm-256 index for a hex colour.
+---
+--- Every group in this file pairs a gui hex with a ctermfg, so an accent has
+--- to carry one too or a 256-colour terminal would silently drop the colour a
+--- palette name still gets. The palette names above ship their index; only a
+--- user's own #rrggbb needs approximating.
+---
+--- The 240 colours above the ANSI 16 are a 6x6x6 cube (levels
+--- 0/95/135/175/215/255) plus a 24-step grey ramp (8 + 10i). Both candidates
+--- are computed and the nearer one wins: picking the ramp only for an exact
+--- r == g == b makes a colour that is grey to within one unit -- #2f2f30 --
+--- come back as a saturated dark blue, and picking the cube for every grey
+--- loses the ramp's much finer steps.
+local function cterm_for(hex)
+  local r = tonumber(hex:sub(2, 3), 16)
+  local g = tonumber(hex:sub(4, 5), 16)
+  local b = tonumber(hex:sub(6, 7), 16)
+  local function dist(cr, cg, cb)
+    return (r - cr) ^ 2 + (g - cg) ^ 2 + (b - cb) ^ 2
+  end
+
+  -- Cube. The levels are unevenly spaced at the bottom, hence the two special
+  -- cases before the arithmetic takes over.
+  local function level(v)
+    if v < 48  then return 0 end
+    if v < 115 then return 1 end
+    return math.floor((v - 35) / 40)
+  end
+  local function level_value(i) return i == 0 and 0 or 55 + i * 40 end
+  local ri, gi, bi = level(r), level(g), level(b)
+  local cube_d = dist(level_value(ri), level_value(gi), level_value(bi))
+
+  -- Grey ramp, indexed off the average channel.
+  local gi_ramp = math.floor(((r + g + b) / 3 - 8) / 10 + 0.5)
+  gi_ramp = math.max(0, math.min(23, gi_ramp))
+  local grey = 8 + 10 * gi_ramp
+
+  if dist(grey, grey, grey) < cube_d then return 232 + gi_ramp end
+  return 16 + 36 * ri + 6 * gi + bi
+end
+
+--- A palette name or "#rrggbb" as an accent, or nil for anything else.
+--- Unknown values are nil rather than an error: a typo in connections.json
+--- must cost the colour, not the connection.
+local function resolve_accent(color)
+  if type(color) ~= "string" then return nil end
+  local named = ACCENTS[color:lower()]
+  if named then return named end
+  local hex = color:match("^#%x%x%x%x%x%x$")
+  if hex then return { hex = hex, cterm = cterm_for(hex) } end
+  return nil
+end
+
+-- The accent of the connection currently switched to. Read by
+-- ensure_highlights, so it is re-applied on every :colorscheme too.
+local _accent = nil
+
 local function ensure_highlights()
   local hl = vim.api.nvim_set_hl
   hl(0, "GripHeader",       { bold = true })
@@ -137,7 +213,6 @@ local function ensure_highlights()
   hl(0, "GripInserted",     { bold = true,         fg = "#a6e3a1", ctermfg = 113, bg = "#162d18", ctermbg = 236 })
   hl(0, "GripNullStaged",   { bold = true,         fg = "#fab387", ctermfg = 216, bg = "#2d1800", ctermbg = 236 })
   hl(0, "GripReadonly",     { italic = true,       fg = "#6c7086", ctermfg = 243 })
-  hl(0, "GripBorder",       { bold = true,         fg = "#cba6f7", ctermfg = 147 })
   hl(0, "GripStatusOk",     { bold = true,         fg = "#f9e2af", ctermfg = 229 })
   hl(0, "GripStatusChg",    { bold = true,         fg = "#f9e2af", ctermfg = 229 })
   hl(0, "GripNegative",     { bold = true,         fg = "#f38ba8", ctermfg = 203 })
@@ -149,12 +224,36 @@ local function ensure_highlights()
   hl(0, "GripColHighlight", { bg = "#313244", ctermbg = 237 })
   -- Dim marker group: filter-line bullets, column type annotations.
   hl(0, "GripColType",      { fg = "#6c7086", ctermfg = 243 })
+  -- Connection accent. GripBorder is defined from it rather than beside the
+  -- groups above, so an uncoloured connection restores its historical violet
+  -- instead of leaving the last coloured connection's border behind.
+  local accent = _accent or DEFAULT_ACCENT
+  hl(0, "GripConnAccent",     {              fg = accent.hex, ctermfg = accent.cterm })
+  hl(0, "GripConnAccentBold", { bold = true, fg = accent.hex, ctermfg = accent.cterm })
+  hl(0, "GripBorder",         { bold = true, fg = accent.hex, ctermfg = accent.cterm })
 end
 ensure_highlights() -- define groups on module load so welcome screen can use them
 vim.api.nvim_create_autocmd("ColorScheme", {
   group    = _hl_ag,
   callback = ensure_highlights,
 })
+
+--- Tint the accent groups for the connection being switched to.
+---
+--- Called from connections.switch() with the entry's `color` -- nil, an
+--- unknown name and a non-string all mean "no accent", which restores the
+--- defaults rather than leaving the previous connection's colour on screen:
+--- coming back from a red prod connection to an uncoloured local one must not
+--- keep the red border.
+---
+--- The accent is stored, not just applied, because ensure_highlights() runs
+--- again on every ColorScheme -- that is what keeps the accent alive across a
+--- :colorscheme switch.
+--- @param color string|nil  a palette name (green/orange/red/blue/violet/yellow) or "#rrggbb"
+function M.set_connection_accent(color)
+  _accent = resolve_accent(color)
+  ensure_highlights()
+end
 
 -- Module-level augroup for all buffer/window lifecycle autocmds in this module.
 -- Created once at require time with clear=true so re-sourcing never doubles handlers.
@@ -838,6 +937,9 @@ function M.render(bufnr, state)
 
   -- The sticky header mirrors this render's column row; a new render (page
   -- turn, sort, FK jump, tab view) changes it, so refresh the winbar with it.
+  -- Drop the cached connection mode with it: a render is rare enough to pay
+  -- for the file read the RO badge needs, a CursorMoved is not.
+  session._ro_mode = nil
   M._update_winbar(bufnr)
 end
 
@@ -1131,6 +1233,20 @@ function M._update_winbar(bufnr)
   if not winid or not vim.api.nvim_win_is_valid(winid) then return end
 
   local badges = {}
+  -- The mode of the session's own connection, not the ambient one: a grid
+  -- outliving a :GripConnect must still say what it is connected to. Cached
+  -- on the session because this function runs on every CursorMoved while
+  -- current_mode() reads connections.json. Two things clear the cache, and
+  -- between them they cover everything that can change the answer:
+  -- M.render (requery, page turn, refresh) and M.invalidate_mode_cache,
+  -- which connections.switch calls.
+  if session._ro_mode == nil then
+    session._ro_mode =
+      require("dadbod-grip.connections").current_mode(session.url) == "ro"
+  end
+  if session._ro_mode then
+    table.insert(badges, { text = "RO", hl = "GripReadonly" })
+  end
   if session.watch_ms then
     local secs = session.watch_ms / 1000
     local label = secs == math.floor(secs) and tostring(math.floor(secs)) .. "s" or tostring(secs) .. "s"
@@ -1180,6 +1296,23 @@ function M._update_winbar(bufnr)
     if bar == "" and sticky then bar = " " end
   end
   pcall(function() vim.wo[winid].winbar = bar end)
+end
+
+--- Drop every session's cached connection mode and redraw the winbars.
+---
+--- connections.switch() calls this: a switch changes what current_mode()
+--- answers, for the connection being switched to and for any connection whose
+--- session override it just cleared. The grid in the current window is
+--- replaced by the welcome screen and takes its session with it, but a grid in
+--- any other window survives -- the sidebar and the query pad both hold focus
+--- at switch time, and a pinned grid is skipped by find_content_win() -- and
+--- would otherwise keep rendering its stale badge off the cache until its next
+--- requery. A badge that says RO on a writable connection is worse than none.
+function M.invalidate_mode_cache()
+  for bufnr, session in pairs(M._sessions) do
+    session._ro_mode = nil
+    if vim.api.nvim_buf_is_valid(bufnr) then M._update_winbar(bufnr) end
+  end
 end
 
 --- Start a watch timer for bufnr at interval ms. Stops any existing timer.
@@ -2066,6 +2199,9 @@ function M._fk_referencing(bufnr)
     -- Fetch PKs for the referencing table
     local pks = db.get_primary_keys(ref.table, session.state.url) or {}
     result.primary_keys = pks
+    -- FK navigation lands on a different table but the same connection, so a
+    -- read-only one stays read-only here too.
+    result.readonly = db.is_readonly(session.state.url)
     result.table_name = ref.table
     result.url = session.state.url
     result.sql = ref_sql

--- a/lua/dadbod-grip/view/keymaps_fk.lua
+++ b/lua/dadbod-grip/view/keymaps_fk.lua
@@ -96,6 +96,9 @@ function M.setup(bufnr, ctx)
     -- Fetch PKs for referenced table
     local pks = db.get_primary_keys(fk_info.ref_table, session_fk.state.url) or {}
     result.primary_keys = pks
+    -- Same connection as the grid we jumped from: a read-only one stays
+    -- read-only on the referenced table too.
+    result.readonly = db.is_readonly(session_fk.state.url)
     result.table_name = fk_info.ref_table
     result.url = session_fk.state.url
     result.sql = ref_sql

--- a/lua/dadbod-grip/view/keymaps_inspect.lua
+++ b/lua/dadbod-grip/view/keymaps_inspect.lua
@@ -141,6 +141,9 @@ function M.setup(bufnr, ctx)
   -- gN: rename column under cursor
   kmap("grid_rename_col", function()
     local session = ctx.session()
+    if session and require("dadbod-grip.connections").deny_if_readonly("Rename column", session.url) then
+      return
+    end
     if not session or not session.state.table_name then
       vim.notify("Rename requires a table name", vim.log.levels.INFO)
       return

--- a/tests/spec/adapter_env_spec.lua
+++ b/tests/spec/adapter_env_spec.lua
@@ -1,0 +1,108 @@
+-- adapter_env_spec.lua -- run_cmd/run_cmd_async accept an opts.env table that
+-- is merged into the child process's inherited environment. Later tasks use
+-- this to pass PGPASSWORD/MYSQL_PWD/PGOPTIONS without putting secrets on the
+-- command line where they would be visible via `ps`.
+local adapters = require("dadbod-grip.adapters")
+
+local pass = 0
+local fail = 0
+
+local function test(name, fn)
+  local ok, err = pcall(fn)
+  if ok then
+    pass = pass + 1
+  else
+    fail = fail + 1
+    print("FAIL: " .. name .. ": " .. tostring(err))
+  end
+end
+
+local function eq(a, b, msg)
+  assert(a == b, (msg or "") .. ": expected " .. tostring(b) .. ", got " .. tostring(a))
+end
+
+test("run_cmd passes env to the child process", function()
+  local out = adapters.run_cmd({ "sh", "-c", "printf %s \"$GRIP_TEST_VAR\"" }, 5000,
+    { env = { GRIP_TEST_VAR = "sentinel-value" } })
+  eq(out, "sentinel-value", "child sees the injected variable")
+end)
+
+test("run_cmd env merges with the inherited environment", function()
+  local out = adapters.run_cmd({ "sh", "-c", "printf %s \"$HOME|$GRIP_TEST_VAR\"" }, 5000,
+    { env = { GRIP_TEST_VAR = "x" } })
+  assert(out:match("^/"), "HOME survived the injection, got: " .. out)
+  assert(out:match("|x$"), "injected var present, got: " .. out)
+end)
+
+test("run_cmd without env still works", function()
+  local out = adapters.run_cmd({ "sh", "-c", "printf ok" }, 5000)
+  eq(out, "ok", "no-opts call unchanged")
+end)
+
+test("run_cmd_async passes env to the child process", function()
+  local out, done
+  adapters.run_cmd_async({ "sh", "-c", "printf %s \"$GRIP_TEST_VAR\"" }, 5000, function(stdout)
+    out = stdout
+    done = true
+  end, { env = { GRIP_TEST_VAR = "async-sentinel" } })
+  vim.wait(5000, function() return done end, 1)
+  eq(out, "async-sentinel", "async child sees the injected variable")
+end)
+
+test("run_cmd_async without opts still works", function()
+  local out, done
+  adapters.run_cmd_async({ "sh", "-c", "printf ok" }, 5000, function(stdout)
+    out = stdout
+    done = true
+  end)
+  vim.wait(5000, function() return done end, 1)
+  eq(out, "ok", "no-opts call unchanged")
+end)
+
+test("psql argv carries no password", function()
+  local pg = require("dadbod-grip.adapters.postgresql")
+  local args = pg._psql_args("postgresql://u:hunter2@h:5432/db", "select 1")
+  for _, a in ipairs(args) do
+    assert(not tostring(a):find("hunter2", 1, true),
+      "password found in argv element: " .. tostring(a))
+  end
+end)
+
+test("psql password goes to PGPASSWORD, percent-decoded", function()
+  local pg = require("dadbod-grip.adapters.postgresql")
+  local env = pg._psql_env("postgresql://u:pa%25ss%40word@h:5432/db")
+  eq(env.PGPASSWORD, "pa%ss@word", "decoded exactly once")
+end)
+
+test("no password means no PGPASSWORD", function()
+  local pg = require("dadbod-grip.adapters.postgresql")
+  local env = pg._psql_env("postgresql://u@h:5432/db")
+  eq(env.PGPASSWORD, nil, "absent rather than empty")
+end)
+
+test("mysql argv carries no password", function()
+  local my = require("dadbod-grip.adapters.mysql")
+  local args = my._mysql_args({ host = "h", port = "3306", user = "u",
+                                pass = "hunter2", dbname = "db" }, "select 1")
+  for _, a in ipairs(args) do
+    assert(not tostring(a):find("hunter2", 1, true), "password in argv: " .. tostring(a))
+  end
+end)
+
+test("mysql password is NOT percent-decoded", function()
+  local my = require("dadbod-grip.adapters.mysql")
+  local env = my._mysql_env({ pass = "pa%25ss" })
+  eq(env.MYSQL_PWD, "pa%25ss", "verbatim, matching sql.lua's no-decode contract")
+end)
+
+test("sqlcmd argv carries no password", function()
+  local ms = require("dadbod-grip.adapters.sqlserver")
+  local args = ms._sqlcmd_args({ host = "h", user = "u", pass = "hunter2", dbname = "db" },
+                               "select 1")
+  for _, a in ipairs(args) do
+    assert(not tostring(a):find("hunter2", 1, true), "password in argv: " .. tostring(a))
+  end
+end)
+
+print(string.format("\nadapter_env_spec: %d passed, %d failed", pass, fail))
+if fail > 0 then os.exit(1) end

--- a/tests/spec/adapter_spec.lua
+++ b/tests/spec/adapter_spec.lua
@@ -65,6 +65,24 @@ local function capture_system_args(stdout, fn)
   return captured
 end
 
+--- Same as capture_system_args but also returns the opts vim.system was
+--- called with, so a test can inspect opts.env (e.g. a password delivered
+--- via the environment instead of argv).
+local function capture_system_call(stdout, fn)
+  local captured_args, captured_opts
+  local orig = vim.system
+  vim.system = function(args, opts, cb)
+    captured_args = args
+    captured_opts = opts
+    local r = { stdout = stdout or "", stderr = "", code = 0 }
+    if cb then cb(r) else return { wait = function() return r end } end
+  end
+  local ok, err = pcall(fn)
+  vim.system = orig
+  if not ok then error(err) end
+  return captured_args, captured_opts
+end
+
 local function with_executable(fn)
   local orig = vim.fn.executable
   vim.fn.executable = function() return 1 end
@@ -410,15 +428,18 @@ end)
 
 test("sqlserver query: builds sqlcmd args for non-interactive use", function()
   with_executable(function()
-    local args = capture_system_args("id\n--\n1\n", function()
+    local args, opts = capture_system_call("id\n--\n1\n", function()
       sqlserver.query("SELECT 1", "sqlserver://sa:pw@localhost:1433/grip_test")
     end)
     has_arg(args, "sqlcmd", "uses sqlcmd")
     has_arg(args, "-S", "sets server")
     has_arg(args, "-d", "sets database")
     has_arg(args, "-U", "sets user")
-    has_arg(args, "-P", "sets password")
     has_arg(args, "-Q", "sets query")
+    for _, a in ipairs(args) do
+      assert(not tostring(a):find("pw", 1, true), "password in argv: " .. tostring(a))
+    end
+    eq(opts.env.SQLCMDPASSWORD, "pw", "password delivered via env instead")
   end)
 end)
 

--- a/tests/spec/conn_color_spec.lua
+++ b/tests/spec/conn_color_spec.lua
@@ -1,0 +1,323 @@
+-- conn_color_spec.lua -- a connection saved with "color" tints the accent
+-- highlight groups, and a connection without one restores the defaults.
+--
+-- The assertions read the groups back through nvim_get_hl rather than
+-- checking what set_connection_accent was called with: the failure this
+-- guards against is a border left red after switching away from a red
+-- connection, which only the resolved group can show.
+local paths = require("dadbod-grip.paths")
+local grip = require("dadbod-grip")
+
+local pass = 0
+local fail = 0
+
+local function test(name, fn)
+  local ok, err = pcall(fn)
+  if ok then
+    pass = pass + 1
+  else
+    fail = fail + 1
+    print("FAIL: " .. name .. ": " .. tostring(err))
+  end
+end
+
+local function eq(a, b, msg)
+  assert(a == b, (msg or "") .. ": expected " .. tostring(b) .. ", got " .. tostring(a))
+end
+
+local function fg(group)
+  return vim.api.nvim_get_hl(0, { name = group }).fg
+end
+
+-- GripBorder's definition from before per-connection colour existed. Every
+-- "restores the default" assertion is against this number.
+local DEFAULT_BORDER = 0xcba6f7
+
+-- ── set_connection_accent ─────────────────────────────────────────────────
+
+test("a palette name sets the accent groups", function()
+  local view = require("dadbod-grip.view")
+  view.set_connection_accent("red")
+  local hl = vim.api.nvim_get_hl(0, { name = "GripConnAccent" })
+  assert(hl.fg, "GripConnAccent has a foreground")
+  -- The palette is the one already in ensure_highlights: red is GripNegative's.
+  eq(hl.fg, 0xf38ba8, "red is the plugin's own red, not a second palette")
+  eq(fg("GripConnAccentBold"), 0xf38ba8, "the bold variant follows it")
+  eq(vim.api.nvim_get_hl(0, { name = "GripConnAccentBold" }).bold, true, "and is bold")
+  eq(fg("GripBorder"), 0xf38ba8, "the border takes the accent too")
+end)
+
+test("a palette name is case-insensitive", function()
+  local view = require("dadbod-grip.view")
+  view.set_connection_accent("Green")
+  eq(fg("GripConnAccent"), 0xa6e3a1, "Green resolves like green")
+end)
+
+test("every documented palette name resolves", function()
+  local view = require("dadbod-grip.view")
+  -- doc/dadbod-grip.txt lists exactly these six.
+  for _, name in ipairs({ "green", "orange", "red", "blue", "violet", "yellow" }) do
+    view.set_connection_accent(name)
+    assert(fg("GripConnAccent"), name .. " resolves to a colour")
+    if name ~= "violet" then
+      assert(fg("GripConnAccent") ~= DEFAULT_BORDER,
+        name .. " must not silently fall through to the default")
+    end
+  end
+end)
+
+test("a hex value is accepted", function()
+  local view = require("dadbod-grip.view")
+  view.set_connection_accent("#00ff00")
+  eq(vim.api.nvim_get_hl(0, { name = "GripConnAccent" }).fg, 0x00ff00, "hex honoured")
+end)
+
+test("nil restores the default border", function()
+  local view = require("dadbod-grip.view")
+  view.set_connection_accent("red")
+  view.set_connection_accent(nil)
+  eq(vim.api.nvim_get_hl(0, { name = "GripBorder" }).fg, 0xcba6f7,
+     "border back to its default after leaving a coloured connection")
+  eq(fg("GripConnAccent"), DEFAULT_BORDER, "and so are the accent groups")
+end)
+
+test("an unknown colour name is ignored rather than raising", function()
+  local view = require("dadbod-grip.view")
+  local ok = pcall(view.set_connection_accent, "chartreuse-ish")
+  eq(ok, true, "no error on a bad value")
+  eq(fg("GripBorder"), DEFAULT_BORDER, "and it leaves the default look, not the last colour")
+end)
+
+test("a malformed hex is ignored rather than half-applied", function()
+  local view = require("dadbod-grip.view")
+  for _, bad in ipairs({ "#00ff0", "#gggggg", "00ff00", "#00ff00ff", 42, true }) do
+    view.set_connection_accent("red")
+    local ok = pcall(view.set_connection_accent, bad)
+    eq(ok, true, "no error on " .. tostring(bad))
+    eq(fg("GripBorder"), DEFAULT_BORDER, tostring(bad) .. " leaves the default look")
+  end
+end)
+
+-- ── 256-colour terminals ──────────────────────────────────────────────────
+-- Every group in view.lua pairs a gui hex with a ctermfg. An accent without
+-- one would simply vanish on a terminal without truecolor.
+
+test("an accent carries a ctermfg", function()
+  local view = require("dadbod-grip.view")
+  view.set_connection_accent("red")
+  eq(vim.api.nvim_get_hl(0, { name = "GripConnAccent" }).ctermfg, 203,
+    "the palette's own cterm index, matching GripNegative")
+  view.set_connection_accent("#00ff00")
+  eq(vim.api.nvim_get_hl(0, { name = "GripConnAccent" }).ctermfg, 46,
+    "a user hex is approximated into the xterm cube (#00ff00 = bright green)")
+  -- The cube's bottom two levels are 0 and 95, not 0 and 40: both channels
+  -- below 115 here, and both would land a level too low on plain division.
+  view.set_connection_accent("#3c50ff")
+  eq(vim.api.nvim_get_hl(0, { name = "GripConnAccent" }).ctermfg, 63,
+    "the cube's uneven low end is honoured")
+  view.set_connection_accent(nil)
+  eq(vim.api.nvim_get_hl(0, { name = "GripBorder" }).ctermfg, 147,
+    "the default's cterm index is unchanged too")
+end)
+
+-- The 240 indices above the ANSI 16 are the 6x6x6 cube plus a 24-step grey
+-- ramp (8 + 10i). Each case below is the true nearest index, confirmed by
+-- brute force against the whole palette; each is also a case an
+-- exact-grey-only ramp test would get wrong.
+test("a grey resolves to its nearest ramp step, not to the cube", function()
+  local view = require("dadbod-grip.view")
+  local bad = {}
+  for _, case in ipairs({
+    { "#808080", 244 },  -- an exact ramp hit: 8 + 10*12
+    { "#080808", 232 },  -- the ramp's first step
+    { "#ededed", 255 },  -- the last, where the cube's 231 is 30 away
+    { "#2f2f30", 236 },  -- grey to within one unit: the cube answers dark blue
+    { "#5f5f5f", 59  },  -- an exact *cube* hit, so here the cube must win
+  }) do
+    view.set_connection_accent(case[1])
+    local got = vim.api.nvim_get_hl(0, { name = "GripConnAccent" }).ctermfg
+    if got ~= case[2] then
+      table.insert(bad, string.format("%s -> %s (want %d)", case[1], tostring(got), case[2]))
+    end
+  end
+  view.set_connection_accent(nil)
+  eq(#bad, 0, "every case lands on its true nearest index: " .. table.concat(bad, ", "))
+end)
+
+-- ── surviving a :colorscheme ──────────────────────────────────────────────
+-- A colorscheme runs `hi clear`, which wipes every group this plugin defines.
+-- ensure_highlights re-runs on ColorScheme; the accent has to be re-applied
+-- from stored state there, not merely set once when the connection changed.
+
+test("the accent survives a :colorscheme change", function()
+  local view = require("dadbod-grip.view")
+  local orig_scheme = vim.g.colors_name
+  view.set_connection_accent("red")
+  vim.cmd("colorscheme blue")
+  eq(fg("GripConnAccent"), 0xf38ba8, "accent re-applied after the scheme wiped it")
+  eq(fg("GripBorder"), 0xf38ba8, "and the border with it")
+  view.set_connection_accent(nil)
+  vim.cmd("colorscheme " .. (orig_scheme or "default"))
+  eq(fg("GripBorder"), DEFAULT_BORDER, "an uncoloured connection survives it as the default")
+end)
+
+-- ── the sidebar title ─────────────────────────────────────────────────────
+-- Driven through the real sidebar: the extmark on row 0 carries the group
+-- name, so this asserts both that the title takes the accent group and that
+-- the group follows the connection colour.
+
+test("the sidebar title is drawn with the accent group", function()
+  local view = require("dadbod-grip.view")
+  local schema = require("dadbod-grip.schema")
+  local db = require("dadbod-grip.db")
+  local conns = require("dadbod-grip.connections")
+
+  local orig = { lt = db.list_tables, lr = db.list_routines,
+                 cur = conns.current, g_db = vim.g.db }
+  db.list_tables   = function() return { { name = "users", type = "table" } } end
+  db.list_routines = function() return {} end
+  conns.current    = function() return nil end  -- title falls back to the url
+  vim.g.db = nil
+
+  local ok, err = pcall(function()
+    view.set_connection_accent("red")
+    schema.toggle("postgresql://u:p@h/appdb_accent_test")
+    local win = schema.get_winid()
+    assert(win and vim.api.nvim_win_is_valid(win), "the sidebar opened")
+    local buf = vim.api.nvim_win_get_buf(win)
+    local ns = vim.api.nvim_create_namespace("grip_schema")
+    local marks = vim.api.nvim_buf_get_extmarks(buf, ns, { 0, 0 }, { 0, -1 },
+      { details = true })
+    assert(#marks > 0, "the title line carries a highlight")
+    eq(marks[1][4].hl_group, "GripConnAccentBold", "and it is the accent group")
+    eq(fg(marks[1][4].hl_group), 0xf38ba8, "which resolves red on a red connection")
+    view.set_connection_accent(nil)
+    eq(fg(marks[1][4].hl_group), DEFAULT_BORDER, "and back to the default without one")
+  end)
+
+  schema.close()
+  for _, b in ipairs(vim.api.nvim_list_bufs()) do
+    if vim.api.nvim_buf_is_valid(b)
+       and vim.api.nvim_buf_get_name(b):find("grip://schema", 1, true) then
+      pcall(vim.api.nvim_buf_delete, b, { force = true })
+    end
+  end
+  db.list_tables, db.list_routines = orig.lt, orig.lr
+  conns.current, vim.g.db = orig.cur, orig.g_db
+  view.set_connection_accent(nil)
+  if not ok then error(err) end
+end)
+
+-- ── end to end: switching connections ─────────────────────────────────────
+-- The harness is connections_fields_spec.lua's with_real_file, verbatim
+-- except for the name -- see that file for why each patch exists. view is
+-- deliberately NOT stubbed: the accent it applies is the assertion.
+
+local connections = require("dadbod-grip.connections")
+
+local function with_real_file(fn)
+  local project_dir = vim.fn.tempname() .. "_grip_conn_color_test"
+  local fake_home = project_dir .. "_home"
+  vim.fn.mkdir(project_dir, "p")
+  vim.fn.mkdir(fake_home, "p")
+
+  local orig_project_root = paths.project_root
+  local orig_expand = vim.fn.expand
+  local orig_notify = vim.notify
+  local orig_g_db = vim.g.db
+  local orig_opts = grip.get_opts()
+  local orig_open = grip.open
+  local orig_open_welcome = grip.open_welcome
+  local orig_schema = package.loaded["dadbod-grip.schema"]
+  local orig_query_pad = package.loaded["dadbod-grip.query_pad"]
+  local orig_completion = package.loaded["dadbod-grip.completion"]
+  local orig_connections = package.loaded["dadbod-grip.connections"]
+
+  paths.project_root = function() return project_dir end
+  vim.fn.expand = function(a, ...)
+    if a == "~" then return fake_home end
+    return orig_expand(a, ...)
+  end
+  vim.notify = function() end
+  grip.setup({})
+  grip.open = function() end
+  grip.open_welcome = function() end
+  package.loaded["dadbod-grip.schema"] = {
+    is_open = function() return true end,
+    refresh = function() end,
+    toggle = function() end,
+    get_winid = function() return nil end,
+  }
+  package.loaded["dadbod-grip.query_pad"] = { open = function() end }
+  package.loaded["dadbod-grip.completion"] = { invalidate = function() end, warm_schema = function() end }
+  package.loaded["dadbod-grip.connections"] = nil
+  connections = require("dadbod-grip.connections")
+
+  local ok, err = pcall(fn, project_dir .. "/.grip")
+  vim.wait(50) -- flush any vim.schedule() callbacks queued by switch()
+
+  paths.project_root = orig_project_root
+  vim.fn.expand = orig_expand
+  vim.notify = orig_notify
+  vim.g.db = orig_g_db
+  grip.setup(orig_opts)
+  grip.open = orig_open
+  grip.open_welcome = orig_open_welcome
+  package.loaded["dadbod-grip.schema"] = orig_schema
+  package.loaded["dadbod-grip.query_pad"] = orig_query_pad
+  package.loaded["dadbod-grip.completion"] = orig_completion
+  package.loaded["dadbod-grip.connections"] = orig_connections
+  connections = orig_connections
+  require("dadbod-grip.view").set_connection_accent(nil)
+
+  vim.fn.delete(project_dir, "rf")
+  vim.fn.delete(fake_home, "rf")
+  if not ok then error(err) end
+end
+
+local PROD  = "postgresql://u:p@h/prod"
+local LOCAL = "postgresql://u:p@h/local"
+
+--- A connections.json with one red entry and one uncoloured one.
+local function write_conns(local_grip)
+  paths.ensure_dir(local_grip)
+  vim.fn.writefile({ vim.fn.json_encode({
+    { name = "prod",  url = PROD,  type = "postgresql", color = "red" },
+    { name = "local", url = LOCAL, type = "postgresql" },
+  }) }, local_grip .. "/connections.json")
+end
+
+test("switching to a coloured connection tints the accent", function()
+  with_real_file(function(local_grip)
+    write_conns(local_grip)
+    connections.switch(PROD, "prod", "postgresql")
+    eq(fg("GripConnAccent"), 0xf38ba8, "the entry's colour reached the highlight groups")
+    eq(fg("GripBorder"), 0xf38ba8, "so the grid border and sidebar title are red")
+  end)
+end)
+
+test("switching back to an uncoloured connection restores the defaults", function()
+  with_real_file(function(local_grip)
+    write_conns(local_grip)
+    connections.switch(PROD, "prod", "postgresql")
+    connections.switch(LOCAL, "local", "postgresql")
+    eq(fg("GripBorder"), DEFAULT_BORDER,
+      "leaving a red prod connection must not leave the border red")
+    eq(fg("GripConnAccent"), DEFAULT_BORDER, "and the accent with it")
+  end)
+end)
+
+test("switching to a connection that was never saved restores the defaults", function()
+  with_real_file(function(local_grip)
+    write_conns(local_grip)
+    connections.switch(PROD, "prod", "postgresql")
+    -- ~ Connect once: no entry at all, so no colour.
+    connections.switch("postgresql://u:p@h/adhoc", nil, "postgresql")
+    eq(fg("GripBorder"), DEFAULT_BORDER, "an ad-hoc connection is uncoloured")
+  end)
+end)
+
+-- ── summary ─────────────────────────────────────────────────────────────────
+
+print(string.format("\nconn_color_spec: %d passed, %d failed", pass, fail))
+if fail > 0 then os.exit(1) end

--- a/tests/spec/connections_fields_spec.lua
+++ b/tests/spec/connections_fields_spec.lua
@@ -1,0 +1,247 @@
+-- connections_fields_spec.lua -- env_file/mode/color must round-trip through
+-- both connections.lua whitelists (read_json_connections + write_file_connections)
+-- and through the G:global promotion action, without disturbing the
+-- byte-identical output connections_spec.lua pins for entries that don't use
+-- the new fields.
+local paths = require("dadbod-grip.paths")
+local grip = require("dadbod-grip")
+
+-- Rebound to a freshly loaded module by every with_real_file() below -- see
+-- the comment on the harness itself for why this matters.
+local connections = require("dadbod-grip.connections")
+
+local pass = 0
+local fail = 0
+
+local function test(name, fn)
+  local ok, err = pcall(fn)
+  if ok then
+    pass = pass + 1
+  else
+    fail = fail + 1
+    print("FAIL: " .. name .. ": " .. tostring(err))
+  end
+end
+
+local function eq(a, b, msg)
+  assert(a == b, (msg or "") .. ": expected " .. tostring(b) .. ", got " .. tostring(a))
+end
+
+-- ── real-file harness ────────────────────────────────────────────────────
+-- Copied verbatim from tests/spec/connections_spec.lua:53 -- see that file's
+-- comments for why every one of these patches exists. In short:
+-- - paths.project_root is patched (not paths.grip_dir): connections.lua
+--   captures `local grip_dir = paths.grip_dir` at require time, so patching
+--   the grip_dir *field* on the module later would not affect that alias.
+--   The captured function still calls `M.project_root()` dynamically though,
+--   so patching project_root reaches it either way.
+-- - vim.fn.expand("~") is patched to a fake home so the global connections
+--   file used by tests never touches the real ~/.grip/connections.json.
+-- - the module under test is reloaded per call so its module-local state
+--   (notably the _health table set_health writes to) starts empty; the
+--   file-level `connections` alias is rebound to that instance.
+local function with_real_file(fn)
+  local project_dir = vim.fn.tempname() .. "_grip_conn_fields_test"
+  local fake_home = project_dir .. "_home"
+  vim.fn.mkdir(project_dir, "p")
+  vim.fn.mkdir(fake_home, "p")
+
+  local orig_project_root = paths.project_root
+  local orig_expand = vim.fn.expand
+  local orig_notify = vim.notify
+  local orig_g_db = vim.g.db
+  local orig_opts = grip.get_opts()
+  local orig_open = grip.open
+  local orig_open_welcome = grip.open_welcome
+  local orig_schema = package.loaded["dadbod-grip.schema"]
+  local orig_query_pad = package.loaded["dadbod-grip.query_pad"]
+  local orig_completion = package.loaded["dadbod-grip.completion"]
+  local orig_duckdb = package.loaded["dadbod-grip.adapters.duckdb"]
+  local orig_connections = package.loaded["dadbod-grip.connections"]
+
+  paths.project_root = function() return project_dir end
+  vim.fn.expand = function(a, ...)
+    if a == "~" then return fake_home end
+    return orig_expand(a, ...)
+  end
+  vim.notify = function() end
+  grip.setup({}) -- deterministic OPTS baseline (connections_path = nil, etc.)
+  grip.open = function() end
+  grip.open_welcome = function() end
+  package.loaded["dadbod-grip.schema"] = {
+    is_open = function() return true end,
+    refresh = function() end,
+    toggle = function() end,
+    get_winid = function() return nil end,
+  }
+  package.loaded["dadbod-grip.query_pad"] = { open = function() end }
+  package.loaded["dadbod-grip.completion"] = { invalidate = function() end, warm_schema = function() end }
+  package.loaded["dadbod-grip.adapters.duckdb"] = { load_attachments = function() end }
+  package.loaded["dadbod-grip.connections"] = nil
+  connections = require("dadbod-grip.connections")
+
+  local local_grip = project_dir .. "/.grip"
+  local global_grip = fake_home .. "/.grip"
+  local ok, err = pcall(fn, local_grip, global_grip)
+  vim.wait(50) -- flush any vim.schedule() callbacks queued by switch()
+
+  paths.project_root = orig_project_root
+  vim.fn.expand = orig_expand
+  vim.notify = orig_notify
+  vim.g.db = orig_g_db
+  grip.setup(orig_opts)
+  grip.open = orig_open
+  grip.open_welcome = orig_open_welcome
+  package.loaded["dadbod-grip.schema"] = orig_schema
+  package.loaded["dadbod-grip.query_pad"] = orig_query_pad
+  package.loaded["dadbod-grip.completion"] = orig_completion
+  package.loaded["dadbod-grip.adapters.duckdb"] = orig_duckdb
+  package.loaded["dadbod-grip.connections"] = orig_connections
+  connections = orig_connections
+
+  vim.fn.delete(project_dir, "rf")
+  vim.fn.delete(fake_home, "rf")
+  if not ok then error(err) end
+end
+
+-- ── read whitelist ─────────────────────────────────────────────────────────
+
+test("env_file, mode and color survive a read", function()
+  with_real_file(function(local_grip)
+    paths.ensure_dir(local_grip)
+    vim.fn.writefile({ vim.fn.json_encode({
+      { name = "dev", url = "${DB_URL}", env_file = "~/p/.env",
+        mode = "ro", color = "orange" },
+    }) }, local_grip .. "/connections.json")
+    local list = connections.list()
+    local dev
+    for _, c in ipairs(list) do if c.name == "dev" then dev = c end end
+    assert(dev, "entry loaded")
+    eq(dev.env_file, "~/p/.env", "env_file survived read")
+    eq(dev.mode, "ro", "mode survived read")
+    eq(dev.color, "orange", "color survived read")
+  end)
+end)
+
+-- ── write whitelist ────────────────────────────────────────────────────────
+
+test("the fields survive a write triggered by an unrelated mutation", function()
+  with_real_file(function(local_grip)
+    paths.ensure_dir(local_grip)
+    vim.fn.writefile({ vim.fn.json_encode({
+      { name = "dev", url = "${DB_URL}", env_file = "~/p/.env",
+        mode = "ro", color = "orange" },
+    }) }, local_grip .. "/connections.json")
+    connections.touch("${DB_URL}")
+    local raw = table.concat(vim.fn.readfile(local_grip .. "/connections.json"), "\n")
+    local data = vim.fn.json_decode(raw)
+    eq(data[1].env_file, "~/p/.env", "env_file not dropped on rewrite")
+    eq(data[1].mode, "ro", "mode not dropped on rewrite")
+    eq(data[1].color, "orange", "color not dropped on rewrite")
+  end)
+end)
+
+-- ── backwards compatibility ─────────────────────────────────────────────────
+-- An entry with none of the new fields must round-trip exactly as it does
+-- today: no new keys should appear in the JSON just because the feature
+-- exists now.
+
+test("an entry without the new fields round-trips with no new keys added", function()
+  with_real_file(function(local_grip)
+    paths.ensure_dir(local_grip)
+    vim.fn.writefile({ vim.fn.json_encode({
+      { name = "old", url = "postgresql://u:p@h/db", type = "postgresql", last_used = 100 },
+    }) }, local_grip .. "/connections.json")
+    connections.touch("postgresql://u:p@h/db")
+    local raw = table.concat(vim.fn.readfile(local_grip .. "/connections.json"), "\n")
+    local data = vim.fn.json_decode(raw)
+    eq(data[1].env_file, nil, "no env_file key materialized")
+    eq(data[1].mode, nil, "no mode key materialized")
+    eq(data[1].color, nil, "no color key materialized")
+    assert(not raw:find('"env_file"', 1, true), "raw JSON has no env_file key")
+    assert(not raw:find('"mode"', 1, true), "raw JSON has no mode key")
+    assert(not raw:find('"color"', 1, true), "raw JSON has no color key")
+  end)
+end)
+
+-- ── G:global promotion ──────────────────────────────────────────────────────
+-- Promoting a templated entry to ~/.grip/connections.json must carry the new
+-- fields, otherwise the promoted connection can't resolve its secret anymore.
+
+test("G:global carries env_file, mode and color when promoting", function()
+  with_real_file(function(local_grip, global_grip)
+    paths.ensure_dir(local_grip)
+    vim.fn.writefile({ vim.fn.json_encode({
+      { name = "dev", url = "${DB_URL}", env_file = "~/p/.env",
+        mode = "ro", color = "orange" },
+    }) }, local_grip .. "/connections.json")
+
+    local grip_picker = require("dadbod-grip.grip_picker")
+    local orig_picker_open = grip_picker.open
+    local captured
+    grip_picker.open = function(opts) captured = opts end
+
+    connections.pick()
+
+    grip_picker.open = orig_picker_open
+
+    assert(captured and captured.actions, "M.pick() reached grip_picker.open with actions")
+    local global_action
+    for _, a in ipairs(captured.actions) do
+      if a.label == "G:global" then global_action = a end
+    end
+    assert(global_action, "G:global action present")
+
+    local dev
+    for _, item in ipairs(captured.items) do
+      if item.name == "dev" then dev = item end
+    end
+    assert(dev, "dev present among picker items")
+    eq(dev.env_file, "~/p/.env", "picker item carries env_file before promotion")
+
+    global_action.fn(dev)
+
+    local raw = table.concat(vim.fn.readfile(global_grip .. "/connections.json"), "\n")
+    local gdata = vim.fn.json_decode(raw)
+    eq(gdata[1].name, "dev", "promoted entry name")
+    eq(gdata[1].env_file, "~/p/.env", "env_file promoted to global file")
+    eq(gdata[1].mode, "ro", "mode promoted to global file")
+    eq(gdata[1].color, "orange", "color promoted to global file")
+  end)
+end)
+
+-- ── list() rewriting the global file for a new g:dbs entry ────────────────
+-- M.list() rewrites ~/.grip/connections.json whenever vim.g.dbs contains a
+-- URL not yet in that file, so it can persist it there for cross-project
+-- access. That rewrite re-serializes every existing global entry too -- a
+-- third, easy-to-miss whitelist beyond read_json_connections/
+-- write_file_connections/G:global.
+
+test("list() persisting a new g:dbs entry does not drop fields off existing global entries", function()
+  with_real_file(function(local_grip, global_grip)
+    paths.ensure_dir(global_grip)
+    vim.fn.writefile({ vim.fn.json_encode({
+      { name = "existing", url = "postgresql://a/b", env_file = "~/p/.env",
+        mode = "ro", color = "orange" },
+    }) }, global_grip .. "/connections.json")
+
+    vim.g.dbs = { { name = "newdb", url = "postgresql://c/d" } }
+    local ok, err = pcall(connections.list)
+    vim.g.dbs = nil -- never leak into later specs sharing this nvim process
+    assert(ok, err)
+
+    local raw = table.concat(vim.fn.readfile(global_grip .. "/connections.json"), "\n")
+    local data = vim.fn.json_decode(raw)
+    local existing
+    for _, e in ipairs(data) do if e.name == "existing" then existing = e end end
+    assert(existing, "existing global entry still present after g:dbs-triggered rewrite")
+    eq(existing.env_file, "~/p/.env", "env_file survived g:dbs-triggered global rewrite")
+    eq(existing.mode, "ro", "mode survived g:dbs-triggered global rewrite")
+    eq(existing.color, "orange", "color survived g:dbs-triggered global rewrite")
+  end)
+end)
+
+-- ── summary ─────────────────────────────────────────────────────────────────
+
+print(string.format("\nconnections_fields_spec: %d passed, %d failed", pass, fail))
+if fail > 0 then os.exit(1) end

--- a/tests/spec/readonly_mode_spec.lua
+++ b/tests/spec/readonly_mode_spec.lua
@@ -1146,6 +1146,109 @@ test("a failed ordinary reconnect does not clear an override either", function()
   end)
 end)
 
+-- ── the connection whose read-only session is not read-only ───────────────
+-- libpq prefers a URL's own `options` keyword over PGOPTIONS instead of
+-- merging them, so exactly one shape of postgres URL takes the ro flag and
+-- opens writable anyway. Verified against a live server: a URL with
+-- `?options=-c%20statement_timeout%3D5s` reports
+-- `default_transaction_read_only = off` with PGOPTIONS set. The badge and the
+-- DDL refusals read the entry, not the server, so this connection looks the
+-- most protected of all -- hence a warning rather than a comment in the docs.
+
+test("readonly_caveat names the options= that beats PGOPTIONS", function()
+  local pg = require("dadbod-grip.adapters.postgresql")
+  assert(pg.readonly_caveat("postgresql://u:p@h/db?options=-c%20statement_timeout%3D5s"),
+    "the case reproduced live is caught")
+  assert(pg.readonly_caveat("postgresql://u:p@h/db?sslmode=require&options=-cx"),
+    "and when it is not the first parameter")
+  assert(pg.readonly_caveat("postgresql://u:p@h/db?options="),
+    "an empty options= counts: libpq falls back to PGOPTIONS only when the keyword is absent")
+  assert(pg.readonly_caveat("postgresql://u:p@h/db?options"),
+    "as does the valueless form, which parses to the same empty value")
+end)
+
+test("readonly_caveat is silent for a URL the guard does hold on", function()
+  local pg = require("dadbod-grip.adapters.postgresql")
+  eq(pg.readonly_caveat("postgresql://u:p@h/db"), nil, "no query string at all")
+  eq(pg.readonly_caveat("postgresql://u:p@h/db?sslmode=require"), nil, "an unrelated parameter")
+  -- The naive check -- find("options=") -- fires on all three of these, and
+  -- crying wolf on an ordinary connection is how a warning gets ignored on
+  -- the one that matters.
+  eq(pg.readonly_caveat("postgresql://u:p@h/db?myoptions=x"), nil,
+    "a parameter merely ending in options")
+  eq(pg.readonly_caveat("postgresql://u:p@h/options=db"), nil,
+    "the text appearing in the path rather than the query")
+  eq(pg.readonly_caveat("postgresql://u:p@h/db#options=x"), nil,
+    "or in a fragment, which libpq never reads as a parameter")
+end)
+
+test("the caveat can be shown to the user without leaking the password", function()
+  local pg = require("dadbod-grip.adapters.postgresql")
+  local caveat = pg.readonly_caveat("postgresql://u:s3cr3t@h/db?options=-cx")
+  assert(caveat, "there is a caveat to show")
+  assert(not caveat:find("s3cr3t", 1, true), "and it does not carry the password: " .. caveat)
+  assert(not caveat:find("postgresql://", 1, true), "nor the URL: " .. caveat)
+end)
+
+test("the caveat dispatch only answers for adapters that declare one", function()
+  local adapters = require("dadbod-grip.adapters")
+  assert(adapters.readonly_caveat("postgresql://u:p@h/db?options=-cx"),
+    "postgres declares one and it reaches the dispatcher")
+  eq(adapters.readonly_caveat("mysql://u:p@h/db?options=-cx"), nil,
+    "mysql sets its mode through --init-command, which no URL parameter displaces")
+  eq(adapters.readonly_caveat("sqlite:/tmp/x.sqlite?options=-cx"), nil,
+    "sqlite takes -readonly in argv, likewise undisplaceable")
+  eq(adapters.readonly_caveat("nosuchscheme://h/db?options=-cx"), nil,
+    "an unknown scheme resolves to no adapter and must not throw")
+  eq(adapters.readonly_caveat(nil), nil, "nor must a nil URL")
+end)
+
+test("connecting read-only to such a URL says so once", function()
+  with_switchable(nil, function(connections)
+    local url = "postgresql://u:p@h/opts_db?options=-c%20statement_timeout%3D5s"
+    local msgs = {}
+    vim.notify = function(m) table.insert(msgs, tostring(m)) end
+
+    eq(connections.switch(url, "opts-db", "postgresql", { mode = "ro" }), true,
+      "the switch committed")
+
+    local warned = 0
+    for _, m in ipairs(msgs) do
+      if m:find("read%-only is not enforced") then warned = warned + 1 end
+    end
+    eq(warned, 1, "warned exactly once: " .. table.concat(msgs, " / "))
+    for _, m in ipairs(msgs) do
+      assert(not m:find("opts_db", 1, true) or not m:find("read%-only is not enforced"),
+        "and the warning names no URL: " .. m)
+    end
+  end)
+end)
+
+test("it stays quiet when the promise is one the connection can keep", function()
+  with_switchable(nil, function(connections)
+    local opts_url  = "postgresql://u:p@h/opts_db?options=-cx"
+    local plain_url = "postgresql://u:p@h/plain_db"
+    local function switch_and_collect(url, name, mode)
+      local msgs = {}
+      vim.notify = function(m) table.insert(msgs, tostring(m)) end
+      connections.switch(url, name, "postgresql", mode and { mode = mode } or nil)
+      for _, m in ipairs(msgs) do
+        if m:find("read%-only is not enforced") then return true end
+      end
+      return false
+    end
+
+    eq(switch_and_collect(opts_url, "opts-db", "rw"), false,
+      "a writable connection was never promised anything to break")
+    eq(switch_and_collect(plain_url, "plain-db", "ro"), false,
+      "and a ro connection whose PGOPTIONS does take must not be second-guessed")
+    -- The r:ro/rw action routes through the same switch(), so the toggle into
+    -- read-only is the other way a user meets this and has to warn too.
+    eq(switch_and_collect(opts_url, "opts-db", "ro"), true,
+      "toggling that same connection into ro does warn")
+  end)
+end)
+
 -- ── summary ─────────────────────────────────────────────────────────────────
 
 print(string.format("\nreadonly_mode_spec: %d passed, %d failed", pass, fail))

--- a/tests/spec/readonly_mode_spec.lua
+++ b/tests/spec/readonly_mode_spec.lua
@@ -1,0 +1,1152 @@
+-- readonly_mode_spec.lua -- a connection saved with "mode": "ro" puts the
+-- database CLI itself in read-only mode and makes the schema-modifying
+-- commands decline before they prompt.
+--
+-- The adapter cases call the argv/env builders directly with an explicit opts
+-- table rather than going through a connection, because the load-bearing part
+-- is *which flags are produced*: `duckdb -readonly` on :memory: aborts with
+-- "Cannot launch in-memory database in read-only mode!", and both sqlite3 and
+-- duckdb refuse to open a not-yet-existing file read-only instead of creating
+-- it. All four builders are pure, so the assertions can be exact.
+local paths = require("dadbod-grip.paths")
+local grip = require("dadbod-grip")
+
+local pass = 0
+local fail = 0
+
+local function test(name, fn)
+  local ok, err = pcall(fn)
+  if ok then
+    pass = pass + 1
+  else
+    fail = fail + 1
+    print("FAIL: " .. name .. ": " .. tostring(err))
+  end
+end
+
+local function eq(a, b, msg)
+  assert(a == b, (msg or "") .. ": expected " .. tostring(b) .. ", got " .. tostring(a))
+end
+
+-- ── adapter argv / env builders ───────────────────────────────────────────
+
+test("postgres ro sets PGOPTIONS", function()
+  local pg = require("dadbod-grip.adapters.postgresql")
+  local env = pg._psql_env("postgresql://u:p@h/db", { readonly = true })
+  assert(env.PGOPTIONS and env.PGOPTIONS:find("default_transaction_read_only=on", 1, true),
+    "PGOPTIONS set, got: " .. tostring(env.PGOPTIONS))
+end)
+
+test("postgres rw does not set PGOPTIONS", function()
+  local pg = require("dadbod-grip.adapters.postgresql")
+  eq(pg._psql_env("postgresql://u:p@h/db", {}).PGOPTIONS, nil, "absent in rw")
+end)
+
+test("postgres ro still delivers the password out of band", function()
+  local pg = require("dadbod-grip.adapters.postgresql")
+  local env = pg._psql_env("postgresql://u:s3cr3t@h/db", { readonly = true })
+  eq(env.PGPASSWORD, "s3cr3t", "PGPASSWORD survives alongside PGOPTIONS")
+end)
+
+test("mysql merges rather than duplicates --init-command", function()
+  local my = require("dadbod-grip.adapters.mysql")
+  local args = my._mysql_args({ host = "h" }, "select 1", { readonly = true })
+  local n = 0
+  for _, a in ipairs(args) do
+    if tostring(a):match("^%-%-init%-command=") then n = n + 1 end
+  end
+  eq(n, 1, "exactly one --init-command (a second one would overwrite the first)")
+  local found = false
+  for _, a in ipairs(args) do
+    if tostring(a):find("TRANSACTION READ ONLY", 1, true)
+       and tostring(a):find("ANSI_QUOTES", 1, true) then found = true end
+  end
+  assert(found, "both the sql_mode and the read-only statement survive the merge")
+end)
+
+test("mysql rw leaves the init-command alone", function()
+  local my = require("dadbod-grip.adapters.mysql")
+  local args = my._mysql_args({ host = "h" }, "select 1", {})
+  for _, a in ipairs(args) do
+    assert(not tostring(a):find("TRANSACTION READ ONLY", 1, true),
+      "no read-only statement in rw, got: " .. tostring(a))
+  end
+  eq(args[3], "--init-command=SET sql_mode='ANSI_QUOTES,NO_BACKSLASH_ESCAPES'",
+    "rw argv is byte-identical to what it was before read-only mode existed")
+end)
+
+test("duckdb never passes -readonly for :memory:", function()
+  local dd = require("dadbod-grip.adapters.duckdb")
+  local args = dd._args("duckdb::memory:", { readonly = true })
+  for _, a in ipairs(args) do
+    assert(a ~= "-readonly", "-readonly on :memory: aborts duckdb entirely")
+  end
+end)
+
+test("duckdb passes -readonly for an existing file", function()
+  local dd = require("dadbod-grip.adapters.duckdb")
+  local f = vim.fn.tempname() .. ".duckdb"
+  vim.fn.writefile({ "" }, f)
+  local args = dd._args("duckdb:" .. f, { readonly = true })
+  local found = false
+  for _, a in ipairs(args) do if a == "-readonly" then found = true end end
+  assert(found, "-readonly applied to an existing file")
+  vim.fn.delete(f)
+end)
+
+test("duckdb never passes -readonly for a missing file", function()
+  local dd = require("dadbod-grip.adapters.duckdb")
+  local f = vim.fn.tempname() .. ".duckdb"
+  local args = dd._args("duckdb:" .. f, { readonly = true })
+  for _, a in ipairs(args) do
+    assert(a ~= "-readonly", "-readonly would turn create-on-open into an error")
+  end
+end)
+
+test("duckdb rw argv is unchanged", function()
+  local dd = require("dadbod-grip.adapters.duckdb")
+  local f = vim.fn.tempname() .. ".duckdb"
+  vim.fn.writefile({ "" }, f)
+  eq(table.concat(dd._args("duckdb:" .. f, {}, { "-csv", "-header" }), " "),
+    "duckdb -csv -header " .. f, "rw file-backed argv")
+  eq(table.concat(dd._args("duckdb::memory:", {}, { "-csv", "-header" }), " "),
+    "duckdb -csv -header", "rw :memory: argv carries no path")
+  vim.fn.delete(f)
+end)
+
+test("sqlite never passes -readonly for a missing file", function()
+  local sq = require("dadbod-grip.adapters.sqlite")
+  local args = sq._sqlite3_args("/nonexistent/db.sqlite", "select 1", { readonly = true })
+  for _, a in ipairs(args) do
+    assert(a ~= "-readonly", "-readonly would turn create-on-open into an error")
+  end
+end)
+
+test("sqlite passes -readonly for an existing file", function()
+  local sq = require("dadbod-grip.adapters.sqlite")
+  local f = vim.fn.tempname() .. ".sqlite"
+  vim.fn.writefile({ "" }, f)
+  local args = sq._sqlite3_args(f, "select 1", { readonly = true })
+  local found = false
+  for i, a in ipairs(args) do
+    if a == "-readonly" then
+      found = true
+      -- sqlite3 takes its options before the database file.
+      assert(i < #args - 1, "-readonly must precede the db path and the statement")
+    end
+  end
+  assert(found, "-readonly applied to an existing file")
+  eq(args[#args - 1], f, "db path still second-to-last")
+  eq(args[#args], "select 1", "statement still last")
+  vim.fn.delete(f)
+end)
+
+test("sqlite rw argv is unchanged", function()
+  local sq = require("dadbod-grip.adapters.sqlite")
+  local f = vim.fn.tempname() .. ".sqlite"
+  vim.fn.writefile({ "" }, f)
+  eq(table.concat(sq._sqlite3_args(f, "select 1", {}), "|"),
+    table.concat({ "sqlite3", "-init", "", "-csv", "-header", f, "select 1" }, "|"),
+    "rw argv is byte-identical to what it was before read-only mode existed")
+  vim.fn.delete(f)
+end)
+
+-- ── the grid state ────────────────────────────────────────────────────────
+
+test("data.new honors an explicit readonly flag", function()
+  local data = require("dadbod-grip.data")
+  local base = { rows = { { "1" } }, columns = { "id" }, primary_keys = { "id" },
+                 table_name = "users", url = "sqlite:/tmp/x.db", sql = "select 1" }
+  eq(data.new(base).readonly, false, "a table with a PK is editable by default")
+  base.readonly = true
+  eq(data.new(base).readonly, true, "an explicit readonly wins over having a PK")
+end)
+
+-- ── connections.current_mode ──────────────────────────────────────────────
+-- Isolation follows connections_spec.lua: paths.project_root and the fake
+-- home are patched so the real ~/.grip and the repo's own .grip are never
+-- read, and grip.setup({}) pins connections_path = nil.
+
+local RO_URL = "postgresql://u:p@h/ro_db"
+local RW_URL = "postgresql://u:p@h/rw_db"
+local BARE_URL = "postgresql://u:p@h/bare_db"
+-- A ro entry whose secret cannot resolve, for the failed-switch case, and a
+-- ro entry with a production-length name and host, for the picker row.
+local UNRESOLVABLE_URL = "postgresql://u:${GRIP_NO_SUCH_VAR_FOR_TESTS}@h/locked_db"
+-- Same shape, but the variable is one the test sets and then removes.
+local TEMPLATED_URL = "postgresql://u:${GRIP_TEST_PW}@h/tpl_db"
+local LONG_RO_URL =
+  "postgresql://warehouse_reader:hunter2@db-prod-analytics.eu-central-1.example.com:5432/warehouse"
+local LONG_RO_NAME = "prod-warehouse-readonly"
+
+--- Run fn with a connections.json holding one ro, one rw and one entry with
+--- no mode field at all (what every file written before this option looks
+--- like), and vim.g.db pointing at `initial_url`.
+---
+--- Two sqlite entries, one ro and one rw, back the end-to-end argv tests: they
+--- need a URL whose adapter actually reaches an argv builder, and a database
+--- file that exists (the `-readonly` flag is withheld for a missing one). The
+--- files are empty -- run_cmd is stubbed in those tests, so sqlite3 never runs
+--- against them. fn receives their two URLs.
+local function with_connections(initial_url, fn)
+  local project_dir = vim.fn.tempname() .. "_grip_ro_test"
+  local fake_home = project_dir .. "_home"
+  vim.fn.mkdir(project_dir .. "/.grip", "p")
+  vim.fn.mkdir(fake_home .. "/.grip", "p")
+
+  local orig_project_root = paths.project_root
+  local orig_expand = vim.fn.expand
+  local orig_notify = vim.notify
+  local orig_g_db = vim.g.db
+  local orig_b_db = vim.b.db
+  local orig_opts = grip.get_opts()
+
+  paths.project_root = function() return project_dir end
+  vim.fn.expand = function(a, ...)
+    if a == "~" then return fake_home end
+    return orig_expand(a, ...)
+  end
+  grip.setup({})
+  local ro_sqlite = "sqlite:" .. project_dir .. "/ro.sqlite"
+  local rw_sqlite = "sqlite:" .. project_dir .. "/rw.sqlite"
+  vim.fn.writefile({ "" }, project_dir .. "/ro.sqlite")
+  vim.fn.writefile({ "" }, project_dir .. "/rw.sqlite")
+  vim.fn.writefile({ vim.fn.json_encode({
+    { name = "ro-db",     url = RO_URL,   type = "postgresql", mode = "ro" },
+    { name = "rw-db",     url = RW_URL,   type = "postgresql", mode = "rw" },
+    { name = "bare-db",   url = BARE_URL, type = "postgresql" },
+    { name = "ro-sqlite", url = ro_sqlite, type = "sqlite", mode = "ro" },
+    { name = "rw-sqlite", url = rw_sqlite, type = "sqlite", mode = "rw" },
+    { name = "locked-db", url = UNRESOLVABLE_URL, type = "postgresql", mode = "ro" },
+    { name = "templated-db", url = TEMPLATED_URL, type = "postgresql", mode = "ro" },
+    { name = LONG_RO_NAME, url = LONG_RO_URL, type = "postgresql", mode = "ro" },
+  }) }, project_dir .. "/.grip/connections.json")
+  vim.g.db = initial_url
+  vim.b.db = nil
+
+  local ok, err = pcall(fn, ro_sqlite, rw_sqlite)
+
+  paths.project_root = orig_project_root
+  vim.fn.expand = orig_expand
+  vim.notify = orig_notify
+  vim.g.db = orig_g_db
+  vim.b.db = orig_b_db
+  grip.setup(orig_opts)
+  vim.fn.delete(project_dir, "rf")
+  vim.fn.delete(fake_home, "rf")
+  if not ok then error(err) end
+end
+
+test("current_mode reads the entry of the connected URL", function()
+  with_connections(RO_URL, function()
+    local connections = require("dadbod-grip.connections")
+    eq(connections.current_mode(), "ro", "vim.g.db is the ro entry")
+    eq(connections.current_mode(RW_URL), "rw", "explicit url wins over vim.g.db")
+    eq(connections.current_mode(BARE_URL), "rw", "an entry with no mode field is rw")
+    eq(connections.current_mode("postgresql://u:p@h/unsaved"), "rw", "an unsaved url is rw")
+  end)
+end)
+
+test("current_mode is rw with no connection at all", function()
+  with_connections(nil, function()
+    eq(require("dadbod-grip.connections").current_mode(), "rw", "never nil")
+  end)
+end)
+
+test("current_mode prefers vim.b.db over vim.g.db", function()
+  with_connections(RW_URL, function()
+    vim.b.db = RO_URL
+    eq(require("dadbod-grip.connections").current_mode(), "ro", "buffer-local connection wins")
+  end)
+end)
+
+test("db.is_readonly is true on a ro connection and false on a rw one", function()
+  with_connections(RO_URL, function()
+    local db = require("dadbod-grip.db")
+    eq(db.is_readonly(RO_URL), true, "ro entry")
+    eq(db.is_readonly(RW_URL), false, "rw entry")
+    eq(db.is_readonly(BARE_URL), false, "entry with no mode field")
+  end)
+end)
+
+test("adapters.session_opts follows the connection mode", function()
+  with_connections(RO_URL, function()
+    eq(require("dadbod-grip.adapters").session_opts().readonly, true, "ro")
+    vim.g.db = RW_URL
+    eq(require("dadbod-grip.adapters").session_opts().readonly, false, "rw")
+  end)
+end)
+
+-- ── end to end: db.query(sql, url) → argv ─────────────────────────────────
+-- The assertions above call the builders directly, which cannot see how the
+-- mode reaches them. That is the gap I1 shipped through: the adapters read the
+-- *ambient* connection while db.is_readonly read the URL it was given, so the
+-- two disagreed the moment a grid or sidebar outlived a :GripConnect. These
+-- drive the whole path -- db.query → resolve → adapter → argv -- with the URL
+-- and the ambient connection deliberately different.
+
+--- The argv of the one CLI spawn db.query(url) makes. run_cmd is stubbed, so
+--- no process runs; a spawn that never happens is an error, not a skip.
+local function argv_for_query(url)
+  local adapters_mod = require("dadbod-grip.adapters")
+  local orig = adapters_mod.run_cmd
+  local seen
+  adapters_mod.run_cmd = function(args) seen = args; return "", "", 0 end
+  local _, err = require("dadbod-grip.db").query("SELECT 1", url)
+  adapters_mod.run_cmd = orig
+  assert(seen, "no CLI spawn happened; db.query said: " .. tostring(err))
+  return seen
+end
+
+local function has_readonly(args)
+  for _, a in ipairs(args) do
+    if a == "-readonly" then return true end
+  end
+  return false
+end
+
+test("db.query reads the mode of the URL it is given, not the ambient one", function()
+  with_connections(nil, function(ro_sqlite, rw_sqlite)
+    vim.g.db = rw_sqlite
+    assert(has_readonly(argv_for_query(ro_sqlite)),
+      "a ro URL must spawn read-only even while the ambient connection is rw: "
+      .. table.concat(argv_for_query(ro_sqlite), " "))
+  end)
+end)
+
+test("db.query leaves a rw URL writable while the ambient connection is ro", function()
+  with_connections(nil, function(ro_sqlite, rw_sqlite)
+    vim.g.db = ro_sqlite
+    assert(not has_readonly(argv_for_query(rw_sqlite)),
+      "a rw connection must not be spawned read-only because another one is ro: "
+      .. table.concat(argv_for_query(rw_sqlite), " "))
+  end)
+end)
+
+test("db.query treats an unsaved URL as rw whatever the ambient connection is", function()
+  with_connections(nil, function(ro_sqlite)
+    vim.g.db = ro_sqlite
+    local unsaved = "sqlite:" .. vim.fn.tempname() .. ".sqlite"
+    vim.fn.writefile({ "" }, unsaved:sub(#"sqlite:" + 1))
+    assert(not has_readonly(argv_for_query(unsaved)), "an unsaved URL has no mode, so rw")
+    vim.fn.delete(unsaved:sub(#"sqlite:" + 1))
+  end)
+end)
+
+test("db.query with no URL still follows the ambient connection", function()
+  with_connections(nil, function(ro_sqlite, rw_sqlite)
+    vim.g.db = ro_sqlite
+    assert(has_readonly(argv_for_query(nil)), "ambient ro")
+    vim.g.db = rw_sqlite
+    assert(not has_readonly(argv_for_query(nil)), "ambient rw")
+  end)
+end)
+
+test("the published mode is unpublished again when the db call returns", function()
+  with_connections(nil, function(ro_sqlite, rw_sqlite)
+    local adapters_mod = require("dadbod-grip.adapters")
+    vim.g.db = rw_sqlite
+    argv_for_query(ro_sqlite)  -- publishes readonly = true for its duration
+    eq(adapters_mod.session_opts().readonly, false,
+      "outside a db.* call session_opts must be back on the ambient connection")
+  end)
+end)
+
+test("vim.b.db wins over vim.g.db end to end", function()
+  with_connections(nil, function(ro_sqlite, rw_sqlite)
+    vim.g.db = rw_sqlite
+    vim.b.db = ro_sqlite
+    local args = argv_for_query(nil)
+    vim.b.db = nil
+    assert(has_readonly(args), "the buffer-local connection is the one being queried")
+  end)
+end)
+
+-- ── the three ways the published mode can be lost ─────────────────────────
+-- via_adapter publishes the mode for the duration of one db.* call. Three
+-- things can strip it before the argv is built, and none of them was covered
+-- until a reviewer reproduced two of them by hand.
+
+test("the async path builds its argv while the mode is still published", function()
+  with_connections(nil, function(ro_sqlite, rw_sqlite)
+    vim.g.db = rw_sqlite  -- ambient rw: -readonly can only come from the URL
+    local adapters_mod = require("dadbod-grip.adapters")
+    local orig = adapters_mod.run_cmd_async
+    local seen
+    adapters_mod.run_cmd_async = function(args, _, cb)
+      seen = args
+      vim.schedule(function() cb("", "", 1) end)
+    end
+    local done = false
+    require("dadbod-grip.db").get_schema_batch_async(ro_sqlite, function() done = true end)
+    vim.wait(1000, function() return done end, 1)
+    adapters_mod.run_cmd_async = orig
+
+    assert(seen, "no async spawn happened")
+    assert(has_readonly(seen),
+      "the async argv is built after the callback is registered but before the call returns, "
+      .. "so it must still see the mode: " .. table.concat(seen, " "))
+  end)
+end)
+
+test("a db.* call landing inside a blocking spawn leaves the outer call's mode alone", function()
+  with_connections(nil, function(ro_sqlite, rw_sqlite)
+    vim.g.db = rw_sqlite
+    -- Real databases and real spawns: run_cmd has to actually block in
+    -- vim.wait, which pumps the main loop, for the scheduled call below to
+    -- land in the middle of the outer one. That is the whole mechanism.
+    local ro_path = ro_sqlite:sub(#"sqlite:" + 1)
+    local rw_path = rw_sqlite:sub(#"sqlite:" + 1)
+    vim.fn.system({ "sqlite3", ro_path, "create table t(id integer); insert into t values (1);" })
+    vim.fn.system({ "sqlite3", rw_path, "create table t(id integer);" })
+
+    local adapters_mod = require("dadbod-grip.adapters")
+    local db = require("dadbod-grip.db")
+    local spawns = {}
+    local orig = adapters_mod.run_cmd
+    adapters_mod.run_cmd = function(args, timeout_ms, opts)
+      local ro = false
+      for _, a in ipairs(args) do
+        if a == "-readonly" then ro = true end
+      end
+      table.insert(spawns, { ro = ro, file = (args[#args - 1] or ""):match("([^/]+)$") or "?" })
+      return orig(args, timeout_ms, opts)
+    end
+
+    -- The shape of init.lua's scheduled column-info fetch, on the other
+    -- connection. get_table_stats is the outer call: it spawns twice.
+    vim.schedule(function() db.get_column_info("t", rw_sqlite) end)
+    db.get_table_stats("t", ro_sqlite)
+    adapters_mod.run_cmd = orig
+
+    local first_nested, last_outer, outer_n, lost = nil, nil, 0, 0
+    for i, s in ipairs(spawns) do
+      if s.file == "rw.sqlite" then
+        first_nested = first_nested or i
+      elseif s.file == "ro.sqlite" then
+        last_outer = i
+        outer_n = outer_n + 1
+        if not s.ro then lost = lost + 1 end
+      end
+    end
+    eq(outer_n, 2, "the outer call spawned twice")
+    -- Both comparisons are load-bearing. Without them the test could pass
+    -- while proving nothing: `< last_outer` alone still goes green for a
+    -- nested call that ran to completion *before* the outer one started, so
+    -- `> 1` is what actually pins the interleaving.
+    assert(first_nested and last_outer and first_nested > 1 and first_nested < last_outer,
+      "the scheduled call must land between the outer call's two spawns")
+    eq(lost, 0, "every spawn of the outer call kept the mode of its own connection")
+  end)
+end)
+
+test("a throw inside an adapter restores the published mode and is re-raised", function()
+  with_connections(nil, function(ro_sqlite, rw_sqlite)
+    vim.g.db = rw_sqlite
+    local adapters_mod = require("dadbod-grip.adapters")
+    local sq = require("dadbod-grip.adapters.sqlite")
+    local orig = sq.query
+    sq.query = function() error("boom from the adapter") end
+    local ok, err = pcall(require("dadbod-grip.db").query, "SELECT 1", ro_sqlite)
+    sq.query = orig
+
+    eq(ok, false, "the error propagates rather than being swallowed")
+    assert(tostring(err):find("boom from the adapter", 1, true),
+      "re-raised unchanged, got: " .. tostring(err))
+    eq(adapters_mod.session_opts().readonly, false,
+      "the published mode was restored on the error path, not stranded")
+  end)
+end)
+
+-- ── DDL commands decline ──────────────────────────────────────────────────
+
+--- Run `action` with the ddl module and db.execute stubbed out, and return
+--- (notified_messages, ddl_calls). A recorded call means the refusal did not
+--- happen: ddl.create_table / drop_table open the interactive form, and
+--- :GripRename old new goes straight to db.execute with an ALTER TABLE.
+---
+--- A grip session is installed on the current buffer unless opts.no_session:
+--- :GripRename and :GripFill bail out early without one, so a spec that
+--- skipped this would "pass" against a build with no read-only guard at all.
+local function capture(action, opts)
+  opts = opts or {}
+  local msgs = {}
+  local ddl_calls = {}
+  local orig_ddl = package.loaded["dadbod-grip.ddl"]
+  local orig_notify = vim.notify
+  local orig_execute = require("dadbod-grip.db").execute
+  local view = require("dadbod-grip.view")
+  local bufnr = vim.api.nvim_get_current_buf()
+  local orig_session = view._sessions[bufnr]
+  if not opts.no_session then
+    -- opts.session_url models the ordinary drift this feature has to survive:
+    -- a grid opened on one connection, then a :GripConnect to another.
+    local surl = opts.session_url or vim.g.db
+    view._sessions[bufnr] = {
+      url = surl,
+      state = { table_name = "users", url = surl, pks = { "id" }, rows = {}, columns = { "id" } },
+    }
+  else
+    view._sessions[bufnr] = nil
+  end
+
+  package.loaded["dadbod-grip.ddl"] = {
+    create_table  = function() table.insert(ddl_calls, "create_table") end,
+    drop_table    = function() table.insert(ddl_calls, "drop_table") end,
+    rename_column = function() table.insert(ddl_calls, "rename_column") end,
+    add_column    = function() table.insert(ddl_calls, "add_column") end,
+  }
+  require("dadbod-grip.db").execute = function()
+    table.insert(ddl_calls, "execute")
+    return { affected = 0 }, nil
+  end
+  vim.notify = function(m) table.insert(msgs, tostring(m)) end
+
+  local ok, err = pcall(action)
+
+  vim.notify = orig_notify
+  require("dadbod-grip.db").execute = orig_execute
+  package.loaded["dadbod-grip.ddl"] = orig_ddl
+  view._sessions[bufnr] = orig_session
+  if not ok then error(err) end
+  return msgs, ddl_calls
+end
+
+local function run_command(cmd, opts)
+  return capture(function() vim.cmd(cmd) end, opts)
+end
+
+test("DDL commands decline on a read-only connection", function()
+  with_connections(RO_URL, function()
+    grip.setup({})  -- registers the user commands against the patched paths
+    for _, case in ipairs({
+      { cmd = "GripDrop users",        name = "GripDrop" },
+      { cmd = "GripCreate",            name = "GripCreate" },
+      { cmd = "GripRename a b",        name = "GripRename" },
+      { cmd = "GripFill 1",            name = "GripFill" },
+    }) do
+      local msgs, ddl_calls = run_command(case.cmd)
+      eq(#ddl_calls, 0, case.name .. " reached no DDL/execute path")
+      eq(#msgs, 1, case.name .. " notified exactly once")
+      eq(msgs[1], case.name .. ": Connection is read-only (mode = ro)",
+        case.name .. " names the mode")
+      assert(not msgs[1]:find("postgresql://", 1, true),
+        case.name .. " message must not carry a URL: " .. msgs[1])
+    end
+  end)
+end)
+
+test("DDL commands are not blocked on a rw connection", function()
+  with_connections(RW_URL, function()
+    grip.setup({})
+    local msgs, ddl_calls = run_command("GripDrop users")
+    eq(#ddl_calls, 1, "GripDrop reached the ddl module")
+    eq(ddl_calls[1], "drop_table", "and it is the drop it was asked for")
+    eq(#msgs, 0, "no refusal on rw: " .. table.concat(msgs, " / "))
+
+    -- :GripRename runs its ALTER TABLE through db.execute directly, so this
+    -- is the case that proves the ro run above stopped a real statement.
+    local rn_msgs, rn_calls = run_command("GripRename a b")
+    eq(rn_calls[1], "execute", "GripRename executed the ALTER TABLE on rw")
+    assert(not (rn_msgs[1] or ""):find("read-only", 1, true),
+      "no read-only refusal on rw: " .. tostring(rn_msgs[1]))
+  end)
+end)
+
+-- ── the guard and the action must read the same connection ────────────────
+-- :GripRename is the one command whose action runs against session.url rather
+-- than the ambient connection, and it used to guard the ambient one. With a
+-- grid still open on a ro connection after a :GripConnect to a rw one, the
+-- ALTER went through unrefused.
+
+test("GripRename guards the session's connection, not the ambient one", function()
+  with_connections(RW_URL, function()
+    grip.setup({})
+    local msgs, calls = run_command("GripRename a b", { session_url = RO_URL })
+    eq(#calls, 0, "no ALTER reached db.execute")
+    eq(msgs[1], "GripRename: Connection is read-only (mode = ro)", "names the mode")
+  end)
+end)
+
+test("GripRename still renames when the session's connection is rw", function()
+  with_connections(RO_URL, function()
+    grip.setup({})
+    local msgs, calls = run_command("GripRename a b", { session_url = RW_URL })
+    eq(calls[1], "execute", "the ALTER ran: a ro *ambient* connection must not block a rw session")
+    assert(not (msgs[1] or ""):find("read-only", 1, true),
+      "no refusal: " .. tostring(msgs[1]))
+  end)
+end)
+
+test("GripFill guards the session's connection, not the ambient one", function()
+  with_connections(RO_URL, function(_, rw_sqlite)
+    grip.setup({})
+    -- Ambient ro, session rw: neither GripFill guard may refuse. The AI module
+    -- and the CLI are stubbed out -- reaching generate_rows is the assertion,
+    -- and letting the real one run would put a request on the network.
+    local adapters_mod = require("dadbod-grip.adapters")
+    local orig_run, orig_ai = adapters_mod.run_cmd, package.loaded["dadbod-grip.ai"]
+    local reached_ai = false
+    adapters_mod.run_cmd = function() return "", "", 0 end
+    package.loaded["dadbod-grip.ai"] = {
+      _format_ddl_line = function() return "users(id integer)" end,
+      generate_rows = function(_, _, _, _, _, cb) reached_ai = true; cb(nil, "stubbed") end,
+    }
+
+    local msgs = run_command("GripFill 1", { session_url = rw_sqlite })
+
+    adapters_mod.run_cmd = orig_run
+    package.loaded["dadbod-grip.ai"] = orig_ai
+    assert(reached_ai,
+      "a rw session must not be refused because the ambient connection is ro; got: "
+      .. tostring(msgs[1]))
+  end)
+end)
+
+-- ── GripFill's two guards, one test each ──────────────────────────────────
+-- :GripFill and the AI keymap are separate entry points into the same work,
+-- and each has its own guard. The pair is not redundant, but only because the
+-- command guard runs before do_fill_rows' session checks; these two tests pin
+-- exactly that, so neither guard can be deleted as dead code.
+
+test("the :GripFill guard answers before the session checks do", function()
+  with_connections(RO_URL, function()
+    grip.setup({})
+    local msgs = run_command("GripFill 1", { no_session = true })
+    eq(msgs[1], "GripFill: Connection is read-only (mode = ro)",
+      "the mode is the reason, not the missing session")
+  end)
+end)
+
+test("the do_fill_rows guard covers the AI keymap path", function()
+  with_connections(RO_URL, function()
+    grip.setup({})
+    -- keymaps_ai.lua calls this directly, never going through :GripFill.
+    local msgs, calls = capture(function() grip.do_fill_rows(1) end)
+    eq(#calls, 0, "no DDL/execute reached")
+    eq(msgs[1], "GripFill: Connection is read-only (mode = ro)",
+      "the mode is the reason, not the adapter")
+  end)
+end)
+
+-- ── the properties float's DDL keymaps ────────────────────────────────────
+-- One of the six non-command DDL entry points, driven for real: the float is
+-- opened against a ro connection and "+" (add column) is pressed. The others
+-- (the schema sidebar's drop/create, the float's R/T/D, the grid's gN) take
+-- the identical one-line guard but are covered by inspection only.
+
+--- Open the properties float against `url` with the metadata queries mocked,
+--- press `lhs`, and return (messages, ddl_calls). Closes the float again.
+local function press_properties_key(url, lhs)
+  local properties = require("dadbod-grip.properties")
+  local db = require("dadbod-grip.db")
+  local orig = {}
+  for _, k in ipairs({ "get_column_info", "get_primary_keys", "get_foreign_keys",
+                       "get_indexes", "get_table_stats" }) do
+    orig[k] = db[k]
+  end
+  db.get_column_info = function()
+    return { { column_name = "id", data_type = "integer", is_nullable = "NO", column_default = "" } }
+  end
+  db.get_primary_keys = function() return {} end
+  db.get_foreign_keys = function() return {} end
+  db.get_indexes      = function() return {} end
+  db.get_table_stats  = function() return { row_estimate = 0, size_bytes = 0 } end
+
+  local win, buf = properties.open("users", url)
+  local pressed = false
+  local msgs, calls = capture(function()
+    for _, m in ipairs(vim.api.nvim_buf_get_keymap(buf, "n")) do
+      if m.lhs == lhs and m.callback then
+        pressed = true
+        m.callback()
+        break
+      end
+    end
+  end)
+
+  if vim.api.nvim_win_is_valid(win) then vim.api.nvim_win_close(win, true) end
+  if vim.api.nvim_buf_is_valid(buf) then vim.api.nvim_buf_delete(buf, { force = true }) end
+  for k, v in pairs(orig) do db[k] = v end
+  assert(pressed, lhs .. " keymap must be registered on the properties float")
+  return msgs, calls
+end
+
+test("the properties float declines + (add column) on a read-only connection", function()
+  with_connections(RO_URL, function()
+    local msgs, calls = press_properties_key(RO_URL, "+")
+    eq(#calls, 0, "ddl.add_column not reached")
+    eq(msgs[1], "Add column: Connection is read-only (mode = ro)", "names the action and the mode")
+    assert(not msgs[1]:find("postgresql://", 1, true), "message must not carry a URL")
+  end)
+end)
+
+test("the properties float reports the real problem before the mode", function()
+  with_connections(RO_URL, function()
+    -- Cursor on the header line, not a column row. The guard sits after each
+    -- keymap's own precondition, so "read-only" must not shadow the reason the
+    -- keypress could not have worked anyway.
+    local msgs = press_properties_key(RO_URL, "R")
+    eq(msgs[1], "Move cursor to a column row", "the cursor problem wins")
+  end)
+end)
+
+test("the properties float still adds a column on a rw connection", function()
+  with_connections(RW_URL, function()
+    local msgs, calls = press_properties_key(RW_URL, "+")
+    eq(calls[1], "add_column", "ddl.add_column reached")
+    eq(#msgs, 0, "no refusal on rw: " .. table.concat(msgs, " / "))
+  end)
+end)
+
+-- ── the winbar RO badge ───────────────────────────────────────────────────
+-- The badge answers "how is this grid connected right now", so it reads the
+-- session's own URL through current_mode -- which is also what makes it
+-- follow a session override rather than only the stored field.
+
+--- Render the winbar for a throwaway grid session on `url` and return it.
+local function winbar_for(url)
+  local view = require("dadbod-grip.view")
+  local bufnr = vim.api.nvim_create_buf(false, true)
+  local orig_buf = vim.api.nvim_get_current_buf()
+  vim.api.nvim_set_current_buf(bufnr)
+  view._sessions[bufnr] = { url = url, state = { table_name = "users", url = url } }
+  view._update_winbar(bufnr)
+  local bar = vim.wo[vim.api.nvim_get_current_win()].winbar
+  view._sessions[bufnr] = nil
+  vim.api.nvim_set_current_buf(orig_buf)
+  vim.api.nvim_buf_delete(bufnr, { force = true })
+  vim.wo[vim.api.nvim_get_current_win()].winbar = nil
+  return bar or ""
+end
+
+test("the winbar shows RO on a read-only session and nothing on a rw one", function()
+  with_connections(RW_URL, function()
+    -- Ambient rw throughout: the badge must come from the session's own URL.
+    assert(winbar_for(RO_URL):find("RO", 1, true), "ro session badged")
+    assert(not winbar_for(RW_URL):find("RO", 1, true),
+      "rw session unbadged, got: " .. winbar_for(RW_URL))
+    assert(not winbar_for(BARE_URL):find("RO", 1, true),
+      "an entry with no mode field is rw, so unbadged")
+  end)
+end)
+
+test("the RO badge is highlighted rather than plain text", function()
+  with_connections(RO_URL, function()
+    assert(winbar_for(RO_URL):find("%#GripReadonly#RO", 1, true),
+      "badge carries its highlight group: " .. winbar_for(RO_URL))
+  end)
+end)
+
+--- A grid session on `url` that stays alive across calls, so its winbar cache
+--- is warm -- which winbar_for's throwaway session can never be. fn gets a
+--- bar() that re-renders the winbar the way a CursorMoved does and returns it.
+local function with_live_session(url, fn)
+  local view = require("dadbod-grip.view")
+  local bufnr = vim.api.nvim_create_buf(false, true)
+  local orig_buf = vim.api.nvim_get_current_buf()
+  vim.api.nvim_set_current_buf(bufnr)
+  local win = vim.api.nvim_get_current_win()
+  view._sessions[bufnr] = { url = url, state = { table_name = "users", url = url } }
+  -- bar() re-renders the way a CursorMoved does; raw() reads the option as it
+  -- stands, which is what the user is looking at until they move the cursor.
+  local ok, err = pcall(fn, function()
+    view._update_winbar(bufnr)
+    return vim.wo[win].winbar or ""
+  end, function() return vim.wo[win].winbar or "" end)
+  view._sessions[bufnr] = nil
+  vim.api.nvim_set_current_buf(orig_buf)
+  vim.api.nvim_buf_delete(bufnr, { force = true })
+  vim.wo[win].winbar = nil
+  if not ok then error(err) end
+end
+
+-- ── the picker's r:ro/rw action ───────────────────────────────────────────
+-- A one-shot session override: the entry on disk keeps saying what it said,
+-- and reconnecting the ordinary way puts the connection back on it.
+
+--- with_connections plus the stubs M.switch() needs to be callable headless,
+--- and a freshly required connections module so the module-local override
+--- table starts empty -- a test inheriting another test's override would
+--- prove nothing. fn receives that module instance.
+---
+--- getcwd is pointed at the temp project too: the picker lists the data files
+--- it finds in the working directory and pads every row to the longest name
+--- among them, so from the repo root the row layout would depend on whatever
+--- .json/.csv files happen to sit there. Patched rather than :lcd'd -- Lua's
+--- package.path is cwd-relative under the test runner, and a real chdir stops
+--- `require("dadbod-grip.…")` from resolving at all.
+local function with_switchable(initial_url, fn)
+  with_connections(initial_url, function(ro_sqlite, rw_sqlite)
+    local orig_getcwd = vim.fn.getcwd
+    vim.fn.getcwd = function() return paths.project_root() end
+    local saved = {
+      schema     = package.loaded["dadbod-grip.schema"],
+      query_pad  = package.loaded["dadbod-grip.query_pad"],
+      completion = package.loaded["dadbod-grip.completion"],
+      conns      = package.loaded["dadbod-grip.connections"],
+      open       = grip.open,
+      welcome    = grip.open_welcome,
+    }
+    package.loaded["dadbod-grip.schema"] = {
+      is_open = function() return true end, refresh = function() end,
+      toggle = function() end, get_winid = function() return nil end,
+    }
+    package.loaded["dadbod-grip.query_pad"]  = { open = function() end }
+    package.loaded["dadbod-grip.completion"] = {
+      invalidate = function() end, warm_schema = function() end,
+    }
+    grip.open, grip.open_welcome = function() end, function() end
+    vim.notify = function() end  -- with_connections restores the original
+    package.loaded["dadbod-grip.connections"] = nil
+    local connections = require("dadbod-grip.connections")
+
+    local ok, err = pcall(fn, connections, ro_sqlite, rw_sqlite)
+    vim.wait(50)  -- flush the vim.schedule() callbacks switch() queues
+
+    package.loaded["dadbod-grip.schema"]      = saved.schema
+    package.loaded["dadbod-grip.query_pad"]   = saved.query_pad
+    package.loaded["dadbod-grip.completion"]  = saved.completion
+    package.loaded["dadbod-grip.connections"] = saved.conns
+    grip.open, grip.open_welcome = saved.open, saved.welcome
+    vim.fn.getcwd = orig_getcwd
+    if not ok then error(err) end
+  end)
+end
+
+--- The opts grip_picker.open() would have been called with, plus the action
+--- with `key`, plus the picker item named `name`.
+local function picker_action(connections, key, name)
+  local grip_picker = require("dadbod-grip.grip_picker")
+  local orig = grip_picker.open
+  local captured
+  grip_picker.open = function(o) captured = o end
+  connections.pick()
+  grip_picker.open = orig
+  assert(captured and captured.actions, "M.pick() reached grip_picker.open with actions")
+  local action
+  for _, a in ipairs(captured.actions) do
+    if a.key == key then action = a end
+  end
+  assert(action, key .. " action present in the connections picker")
+  local item
+  for _, c in ipairs(captured.items) do
+    if c.name == name then item = c end
+  end
+  assert(item, "picker item '" .. tostring(name) .. "' present")
+  return captured, action, item
+end
+
+test("the picker row shows RO for an entry defaulting to read-only", function()
+  with_switchable(nil, function(connections)
+    local captured, _, ro_item = picker_action(connections, "r", "ro-db")
+    assert(captured.display(ro_item):find("RO", 1, true),
+      "ro entry marked: " .. captured.display(ro_item))
+    for _, c in ipairs(captured.items) do
+      if c.name == "rw-db" or c.name == "bare-db" then
+        assert(not captured.display(c):find("RO", 1, true),
+          c.name .. " must not be marked: " .. captured.display(c))
+      end
+    end
+  end)
+end)
+
+-- ── the row as it is actually rendered ────────────────────────────────────
+-- display() is not the whole story: grip_picker cuts any row wider than the
+-- float (width - 6, the float capping at 70 columns) and appends "…". A
+-- marker that trails the URL is the first thing cut, and the rows most likely
+-- to be read-only -- long production names, long hosts -- are exactly the
+-- ones that overrun. So this drives the real picker and reads its buffer.
+
+--- Open the connections picker for real and return (lines, popup_buf).
+local function open_real_picker(connections)
+  local before = {}
+  for _, b in ipairs(vim.api.nvim_list_bufs()) do before[b] = true end
+  connections.pick()
+  local buf
+  for _, b in ipairs(vim.api.nvim_list_bufs()) do
+    if not before[b] and vim.api.nvim_buf_is_valid(b) then buf = b; break end
+  end
+  assert(buf, "the picker opened a buffer")
+  return vim.api.nvim_buf_get_lines(buf, 0, -1, false), buf
+end
+
+local function close_floats()
+  for _, win in ipairs(vim.api.nvim_list_wins()) do
+    local ok, cfg = pcall(vim.api.nvim_win_get_config, win)
+    if ok and cfg.relative ~= "" then pcall(vim.api.nvim_win_close, win, true) end
+  end
+end
+
+--- The rendered row containing `frag`, or nil.
+local function row_with(lines, frag)
+  for _, l in ipairs(lines) do
+    if l:find(frag, 1, true) then return l end
+  end
+end
+
+--- Press a buffer-local normal-mode map, as tests/spec/grip_picker_spec.lua does.
+local function press(buf, key)
+  for _, m in ipairs(vim.api.nvim_buf_get_keymap(buf, "n")) do
+    if m.lhs == key and m.callback then m.callback(); return true end
+  end
+  return false
+end
+
+test("the rendered row keeps RO on a production-length name and url", function()
+  with_switchable(nil, function(connections)
+    local orig_columns = vim.o.columns
+    vim.o.columns = 80  -- the float caps at 70, so rows are cut at 64 bytes
+    local ok, err = pcall(function()
+      local lines, buf = open_real_picker(connections)
+      local row = row_with(lines, LONG_RO_NAME)
+      assert(row, "the long entry is rendered: " .. table.concat(lines, "\n"))
+      assert(row:find("RO", 1, true),
+        "RO survives truncation of a long row: [" .. row .. "]")
+      assert(row:find("…", 1, true),
+        "and this row really is being truncated, or the case proves nothing: [" .. row .. "]")
+
+      -- M:mask reveals the full URL, lengthening the row further -- the case
+      -- that lost the marker unconditionally when it trailed the URL.
+      for _ = 1, #lines do
+        local cur = row_with(vim.api.nvim_buf_get_lines(buf, 0, -1, false), "▶")
+        if cur and cur:find(LONG_RO_NAME, 1, true) then break end
+        assert(press(buf, "j"), "j is mapped")
+      end
+      assert(press(buf, "M"), "M is mapped")
+      local unmasked = row_with(vim.api.nvim_buf_get_lines(buf, 0, -1, false), LONG_RO_NAME)
+      assert(unmasked and unmasked:find("RO postg", 1, true),
+        "RO survives with the password revealed -- and the raw url really is "
+        .. "showing (short_url drops the scheme, the unmasked one keeps it), "
+        .. "or M never landed on this row: [" .. tostring(unmasked) .. "]")
+    end)
+    close_floats()
+    vim.o.columns = orig_columns
+    if not ok then error(err) end
+  end)
+end)
+
+test("the RO column costs nothing when no entry is read-only", function()
+  with_switchable(nil, function(connections)
+    -- With a ro entry in the file every row reserves the column, so the
+    -- non-ro rows are indented by it.
+    local with_ro, _, rw_item = picker_action(connections, "r", "rw-db")
+    local url_at_with = with_ro.display(rw_item):find("h/rw_db", 1, true)
+    assert(url_at_with, "the url is on the row at all: [" .. with_ro.display(rw_item) .. "]")
+
+    -- Rewrite the file with every mode flipped to rw and nothing else
+    -- touched -- same names, so the name column is unchanged and the only
+    -- difference left is the marker's own column.
+    vim.fn.writefile({ vim.fn.json_encode({
+      { name = "rw-db",      url = RW_URL,      type = "postgresql", mode = "rw" },
+      { name = "bare-db",    url = BARE_URL,    type = "postgresql" },
+      { name = LONG_RO_NAME, url = LONG_RO_URL, type = "postgresql", mode = "rw" },
+    }) }, paths.project_root() .. "/.grip/connections.json")
+    local without, _, rw_again = picker_action(connections, "r", "rw-db")
+    eq(#with_ro.display(rw_item) - #without.display(rw_again), 3,
+      "no ro entry, no column: [" .. with_ro.display(rw_item) .. "] vs ["
+      .. without.display(rw_again) .. "]")
+    -- Where the url *starts*, not just how long the row is: the name column
+    -- pads to the same width in both renders, so a run of blanks before the
+    -- url proves nothing on its own -- only the shift does.
+    local url_at_without = without.display(rw_again):find("h/rw_db", 1, true)
+    eq(url_at_with - url_at_without, 3,
+      "the url sits exactly three columns later while the marker column exists")
+  end)
+end)
+
+test("r:ro/rw is labelled and closes the picker", function()
+  with_switchable(nil, function(connections)
+    local _, action = picker_action(connections, "r", "ro-db")
+    eq(action.label, "r:ro/rw", "footer label")
+    eq(action.close_on_select, true, "connecting closes the picker, like <CR>")
+  end)
+end)
+
+test("r:ro/rw is offered on a database connection and withheld elsewhere", function()
+  with_switchable(nil, function(connections, ro_sqlite)
+    local _, action, ro_item = picker_action(connections, "r", "ro-db")
+    eq(action.when(ro_item), true, "offered on a saved database connection")
+    -- A file-backed *database* is not a "local file": sqlite3/duckdb take
+    -- -readonly on one, so the toggle means something there.
+    eq(action.when({ name = "ro-sqlite", url = ro_sqlite, type = "sqlite" }), true,
+      "offered on a sqlite database")
+    for _, item in ipairs({
+      { name = "global",  url = "", _section_header = true },
+      { name = "+ New",   url = "", _new = true },
+      { name = "~ Once",  url = "", _temp = true },
+      { name = "d.csv",   url = "/tmp/d.csv", _local_file = true },
+      { name = "sales",   url = "/tmp/sales.parquet", type = "file" },
+      { name = "web",     url = "https://example.com/x.csv" },
+      { name = "mssql",   url = "sqlserver://u:p@h/db", type = "sqlserver" },
+    }) do
+      eq(action.when(item), false, "withheld on " .. item.name)
+    end
+  end)
+end)
+
+test("r:ro/rw connects a rw entry read-only without touching the file", function()
+  with_switchable(nil, function(connections)
+    local _, action, bare = picker_action(connections, "r", "bare-db")
+    eq(connections.current_mode(BARE_URL), "rw", "the entry's own default")
+    action.fn(bare)
+    eq(connections.current_mode(BARE_URL), "ro", "the session override wins")
+    eq(connections.entry_for(BARE_URL).mode, nil,
+      "the saved entry is untouched: an override is never written to connections.json")
+    eq(require("dadbod-grip.db").is_readonly(BARE_URL), true,
+      "the override reaches the grid/adapter gate, not just the badge")
+  end)
+end)
+
+test("r:ro/rw declines the rows it is withheld from, not just hides itself", function()
+  with_switchable(nil, function(connections)
+    -- grip_picker fires fn regardless of the `when` predicate, so `when`
+    -- returning false is not on its own a guarantee that nothing happens:
+    -- fn has to refuse too, or a keypress on a hidden action sets an
+    -- override on an entry that can never honour it.
+    local _, action = picker_action(connections, "r", "ro-db")
+    for _, item in ipairs({
+      { name = "mssql", url = "sqlserver://u:p@h/db", type = "sqlserver" },
+      { name = "sales", url = "/tmp/sales.parquet",   type = "file" },
+      { name = "d.csv", url = "/tmp/d.csv",           _local_file = true },
+    }) do
+      action.fn(item)
+      eq(connections.current_mode(item.url), "rw",
+        "no override taken on " .. item.name .. ", where the action is withheld")
+    end
+  end)
+end)
+
+test("r:ro/rw connects a ro entry writable", function()
+  with_switchable(nil, function(connections)
+    local _, action, ro_item = picker_action(connections, "r", "ro-db")
+    action.fn(ro_item)
+    eq(connections.current_mode(RO_URL), "rw", "opened writable for this session")
+    eq(connections.entry_for(RO_URL).mode, "ro", "the saved entry still says ro")
+  end)
+end)
+
+test("an override applies to that connection only", function()
+  with_switchable(nil, function(connections)
+    -- bare-db is the one overridden, and it is overridden *to* ro: a test
+    -- that overrode a connection to rw could not tell an override keyed by
+    -- URL from one that leaked onto every rw connection in the file.
+    local _, action, bare = picker_action(connections, "r", "bare-db")
+    action.fn(bare)
+    eq(connections.current_mode(BARE_URL), "ro", "the overridden connection")
+    eq(connections.current_mode(RW_URL), "rw", "another connection is unaffected")
+    eq(connections.current_mode("postgresql://u:p@h/unsaved"), "rw", "and so is an unsaved URL")
+  end)
+end)
+
+test("reconnecting the ordinary way drops the override", function()
+  with_switchable(nil, function(connections)
+    local _, action, ro_item = picker_action(connections, "r", "ro-db")
+    action.fn(ro_item)
+    eq(connections.current_mode(RO_URL), "rw", "override in force")
+    connections.switch(RO_URL, "ro-db", "postgresql")
+    eq(connections.current_mode(RO_URL), "ro", "back on the entry's own mode")
+  end)
+end)
+
+test("the winbar badge follows a session override", function()
+  with_switchable(nil, function(connections)
+    local _, action, ro_item = picker_action(connections, "r", "ro-db")
+    action.fn(ro_item)
+    assert(not winbar_for(RO_URL):find("RO", 1, true),
+      "a ro entry opened writable must not keep the badge: " .. winbar_for(RO_URL))
+    local _, _, bare = picker_action(connections, "r", "bare-db")
+    action.fn(bare)
+    assert(winbar_for(BARE_URL):find("RO", 1, true),
+      "a rw entry opened read-only gets it")
+  end)
+end)
+
+-- ── the badge of a grid that is still open when the mode changes ──────────
+-- The badge is cached per session because the winbar is rebuilt on every
+-- cursor move. A switch is the other thing that changes the answer, and the
+-- grid it applies to is not always the one being replaced: switch() ends in
+-- open_welcome, which only touches the *current* window, so a grid in the
+-- sidebar's neighbour window, or a pinned one, lives on with its cache.
+
+test("a switch refreshes the badge of a grid that is still open", function()
+  with_switchable(nil, function(connections)
+    with_live_session(BARE_URL, function(bar, raw)
+      assert(not bar():find("RO", 1, true), "rw to begin with (warms the cache)")
+      local _, action, bare = picker_action(connections, "r", "bare-db")
+      action.fn(bare)
+      eq(connections.current_mode(BARE_URL), "ro", "the override took")
+      assert(raw():find("RO", 1, true),
+        "the badge must be on screen already, not on the next cursor move: " .. raw())
+      assert(bar():find("RO", 1, true), "and it stays there on the next redraw")
+    end)
+  end)
+end)
+
+test("a reconnect drops the badge the override put there", function()
+  with_switchable(nil, function(connections)
+    local _, action, bare = picker_action(connections, "r", "bare-db")
+    action.fn(bare)
+    with_live_session(BARE_URL, function(bar, raw)
+      assert(bar():find("RO", 1, true), "badged while overridden (warms the cache)")
+      connections.switch(BARE_URL, "bare-db", "postgresql")
+      eq(connections.current_mode(BARE_URL), "rw", "the override is gone")
+      assert(not raw():find("RO", 1, true),
+        "a badge claiming read-only on a writable connection is the worse lie: " .. raw())
+      assert(not bar():find("RO", 1, true), "and the next redraw must not bring it back")
+    end)
+  end)
+end)
+
+-- ── a switch that never happened ──────────────────────────────────────────
+
+test("an r whose secret does not resolve leaves the mode exactly as it was", function()
+  with_switchable(UNRESOLVABLE_URL, function(connections)
+    local msgs = {}
+    vim.notify = function(m) table.insert(msgs, tostring(m)) end
+    local _, action, locked = picker_action(connections, "r", "locked-db")
+    eq(connections.current_mode(UNRESOLVABLE_URL), "ro", "the entry's own mode before")
+
+    action.fn(locked)
+
+    assert(#msgs >= 1 and msgs[1]:find("unresolved variable", 1, true),
+      "the switch reported the failure: " .. table.concat(msgs, " / "))
+    for _, m in ipairs(msgs) do
+      assert(not m:find("for this session", 1, true),
+        "and must not also claim the override took: " .. m)
+    end
+    eq(connections.current_mode(UNRESOLVABLE_URL), "ro",
+      "a switch that aborted must not flip the connection the user is still on")
+    eq(require("dadbod-grip.db").is_readonly(UNRESOLVABLE_URL), true,
+      "so the read-only guard is still in force")
+  end)
+end)
+
+test("a failed ordinary reconnect does not clear an override either", function()
+  with_switchable(nil, function(connections)
+    -- The same ordering bug in the other direction: the override is cleared
+    -- at the top of switch(), so a reconnect that aborts would drop an
+    -- override the user is relying on. The variable resolves while the
+    -- override is taken and is gone by the reconnect, which is exactly the
+    -- git-crypt / re-exported-.env case this feature has to survive.
+    vim.fn.setenv("GRIP_TEST_PW", "s3cr3t")
+    local ok, err = pcall(function()
+      local _, action, tpl = picker_action(connections, "r", "templated-db")
+      action.fn(tpl)
+      eq(connections.current_mode(TEMPLATED_URL), "rw", "a ro entry opened writable")
+
+      vim.fn.setenv("GRIP_TEST_PW", vim.NIL)
+      eq(connections.switch(TEMPLATED_URL, "templated-db", "postgresql"), false,
+        "the reconnect aborted")
+      eq(connections.current_mode(TEMPLATED_URL), "rw",
+        "a switch that never happened must not silently re-lock the connection")
+    end)
+    vim.fn.setenv("GRIP_TEST_PW", vim.NIL)  -- never leak into a later spec
+    if not ok then error(err) end
+  end)
+end)
+
+-- ── summary ─────────────────────────────────────────────────────────────────
+
+print(string.format("\nreadonly_mode_spec: %d passed, %d failed", pass, fail))
+if fail > 0 then os.exit(1) end

--- a/tests/spec/redact_spec.lua
+++ b/tests/spec/redact_spec.lua
@@ -1,0 +1,110 @@
+-- redact_spec.lua -- unit tests for sql.redact_url, the single password-masking
+-- pattern shared by history.lua and the adapters' error messages.
+local sql = require("dadbod-grip.sql")
+
+local pass = 0
+local fail = 0
+
+local function test(name, fn)
+  local ok, err = pcall(fn)
+  if ok then
+    pass = pass + 1
+  else
+    fail = fail + 1
+    print("FAIL: " .. name .. ": " .. tostring(err))
+  end
+end
+
+local function eq(a, b, msg)
+  assert(a == b, (msg or "") .. ": expected " .. tostring(b) .. ", got " .. tostring(a))
+end
+
+-- ── basic cases ──────────────────────────────────────────────────────────
+
+test("redacts the password in a postgres URL", function()
+  eq(sql.redact_url("postgresql://user:hunter2@host:5432/db"),
+     "postgresql://user:***@host:5432/db", "password masked")
+end)
+
+test("leaves a password-less URL alone", function()
+  eq(sql.redact_url("postgresql://user@host:5432/db"),
+     "postgresql://user@host:5432/db", "nothing to mask")
+end)
+
+test("leaves a file URL alone", function()
+  eq(sql.redact_url("duckdb:/tmp/x.duckdb"), "duckdb:/tmp/x.duckdb", "no auth part")
+end)
+
+test("handles nil", function()
+  eq(sql.redact_url(nil), "", "nil becomes empty string")
+end)
+
+test("mysql errors do not leak the password", function()
+  local mysql = require("dadbod-grip.adapters.mysql")
+  local _, err = mysql.get_primary_keys("t", "not-a-valid-url-with:hunter2@host")
+  assert(err == nil or not tostring(err):find("hunter2", 1, true),
+    "password must not appear in the error, got: " .. tostring(err))
+end)
+
+test("sqlserver errors do not leak the password", function()
+  local sqlserver = require("dadbod-grip.adapters.sqlserver")
+  local _, err = sqlserver.query("SELECT 1", "not-a-valid-url-with:hunter2@host")
+  assert(err == nil or not tostring(err):find("hunter2", 1, true),
+    "password must not appear in the error, got: " .. tostring(err))
+end)
+
+-- ── pattern decision ─────────────────────────────────────────────────────
+-- history.lua's original pattern captured the user as `[^:]+` (any run of
+-- non-colon characters), which does not stop at a "/". That lets the match
+-- span past the authority component into the path whenever the path itself
+-- contains a colon followed later by an "@" (e.g. a schema-qualified name
+-- that happens to precede an email-like string). This adapter's pattern
+-- (`[^:/@]+` for the user, so it can never cross a "/") stays scoped to
+-- "scheme://user:pass@host" and leaves everything after the first "/" alone.
+test("does not falsely redact across a path separator (no real credentials)", function()
+  local url = "postgresql://host/schema:name@2024/db"
+  eq(sql.redact_url(url), url, "no '://user:pass@' right after the scheme, so no rewrite")
+end)
+
+-- Fix round 1, finding 1: the first cut split on the FIRST "@", so a password
+-- containing "@" was only partly masked — "mysql://user:p@ss@host/db" came
+-- out as "mysql://user:***@ss@host/db", leaking "ss" right next to the mask.
+-- parse_dadbod_url (below) already splits on the LAST "@" for exactly this
+-- reason; redact_url now mirrors that rule. The old assertion here only
+-- checked that "***@" appeared *somewhere*, which is true even while "ss"
+-- leaks — tightened to assert the full, exact output instead.
+test("fully masks a password that itself contains '@' (splits on the LAST '@')", function()
+  local result = sql.redact_url("mysql://user:p@ss@host/db")
+  eq(result, "mysql://user:***@host/db", "no leftover password fragment next to the mask")
+  assert(not result:find("ss", 1, true), "'ss' (part of the password) must not survive, got: " .. result)
+end)
+
+-- Fix round 1, finding 1 (boundary): widening the match to the last "@"
+-- must still stop at the authority boundary — it must not reach past the
+-- host into the path or query, where an unrelated "@" is not a password.
+test("does not swallow an '@' that appears later in the path", function()
+  local url = "postgresql://user:pass@host/db@2024"
+  eq(sql.redact_url(url), "postgresql://user:***@host/db@2024",
+     "the path's '@' is outside the authority and must survive untouched")
+end)
+
+-- Fix round 1, finding 2: the no-"://" fallback did a blind global scan with
+-- no whitespace boundary, so it could reach across an entire sentence, e.g.
+-- "Error at line 12: expected token foo:bar@baz" collapsed to
+-- "Error at line 12:***@baz" — losing "expected token foo" along the way.
+-- Tightened so neither side of the match may contain whitespace (a real URL
+-- never does), which keeps the damage scoped to the one credential-shaped
+-- token and off the surrounding prose. It is still a heuristic, not
+-- authority-aware: "foo:bar@" itself is genuinely indistinguishable from a
+-- real "user:pass@" chunk with no scheme, so it is still masked — this
+-- fallback is for a URL argument, not a full free-form message (see the
+-- doc comment on M.redact_url).
+test("fallback (no '://') is scoped to whitespace-free credential-shaped tokens", function()
+  local msg = "Error at line 12: expected token foo:bar@baz"
+  eq(sql.redact_url(msg),
+     "Error at line 12: expected token foo:***@baz",
+     "only the whitespace-free 'foo:bar@' token is masked; surrounding prose is untouched")
+end)
+
+print(string.format("\nredact_spec: %d passed, %d failed", pass, fail))
+if fail > 0 then os.exit(1) end

--- a/tests/spec/secrets_integration_spec.lua
+++ b/tests/spec/secrets_integration_spec.lua
@@ -649,6 +649,161 @@ test("T:test reports the expansion error and marks it distinctly, not a bogus fa
   end)
 end)
 
+-- ── connecting marks it too, not just T:test ──────────────────────────────
+-- set_health("unresolved") had one call site, the T:test action. Connecting
+-- is how most people meet this failure: press <CR>, read an error, reopen the
+-- picker -- and, before this, find nothing to show for it.
+
+test("a connect attempt that cannot resolve marks the entry unresolved", function()
+  with_real_file(function(local_grip, env_path)
+    vim.fn.writefile({ "SOMETHING_ELSE=1" }, env_path)
+    vim.fn.writefile({ vim.fn.json_encode({
+      { name = "dev", url = "${MISSING_URL}", env_file = env_path },
+    }) }, local_grip .. "/connections.json")
+    eq(connections.get_health("${MISSING_URL}"), "unknown", "nothing known before the attempt")
+
+    eq(connections.switch("${MISSING_URL}", "dev"), false, "the switch aborted")
+
+    eq(connections.get_health("${MISSING_URL}"), "unresolved",
+      "the connect attempt recorded why, distinctly from a database that is down")
+
+    -- And the picker actually renders it, which is the whole point.
+    local grip_picker = require("dadbod-grip.grip_picker")
+    local orig_open, captured = grip_picker.open, nil
+    grip_picker.open = function(opts) captured = opts end
+    connections.pick()
+    grip_picker.open = orig_open
+    local dev
+    for _, item in ipairs(captured.items) do
+      if item.name == "dev" then dev = item end
+    end
+    eq(captured.display(dev):sub(1, 1), "?", "'?' in the picker, not the 'x' of an unreachable db")
+  end)
+end)
+
+test("fixing the .env and reconnecting clears the unresolved marker", function()
+  with_real_file(function(local_grip, env_path)
+    -- The sequence a user actually walks: connect, get the error, unlock or
+    -- fix the .env, connect again. A marker that stuck would leave the entry
+    -- reading "?" forever on a connection that now works.
+    local url = "${SEED_URL}"
+    vim.fn.writefile({ "SOMETHING_ELSE=1" }, env_path)
+    vim.fn.writefile({ vim.fn.json_encode({
+      { name = "dev", url = url, env_file = env_path },
+    }) }, local_grip .. "/connections.json")
+    eq(connections.switch(url, "dev"), false, "aborted while the variable is missing")
+    eq(connections.get_health(url), "unresolved", "marked")
+
+    vim.fn.writefile({ "SEED_URL=sqlite:" .. SEED_DB }, env_path)
+    vim.fn.system({ "touch", "-t", "203001010000", env_path })  -- beat the mtime cache
+    secrets.clear_cache()
+
+    eq(connections.switch(url, "dev"), true, "the switch now commits")
+    eq(connections.get_health(url), "ok", "and the marker is gone, not stuck at '?'")
+  end)
+end)
+
+-- ── an empty .env value refuses to connect ────────────────────────────────
+-- PW= substituted empty produced postgresql://u:@h/db, which psql does not
+-- refuse: with no password it falls through to ~/.pgpass and can authenticate
+-- as somebody else entirely. The expansion has to fail instead.
+
+test("an empty value in .env aborts the connection instead of dropping the password", function()
+  with_real_file(function(local_grip, env_path)
+    vim.fn.writefile({ "DEV_DB_PASSWORD=" }, env_path)
+    local url = "postgresql://u:${DEV_DB_PASSWORD}@h/db"
+    vim.fn.writefile({ vim.fn.json_encode({
+      { name = "dev", url = url, env_file = env_path },
+    }) }, local_grip .. "/connections.json")
+    vim.g.db = nil
+
+    local msgs = {}
+    local harness_notify = vim.notify
+    vim.notify = function(m) table.insert(msgs, tostring(m)) end
+    local committed = connections.switch(url, "dev")
+    vim.notify = harness_notify
+
+    eq(committed, false, "the switch aborted")
+    eq(vim.g.db, nil, "no connection activated")
+    assert(msgs[1] and msgs[1]:find("${DEV_DB_PASSWORD}", 1, true),
+      "and the message names the empty variable: " .. tostring(msgs[1]))
+    eq(connections.expand_url(url), nil, "expansion refuses rather than returning u:@h")
+  end)
+end)
+
+-- ── T:test looks the connection up by its template ────────────────────────
+
+test("T:test pings a ro templated connection with a read-only session", function()
+  with_real_file(function(local_grip, env_path)
+    local url = seed_templated_conn(local_grip, env_path, "PG_URL",
+      "postgresql://u:hunter2@db.internal:5432/app", { mode = "ro" })
+
+    local grip_picker = require("dadbod-grip.grip_picker")
+    local orig_open, captured = grip_picker.open, nil
+    grip_picker.open = function(opts) captured = opts end
+    connections.pick()
+    grip_picker.open = orig_open
+    local test_action, dev
+    for _, a in ipairs(captured.actions) do
+      if a.label == "T:test" then test_action = a end
+    end
+    for _, item in ipairs(captured.items) do
+      if item.name == "dev" then dev = item end
+    end
+    assert(test_action and dev, "T:test and the entry are both present")
+
+    -- Only the process spawn is stubbed: db.ping -> resolve -> via_adapter
+    -- (which publishes the mode) -> adapter.ping is the real path, and what
+    -- the adapter reads through session_opts() is the assertion.
+    local pg = require("dadbod-grip.adapters.postgresql")
+    local orig_ping, seen = pg.ping, nil
+    pg.ping = function(u)
+      seen = { url = u, readonly = require("dadbod-grip.adapters").session_opts().readonly }
+      return true
+    end
+    test_action.fn(dev)
+    pg.ping = orig_ping
+
+    assert(seen, "the adapter's ping was reached")
+    eq(seen.readonly, true,
+      "the mode is looked up by the stored template; the expanded URL matches no entry and reads rw")
+    eq(seen.url, "postgresql://u:hunter2@db.internal:5432/app",
+      "while the adapter itself still receives the resolved URL")
+    eq(connections.get_health(url), "ok", "and the health it records is keyed on the template")
+  end)
+end)
+
+test("T:test pings a rw templated connection writable", function()
+  with_real_file(function(local_grip, env_path)
+    seed_templated_conn(local_grip, env_path, "PG_URL",
+      "postgresql://u:hunter2@db.internal:5432/app")
+
+    local grip_picker = require("dadbod-grip.grip_picker")
+    local orig_open, captured = grip_picker.open, nil
+    grip_picker.open = function(opts) captured = opts end
+    connections.pick()
+    grip_picker.open = orig_open
+    local test_action, dev
+    for _, a in ipairs(captured.actions) do
+      if a.label == "T:test" then test_action = a end
+    end
+    for _, item in ipairs(captured.items) do
+      if item.name == "dev" then dev = item end
+    end
+
+    local pg = require("dadbod-grip.adapters.postgresql")
+    local orig_ping, seen = pg.ping, nil
+    pg.ping = function()
+      seen = require("dadbod-grip.adapters").session_opts().readonly
+      return true
+    end
+    test_action.fn(dev)
+    pg.ping = orig_ping
+
+    eq(seen, false, "an entry with no mode is pinged writable, as before")
+  end)
+end)
+
 -- ── templates resolve where the *scheme* is what matters ─────────────────
 
 test("db.resolved_url gives dialect-sensitive callers a real scheme", function()

--- a/tests/spec/secrets_integration_spec.lua
+++ b/tests/spec/secrets_integration_spec.lua
@@ -1,0 +1,729 @@
+-- secrets_integration_spec.lua -- end-to-end tests for ${VAR} expansion.
+--
+-- secrets_spec.lua covers the parser/expander in isolation. This spec pins
+-- the property the design exists for: the *expanded* URL -- the one carrying
+-- a live database password -- is created at exactly one place (db.resolve(),
+-- the funnel every db.* call goes through) and never reaches any write path.
+-- vim.g.db, .grip/connections.json and .grip/history.jsonl all keep the
+-- template.
+--
+-- Everything here runs against real files and a real sqlite3 process
+-- (tests/seed_sqlite.db), so "the adapter got an expanded URL" is proved by
+-- rows coming back, not by a mock.
+local paths = require("dadbod-grip.paths")
+local grip = require("dadbod-grip")
+local db = require("dadbod-grip.db")
+local secrets = require("dadbod-grip.secrets")
+
+-- Rebound to a freshly loaded module by every with_real_file() below (see
+-- the harness comment) -- same reason as connections_spec.lua: connections
+-- keeps per-URL health in a module-local table with no reset hook.
+local connections = require("dadbod-grip.connections")
+
+local SEED_DB = vim.fn.fnamemodify("tests/seed_sqlite.db", ":p")
+
+local pass = 0
+local fail = 0
+
+local function test(name, fn)
+  local ok, err = pcall(fn)
+  if ok then
+    pass = pass + 1
+  else
+    fail = fail + 1
+    print("FAIL: " .. name .. ": " .. tostring(err))
+  end
+end
+
+local function eq(a, b, msg)
+  assert(a == b, (msg or "") .. ": expected " .. tostring(b) .. ", got " .. tostring(a))
+end
+
+-- ── real-file harness ────────────────────────────────────────────────────
+-- Lifted from connections_spec.lua's with_real_file(), with one deliberate
+-- difference: grip.open is NOT stubbed here, because the history test needs
+-- the real query path. Everything else is stubbed/redirected for the same
+-- reasons documented there:
+-- - paths.project_root is patched (not paths.grip_dir): connections.lua and
+--   history.lua capture grip_dir at require time, but the captured function
+--   still calls M.project_root() dynamically, so patching project_root
+--   reaches both .grip/connections.json and .grip/history.jsonl.
+-- - vim.fn.expand("~") is patched to a fake home so the global connections
+--   file used by tests never touches the real ~/.grip/connections.json.
+-- - the module under test is reloaded per call so its module-local state
+--   starts empty; the file-level `connections` alias is rebound to it.
+-- Pending vim.schedule callbacks are flushed *before* teardown, while the
+-- stubs and fake dirs are still live.
+local function with_real_file(fn)
+  local project_dir = vim.fn.tempname() .. "_grip_secrets_test"
+  local fake_home = project_dir .. "_home"
+  vim.fn.mkdir(project_dir, "p")
+  vim.fn.mkdir(fake_home, "p")
+
+  local orig_project_root = paths.project_root
+  local orig_expand = vim.fn.expand
+  local orig_notify = vim.notify
+  local orig_g_db = vim.g.db
+  local orig_opts = grip.get_opts()
+  local orig_open_welcome = grip.open_welcome
+  local orig_schema = package.loaded["dadbod-grip.schema"]
+  local orig_query_pad = package.loaded["dadbod-grip.query_pad"]
+  local orig_completion = package.loaded["dadbod-grip.completion"]
+  local orig_connections = package.loaded["dadbod-grip.connections"]
+
+  paths.project_root = function() return project_dir end
+  vim.fn.expand = function(a, ...)
+    if a == "~" then return fake_home end
+    return orig_expand(a, ...)
+  end
+  vim.notify = function() end
+  grip.setup({}) -- deterministic OPTS baseline (connections_path = nil, etc.)
+  grip.open_welcome = function() end
+  package.loaded["dadbod-grip.schema"] = {
+    is_open = function() return true end,
+    refresh = function() end,
+    toggle = function() end,
+    get_winid = function() return nil end,
+    -- view.lua asks the sidebar where to place the grid.
+    get_right_win = function() return nil end,
+  }
+  package.loaded["dadbod-grip.query_pad"] = { open = function() end, sync_query = function() end }
+  package.loaded["dadbod-grip.completion"] = { invalidate = function() end, warm_schema = function() end }
+  package.loaded["dadbod-grip.connections"] = nil
+  connections = require("dadbod-grip.connections")
+  secrets.clear_cache()
+
+  local local_grip = project_dir .. "/.grip"
+  local env_path = project_dir .. "/.env"
+  paths.ensure_dir(local_grip)
+  local ok, err = pcall(fn, local_grip, env_path)
+  vim.wait(50) -- flush any vim.schedule() callbacks queued by switch()/open()
+
+  paths.project_root = orig_project_root
+  vim.fn.expand = orig_expand
+  vim.notify = orig_notify
+  vim.g.db = orig_g_db
+  grip.setup(orig_opts)
+  grip.open_welcome = orig_open_welcome
+  package.loaded["dadbod-grip.schema"] = orig_schema
+  package.loaded["dadbod-grip.query_pad"] = orig_query_pad
+  package.loaded["dadbod-grip.completion"] = orig_completion
+  package.loaded["dadbod-grip.connections"] = orig_connections
+  connections = orig_connections
+  secrets.clear_cache()
+
+  vim.fn.delete(project_dir, "rf")
+  vim.fn.delete(fake_home, "rf")
+  if not ok then error(err) end
+end
+
+--- Seed .env + connections.json with a single templated entry and make it
+--- the active connection. Returns the template URL.
+local function seed_templated_conn(local_grip, env_path, var, value, extra)
+  vim.fn.writefile({ var .. "=" .. value }, env_path)
+  local entry = vim.tbl_extend("force", {
+    name = "dev", url = "${" .. var .. "}", env_file = env_path,
+  }, extra or {})
+  vim.fn.writefile({ vim.fn.json_encode({ entry }) }, local_grip .. "/connections.json")
+  return entry.url
+end
+
+-- ── the expanded URL never reaches disk ──────────────────────────────────
+
+test("switch: a templated URL never reaches disk expanded", function()
+  with_real_file(function(local_grip, env_path)
+    local secret_url = "sqlite:" .. vim.fn.tempname()
+    seed_templated_conn(local_grip, env_path, "DB_URL", secret_url)
+
+    connections.switch("${DB_URL}", "dev")
+    vim.wait(200, function() return false end)
+
+    local raw = table.concat(vim.fn.readfile(local_grip .. "/connections.json"), "\n")
+    assert(raw:find("${DB_URL}", 1, true), "template preserved on disk")
+    assert(not raw:find("sqlite:/", 1, true), "expanded value must not be persisted")
+    eq(vim.g.db, "${DB_URL}", "vim.g.db holds the template")
+  end)
+end)
+
+test("switch: aborts without writing anything when a placeholder cannot be resolved", function()
+  with_real_file(function(local_grip, env_path)
+    -- .env exists but does not define the variable the URL references.
+    vim.fn.writefile({ "SOMETHING_ELSE=1" }, env_path)
+    vim.fn.writefile({ vim.fn.json_encode({
+      { name = "dev", url = "${MISSING_URL}", env_file = env_path },
+    }) }, local_grip .. "/connections.json")
+    local before = table.concat(vim.fn.readfile(local_grip .. "/connections.json"), "\n")
+    vim.g.db = nil
+
+    connections.switch("${MISSING_URL}", "dev")
+
+    eq(vim.g.db, nil, "no connection activated")
+    eq(table.concat(vim.fn.readfile(local_grip .. "/connections.json"), "\n"), before,
+      "nothing written: expansion is checked before any mutation")
+  end)
+end)
+
+-- ── expansion happens at the dispatch point ──────────────────────────────
+
+test("db.resolve hands the adapter an expanded URL", function()
+  with_real_file(function(local_grip, env_path)
+    local url = seed_templated_conn(local_grip, env_path, "SEED_URL", "sqlite:" .. SEED_DB)
+    vim.g.db = url
+
+    -- A real sqlite3 process against the seeded database. Rows coming back
+    -- is the proof: the adapter cannot open "${SEED_URL}".
+    local result, err = db.query("SELECT COUNT(*) AS n FROM users", url)
+    eq(err, nil, "query succeeded")
+    assert(result and result.rows and #result.rows == 1, "one row returned")
+    assert(tonumber(result.rows[1][1]) and tonumber(result.rows[1][1]) > 0,
+      "seeded users table has rows, got " .. vim.inspect(result and result.rows))
+    eq(vim.g.db, url, "vim.g.db still holds the template after a query")
+  end)
+end)
+
+test("db.resolve expands the URL taken from vim.g.db when none is passed", function()
+  with_real_file(function(local_grip, env_path)
+    vim.g.db = seed_templated_conn(local_grip, env_path, "SEED_URL", "sqlite:" .. SEED_DB)
+
+    local result, err = db.query("SELECT COUNT(*) AS n FROM users")
+    eq(err, nil, "query succeeded off vim.g.db alone")
+    assert(result and #result.rows == 1, "one row returned")
+  end)
+end)
+
+test("db.resolve reports the expansion error instead of a bogus adapter error", function()
+  with_real_file(function(local_grip, env_path)
+    vim.fn.writefile({ "SOMETHING_ELSE=1" }, env_path)
+    vim.fn.writefile({ vim.fn.json_encode({
+      { name = "dev", url = "${MISSING_URL}", env_file = env_path },
+    }) }, local_grip .. "/connections.json")
+
+    local result, err = db.query("SELECT 1", "${MISSING_URL}")
+    eq(result, nil, "no result")
+    -- Specifically the expander's message, not the adapter's "Unsupported
+    -- database scheme: ${MISSING_URL}" -- which is what a resolve() that
+    -- skipped expansion would produce, and would still mention the variable.
+    assert(err and err:find("unresolved variable ${MISSING_URL}", 1, true),
+      "error is the expander's, got " .. tostring(err))
+    assert(err:find("^secrets:"), "error carries the secrets: prefix, got " .. err)
+  end)
+end)
+
+-- ── literal URLs are untouched (backwards compatibility) ─────────────────
+
+test("a literal URL costs no .env read at all", function()
+  with_real_file(function(local_grip, env_path)
+    -- An entry that *has* an env_file, so the only thing keeping the
+    -- expander out of the way is the URL having no placeholder.
+    vim.fn.writefile({ "UNUSED=1" }, env_path)
+    vim.fn.writefile({ vim.fn.json_encode({
+      { name = "dev", url = "sqlite:" .. SEED_DB, env_file = env_path },
+    }) }, local_grip .. "/connections.json")
+
+    local reads = 0
+    local orig_parse = secrets.parse_env_file
+    secrets.parse_env_file = function(...)
+      reads = reads + 1
+      return orig_parse(...)
+    end
+    local result, err = db.query("SELECT COUNT(*) AS n FROM users", "sqlite:" .. SEED_DB)
+    secrets.parse_env_file = orig_parse
+
+    eq(err, nil, "literal URL still queries")
+    assert(result and #result.rows == 1, "one row returned")
+    eq(reads, 0, "no .env file was read for a literal URL")
+  end)
+end)
+
+test("a templated URL does read the .env file (the counter above can move)", function()
+  with_real_file(function(local_grip, env_path)
+    local url = seed_templated_conn(local_grip, env_path, "SEED_URL", "sqlite:" .. SEED_DB)
+
+    local reads = 0
+    local orig_parse = secrets.parse_env_file
+    secrets.parse_env_file = function(...)
+      reads = reads + 1
+      return orig_parse(...)
+    end
+    local _, err = db.query("SELECT COUNT(*) AS n FROM users", url)
+    secrets.parse_env_file = orig_parse
+
+    eq(err, nil, "query succeeded")
+    assert(reads > 0, "the templated path really does go through parse_env_file")
+  end)
+end)
+
+-- ── history keeps the template ───────────────────────────────────────────
+
+test("history records the template, not the expansion", function()
+  with_real_file(function(local_grip, env_path)
+    local url = seed_templated_conn(local_grip, env_path, "SEED_URL", "sqlite:" .. SEED_DB)
+    vim.g.db = url
+
+    -- The real grid path: resolve_query -> db.query -> history.record.
+    grip.open("SELECT id FROM users LIMIT 1", url, {})
+
+    local lines = vim.fn.readfile(local_grip .. "/history.jsonl")
+    assert(#lines > 0, "a history entry was written")
+    local entry = vim.fn.json_decode(lines[#lines])
+    assert(entry.url:find("${", 1, true), "history url keeps the template, got " .. entry.url)
+    assert(not entry.url:find(SEED_DB, 1, true),
+      "history url must not contain the expanded target, got " .. entry.url)
+
+    local raw = table.concat(lines, "\n")
+    assert(not raw:find(SEED_DB, 1, true), "no expanded URL anywhere in history.jsonl")
+  end)
+end)
+
+-- ── DuckDB attachments: persisted templated, expanded on replay ──────────
+
+test("save_attachments persists the templated dsn, not the expanded one", function()
+  with_real_file(function(local_grip, env_path)
+    vim.fn.writefile({ "PG_URL=postgresql://u:hunter2@localhost:5432/app" }, env_path)
+    vim.fn.writefile({ vim.fn.json_encode({
+      { name = "duck", url = "duckdb::memory:" },
+      { name = "app", url = "${PG_URL}", env_file = env_path },
+    }) }, local_grip .. "/connections.json")
+
+    -- What the a:attach picker action / :GripAttach hand to save_attachments:
+    -- the live record carries the expanded dsn plus the template it came from.
+    connections.save_attachments("duckdb::memory:", {
+      { dsn = "postgres:dbname=app user=u password=hunter2 host=localhost port=5432",
+        alias = "app", template = "${PG_URL}" },
+    })
+
+    local raw = table.concat(vim.fn.readfile(local_grip .. "/connections.json"), "\n")
+    assert(not raw:find("hunter2", 1, true), "attachment password must not be persisted")
+    assert(raw:find("${PG_URL}", 1, true), "attachment dsn stored as the template")
+  end)
+end)
+
+test("save_attachments still persists a literal dsn verbatim", function()
+  with_real_file(function(local_grip)
+    vim.fn.writefile({ vim.fn.json_encode({
+      { name = "duck", url = "duckdb::memory:" },
+    }) }, local_grip .. "/connections.json")
+
+    connections.save_attachments("duckdb::memory:", {
+      { dsn = "sqlite:/tmp/side.db", alias = "side" },
+    })
+
+    local data = vim.fn.json_decode(table.concat(vim.fn.readfile(local_grip .. "/connections.json"), "\n"))
+    eq(data[1].attachments[1].dsn, "sqlite:/tmp/side.db", "literal dsn round-trips unchanged")
+    eq(data[1].attachments[1].alias, "side", "alias round-trips")
+  end)
+end)
+
+test("switch replays a templated attachment against the live database", function()
+  with_real_file(function(local_grip, env_path)
+    if vim.fn.executable("duckdb") == 0 then
+      print("SKIP: switch replays a templated attachment (duckdb CLI not installed)")
+      return
+    end
+    vim.fn.writefile({ "SIDE_URL=sqlite:" .. SEED_DB }, env_path)
+    vim.fn.writefile({ vim.fn.json_encode({
+      {
+        name = "duck", url = "duckdb::memory:",
+        attachments = { { dsn = "${SIDE_URL}", alias = "side" } },
+      },
+      { name = "side", url = "${SIDE_URL}", env_file = env_path },
+    }) }, local_grip .. "/connections.json")
+
+    connections.switch("duckdb::memory:", "duck")
+    vim.wait(100, function() return false end)
+
+    local duckdb = require("dadbod-grip.adapters.duckdb")
+    local atts = duckdb.get_attachments("duckdb::memory:")
+    eq(#atts, 1, "attachment replayed")
+    assert(atts[1].dsn:find(SEED_DB, 1, true),
+      "the live attachment dsn is expanded, got " .. tostring(atts[1].dsn))
+    eq(atts[1].template, "${SIDE_URL}", "the template is kept for the next save")
+
+    -- And it is genuinely attached: query the seeded table through the alias.
+    local result, err = duckdb.query("SELECT COUNT(*) FROM side.users", "duckdb::memory:")
+    eq(err, nil, "federated query succeeded")
+    assert(result and tonumber(result.rows[1][1]) > 0, "rows came back through the alias")
+    duckdb.detach("duckdb::memory:", "side")
+  end)
+end)
+
+-- ── ATTACH failure text carries no credentials ───────────────────────────
+--
+-- The fixtures below are VERBATIM stderr captured from the real duckdb CLI
+-- (v1.5.5 "Variegata" d8cdaa33fd) on 2026-07-31, by running the exact SQL
+-- M.attach builds. They are pinned as literals because they are the whole
+-- point of the test: the first version of this suite asserted against a
+-- message the test itself had composed ("Failed to attach " .. dsn), which is
+-- a tautology -- the mask was checked against a string built from the very
+-- value it matches on -- and it passed while a real password went to the
+-- screen. Note in both samples that DuckDB does NOT echo the DSN back
+-- unchanged: the URL loses a slash and gains the process cwd, and the
+-- key=value form loses its "postgres:" prefix. Any whole-string match misses.
+--
+-- Fidelity note: fixture 1 is the complete message, byte for byte. Fixture 2
+-- is a verbatim *prefix* -- the real stderr continues with a second line,
+-- "\n\tIs the server running on that host and accepting TCP/IP connections?",
+-- which is credential-free and dropped here for readability. The live tests
+-- further down work on the untruncated output.
+local DUCKDB_URL_STDERR =
+  'IO Error: Cannot open file "/Users/gleb/dev/dadbod-grip.nvim/postgresql:/'
+  .. 'pguser:s3cr3t_from_dotenv@127.0.0.1:5472/postgres": No such file or directory'
+local DUCKDB_QUOTED_PW_STDERR =
+  'IO Error: Unable to connect to Postgres at "dbname=app host=127.0.0.1 port=1 '
+  .. "user=u password='hun ter2'\": connection to server at \"127.0.0.1\", port 1 "
+  .. "failed: Connection refused"
+
+test("attach error: real duckdb stderr for a URL-shaped dsn carries no password", function()
+  local duckdb = require("dadbod-grip.adapters.duckdb")
+  local dsn = "postgresql://pguser:s3cr3t_from_dotenv@127.0.0.1:5472/postgres"
+  local msg = duckdb._redact_attach_error(DUCKDB_URL_STDERR, dsn)
+  assert(not msg:find("s3cr3t_from_dotenv", 1, true), "password removed, got " .. msg)
+  assert(msg:find("No such file or directory", 1, true),
+    "the diagnostic itself survives, got " .. msg)
+  assert(msg:find("127.0.0.1", 1, true), "non-secret parts survive, got " .. msg)
+end)
+
+test("attach error: real duckdb stderr for a quoted key=value password carries no password", function()
+  local duckdb = require("dadbod-grip.adapters.duckdb")
+  -- libpq conninfo allows a quoted value with spaces, and :GripAttach rejoins
+  -- its argv with spaces, so this DSN is reachable by typing.
+  local dsn = "postgres:dbname=app host=127.0.0.1 port=1 user=u password='hun ter2'"
+  local msg = duckdb._redact_attach_error(DUCKDB_QUOTED_PW_STDERR, dsn)
+  assert(not msg:find("hun ter2", 1, true), "whole password removed, got " .. msg)
+  assert(not msg:find("ter2", 1, true), "no tail of the password survives, got " .. msg)
+  assert(msg:find("Connection refused", 1, true), "the diagnostic survives, got " .. msg)
+end)
+
+test("attach error: the live duckdb binary cannot leak a password through M.attach", function()
+  if vim.fn.executable("duckdb") == 0 then
+    print("SKIP: live duckdb attach-leak test (duckdb CLI not installed)")
+    return
+  end
+  local duckdb = require("dadbod-grip.adapters.duckdb")
+  -- Port 1 is unreachable, and DuckDB's postgres extension never claims the
+  -- "postgresql://" prefix for ATTACH anyway -- it falls through to its file
+  -- reader. Either way this fails fast, without touching the network, and
+  -- whatever the real binary says has to come back with no password in it.
+  local dsn = "postgresql://pguser:s3cr3t_live_pw@127.0.0.1:1/postgres"
+  local err = duckdb.attach("duckdb::memory:", dsn, "leaky")
+  assert(err, "the attach failed, as this test requires")
+  assert(not err:find("s3cr3t_live_pw", 1, true),
+    "no password in what the real duckdb binary produced: " .. err)
+  eq(#duckdb.get_attachments("duckdb::memory:"), 0, "nothing was stored")
+end)
+
+test("attach: a database duckdb has no scanner for is refused before the CLI runs", function()
+  local duckdb = require("dadbod-grip.adapters.duckdb")
+  -- Reachable with two keystrokes: a:attach in the picker on a saved SQL
+  -- Server connection. url_to_dsn has no conversion for it, so the URL used
+  -- to go to DuckDB verbatim and come back as a "Cannot open file" quoting
+  -- the credentials.
+  local dsn = "sqlserver://sa:P%40ssw0rd_from_env@10.255.255.1:1433/app"
+  eq(duckdb.url_to_dsn(dsn), dsn, "url_to_dsn passes sqlserver:// through unchanged")
+  local err = duckdb.attach("duckdb::memory:", dsn, "app")
+  assert(err, "refused")
+  assert(err:find("no scanner for sqlserver://", 1, true), "says why, got " .. err)
+  assert(not err:find("P%40ssw0rd_from_env", 1, true),
+    "the refusal names the scheme, never the credentials, got " .. err)
+  eq(#duckdb.get_attachments("duckdb::memory:"), 0, "nothing was stored")
+end)
+
+test("attach: postgres/mysql/sqlite URLs are not caught by the scheme refusal", function()
+  local duckdb = require("dadbod-grip.adapters.duckdb")
+  for _, dsn in ipairs({
+    "postgres:dbname=app host=h", "mysql:host=h user=u", "sqlite:/tmp/x.db",
+    "sqlite://tmp/x.db", "md:analytics", "/plain/path/to.duckdb",
+  }) do
+    eq(duckdb._unsupported_attach_scheme(dsn), nil, "attachable: " .. dsn)
+  end
+  assert(duckdb._unsupported_attach_scheme("oracle://u:p@h/db"), "oracle is refused")
+end)
+
+test("attach error: a credential-free message is returned untouched", function()
+  local duckdb = require("dadbod-grip.adapters.duckdb")
+  local stderr = "Error: Extension \"postgres_scanner\" not found"
+  eq(duckdb._redact_attach_error(stderr, "postgres:dbname=app host=db.internal"), stderr,
+    "no over-masking of a plain diagnostic")
+end)
+
+-- ── live-binary leak tests ───────────────────────────────────────────────
+-- Every case below drives the real duckdb CLI through the plugin's own path
+-- and asserts on what the binary actually produced. Nothing here composes the
+-- message it then greps: that pattern is what let the original ATTACH test
+-- pass while a password reached the screen.
+--
+-- All point at 127.0.0.1:1, which refuses instantly -- no network wait, and
+-- no live server is touched.
+
+--- Run fn only when the duckdb CLI is present; print a visible skip if not.
+local function with_duckdb(label, fn)
+  if vim.fn.executable("duckdb") == 0 then
+    print("SKIP: " .. label .. " (duckdb CLI not installed)")
+    return
+  end
+  fn()
+end
+
+test("attach error: a password containing @ survives url_to_dsn and is fully masked", function()
+  with_duckdb("@-in-password leak test", function()
+    local duckdb = require("dadbod-grip.adapters.duckdb")
+    -- url_to_dsn used to split the authority on the FIRST "@", yielding
+    -- password=P host=ssw0rd@127.0.0.1 -- so the mask masked one character
+    -- and DuckDB printed the other seven. It now uses sql.split_authority.
+    local dsn = duckdb.url_to_dsn("postgresql://u:P@ssw0rd@127.0.0.1:1/app")
+    local err = duckdb.attach("duckdb::memory:", dsn, "atsign")
+    duckdb.detach("duckdb::memory:", "atsign")
+    assert(err, "the attach failed, as this test requires")
+    -- Leak assertion first: it is the one that must speak when the parse
+    -- regresses, and it reports what the real binary printed.
+    assert(not err:find("ssw0rd", 1, true), "no fragment of the password: " .. err)
+    eq(dsn, "postgres:dbname=app user=u password=P@ssw0rd host=127.0.0.1 port=1",
+      "the whole password lands in password=, not half of it in host=")
+  end)
+end)
+
+test("attach error: a backslash-escaped quote inside a quoted password is fully masked", function()
+  with_duckdb("escaped-quote leak test", function()
+    local duckdb = require("dadbod-grip.adapters.duckdb")
+    -- libpq documents \' as the way to put a quote inside a quoted value.
+    -- The scan used to stop at that escaped quote and leave "ter2'" on screen.
+    local dsn = [[postgres:dbname=app host=127.0.0.1 port=1 user=u password='hun\'ter2']]
+    local err = duckdb.attach("duckdb::memory:", dsn, "escq")
+    assert(err, "the attach failed, as this test requires")
+    assert(not err:find("ter2", 1, true), "no tail of the password: " .. err)
+    duckdb.detach("duckdb::memory:", "escq")
+  end)
+end)
+
+test("attach error: libpq sslpassword is masked", function()
+  with_duckdb("sslpassword leak test", function()
+    local duckdb = require("dadbod-grip.adapters.duckdb")
+    -- sslpassword is the client-key passphrase -- exactly the kind of value a
+    -- ${VAR} holds -- and was missing from DSN_SECRET_KEYS entirely.
+    local dsn = "postgres:dbname=app host=127.0.0.1 port=1 user=u sslpassword=keyphrase_s3cret"
+    local err = duckdb.attach("duckdb::memory:", dsn, "sslpw")
+    assert(err, "the attach failed, as this test requires")
+    assert(not err:find("keyphrase_s3cret", 1, true), "passphrase masked: " .. err)
+    duckdb.detach("duckdb::memory:", "sslpw")
+  end)
+end)
+
+test("query error: an attachment that dies after attach cannot leak on the next query", function()
+  with_duckdb("query-path leak test", function()
+    local duckdb = require("dadbod-grip.adapters.duckdb")
+    -- The ordinary failure mode: the attachment validated at attach time and
+    -- the server went away afterwards (restart, VPN drop). build_attach_prefix
+    -- puts the DSN at the head of every query from then on, and M.query used
+    -- to return DuckDB's stderr raw to vim.notify. _attach_unchecked is how
+    -- the test gets to that state without a server that later dies.
+    duckdb._attach_unchecked("duckdb::memory:",
+      "postgres:dbname=app user=u password=s3cr3t_query_path host=127.0.0.1 port=1", "gone")
+    local result, err = duckdb.query("SELECT 1", "duckdb::memory:")
+    duckdb.detach("duckdb::memory:", "gone")
+    eq(result, nil, "the query failed, as this test requires")
+    assert(err and not err:find("s3cr3t_query_path", 1, true),
+      "no password on the query path: " .. tostring(err))
+    assert(err:find("Connection refused", 1, true) or err:find("Unable to connect", 1, true),
+      "the diagnostic still says what went wrong: " .. err)
+  end)
+end)
+
+test("attach error: a motherduck token never reaches the message", function()
+  with_duckdb("motherduck token test", function()
+    local duckdb = require("dadbod-grip.adapters.duckdb")
+    -- Honest scope: DuckDB v1.5.5 rejects this before it echoes the DSN, so
+    -- this asserts the property (no token on screen) rather than proving the
+    -- mask fired. It is a forward guard against a binary that does echo -- and
+    -- unlike the composed-message test it replaces, it cannot pass by
+    -- construction.
+    local dsn = "md:analytics?motherduck_token=eyJhbGciOi_fake_token"
+    local err = duckdb.attach("duckdb::memory:", dsn, "mdtok")
+    duckdb.detach("duckdb::memory:", "mdtok")
+    assert(not (err or ""):find("eyJhbGciOi_fake_token", 1, true),
+      "no token in the message: " .. tostring(err))
+  end)
+end)
+
+test("the secret-key list covers the audited libpq and token keywords", function()
+  local duckdb = require("dadbod-grip.adapters.duckdb")
+  -- Deliberately a structural assertion on the list itself, not a masking run
+  -- against a message this test composed: that shape proves nothing about the
+  -- real output (see the live tests above, which do). What it pins is the
+  -- outcome of the keyword audit -- including the two decided against.
+  local keys = duckdb._dsn_secret_keys
+  for _, key in ipairs({
+    "password", "sslpassword", "passwd", "pwd", "token", "motherduck_token",
+    "access_token", "auth_token", "session_token", "api_key", "apikey",
+    "secret", "secret_access_key",
+  }) do
+    eq(keys[key], true, key .. " is classified as a credential")
+  end
+  -- Paths, not secrets: masking one protects nothing and makes the error
+  -- unactionable.
+  for _, key in ipairs({ "passfile", "sslkey", "user", "dbname", "host" }) do
+    eq(keys[key], nil, key .. " is deliberately not masked")
+  end
+end)
+
+-- ── the failure path: no trace, and a legible error ──────────────────────
+
+test("the git-crypt hint reaches the user", function()
+  with_real_file(function(local_grip, env_path)
+    -- git-crypt's own magic header (see secrets.lua's GITCRYPT_MAGIC).
+    -- io.open in "wb" mode, not vim.fn.writefile(), so the leading NUL
+    -- byte survives -- writefile() would turn it into a newline and the
+    -- lock would never be detected.
+    local f = io.open(env_path, "wb")
+    f:write("\0GITCRYPT\0" .. string.rep("x", 20))
+    f:close()
+    vim.fn.writefile({ vim.fn.json_encode({
+      { name = "dev", url = "${LOCKED_URL}", env_file = env_path },
+    }) }, local_grip .. "/connections.json")
+
+    local captured
+    local harness_notify = vim.notify -- with_real_file's no-op stub
+    vim.notify = function(msg, level) captured = { msg = msg, level = level } end
+
+    connections.switch("${LOCKED_URL}", "dev")
+
+    vim.notify = harness_notify
+
+    assert(captured, "vim.notify was called")
+    eq(captured.level, vim.log.levels.ERROR, "reported at ERROR level")
+    assert(captured.msg:find("git-crypt unlock", 1, true),
+      "message tells the user how to fix it, got " .. tostring(captured.msg))
+    assert(captured.msg:find(env_path, 1, true),
+      "message names the locked file, got " .. tostring(captured.msg))
+  end)
+end)
+
+-- ── T:test on an unresolvable entry ───────────────────────────────────────
+-- Before this, T:test handed the literal "${VAR}" straight to db.ping(),
+-- which resolves internally, fails, and swallows the expansion error --
+-- the picker just showed a generic "x" fail, indistinguishable from a
+-- database that is actually unreachable.
+
+test("T:test reports the expansion error and marks it distinctly, not a bogus fail", function()
+  with_real_file(function(local_grip, env_path)
+    -- .env exists but the variable the URL references was renamed/removed.
+    vim.fn.writefile({ "SOMETHING_ELSE=1" }, env_path)
+    vim.fn.writefile({ vim.fn.json_encode({
+      { name = "dev", url = "${RENAMED_URL}", env_file = env_path },
+    }) }, local_grip .. "/connections.json")
+
+    local grip_picker = require("dadbod-grip.grip_picker")
+    local orig_picker_open = grip_picker.open
+    local captured
+    grip_picker.open = function(opts) captured = opts end
+    connections.pick()
+    grip_picker.open = orig_picker_open
+
+    assert(captured and captured.actions, "pick() reached grip_picker.open with actions")
+    local test_action
+    for _, a in ipairs(captured.actions) do
+      if a.label == "T:test" then test_action = a end
+    end
+    assert(test_action, "T:test action present")
+
+    local dev
+    for _, item in ipairs(captured.items) do
+      if item.name == "dev" then dev = item end
+    end
+    assert(dev, "dev present among picker items")
+
+    local captured_notify
+    local harness_notify = vim.notify -- with_real_file's no-op stub
+    vim.notify = function(msg, level) captured_notify = { msg = msg, level = level } end
+    test_action.fn(dev)
+    vim.notify = harness_notify
+
+    eq(connections.get_health(dev.url), "unresolved",
+      "health is a distinct 'unresolved' status, not the generic 'fail' a real ping would set")
+    assert(captured_notify, "the expansion error was surfaced via vim.notify")
+    eq(captured_notify.level, vim.log.levels.ERROR, "reported at ERROR level")
+    assert(captured_notify.msg:find("unresolved variable ${RENAMED_URL}", 1, true),
+      "message is the expander's, not a scheme error, got " .. tostring(captured_notify.msg))
+
+    -- The picker marker for it must not read as a plain failure ("x").
+    eq(captured.display(dev):sub(1, 1), "?", "distinct health marker for an unresolvable entry")
+  end)
+end)
+
+-- ── templates resolve where the *scheme* is what matters ─────────────────
+
+test("db.resolved_url gives dialect-sensitive callers a real scheme", function()
+  with_real_file(function(local_grip, env_path)
+    local url = seed_templated_conn(local_grip, env_path, "PG_URL",
+      "postgresql://u:hunter2@db.internal:5432/app")
+
+    eq(db.resolved_url(url), "postgresql://u:hunter2@db.internal:5432/app",
+      "template resolved for scheme dispatch")
+    eq(require("dadbod-grip.adapters").kind(db.resolved_url(url)), "postgresql",
+      "adapters.kind now sees postgresql, not nil")
+    eq(require("dadbod-grip.explain").detect_adapter(url), "postgresql",
+      "Query Doctor keeps its parser instead of degrading to 'unknown'")
+    eq(require("dadbod-grip.adapters").display_name(db.resolved_url(url)), "PostgreSQL",
+      "the LLM prompt gets the right dialect")
+  end)
+end)
+
+test("db.resolved_url leaves literals alone and never errors on a broken template", function()
+  with_real_file(function(local_grip, env_path)
+    eq(db.resolved_url("postgresql://u:p@h/db"), "postgresql://u:p@h/db", "literal unchanged")
+    eq(db.resolved_url(nil), nil, "nil unchanged")
+    vim.fn.writefile({ "SOMETHING_ELSE=1" }, env_path)
+    vim.fn.writefile({ vim.fn.json_encode({
+      { name = "dev", url = "${MISSING_URL}", env_file = env_path },
+    }) }, local_grip .. "/connections.json")
+    -- Best-effort: a display/dialect caller must degrade, not blow up.
+    eq(db.resolved_url("${MISSING_URL}"), "${MISSING_URL}", "unresolvable comes back as-is")
+    eq(require("dadbod-grip.explain").detect_adapter("${MISSING_URL}"), "unknown",
+      "and the caller falls back exactly as it did before this feature")
+  end)
+end)
+
+test("DROP TABLE on a templated postgres connection still emits CASCADE", function()
+  with_real_file(function(local_grip, env_path)
+    local url = seed_templated_conn(local_grip, env_path, "PG_URL",
+      "postgresql://u:hunter2@db.internal:5432/app")
+    local ddl = require("dadbod-grip.ddl")
+
+    -- No server is contacted: the DDL text is built from the adapter kind
+    -- alone, so only the FK lookup needs standing in for.
+    local orig_refs = db.get_referencing_foreign_keys
+    db.get_referencing_foreign_keys = function()
+      return { { table = "public.orders", column = "user_id", ref_column = "id" } }
+    end
+    local ok, err = pcall(ddl.drop_table, "public.users", url)
+    db.get_referencing_foreign_keys = orig_refs
+    assert(ok, "drop_table raised: " .. tostring(err))
+
+    -- destructive_confirm draws its preview into a scratch buffer and enters
+    -- its window, so the SQL that would run is readable right here.
+    local popup = table.concat(vim.api.nvim_buf_get_lines(0, 0, -1, false), "\n")
+    vim.api.nvim_win_close(0, true)
+
+    assert(popup:find("CASCADE", 1, true), "CASCADE survives on postgresql, got:\n" .. popup)
+    assert(not popup:find("doesn't support CASCADE", 1, true),
+      "no false 'this adapter can't CASCADE' note, got:\n" .. popup)
+  end)
+end)
+
+test("completion looks up duckdb attachments under the expanded URL", function()
+  with_real_file(function(local_grip, env_path)
+    local url = seed_templated_conn(local_grip, env_path, "DUCK_URL", "duckdb::memory:")
+    local duckdb = require("dadbod-grip.adapters.duckdb")
+    duckdb._attach_unchecked("duckdb::memory:", "sqlite:/tmp/side.db", "side")
+
+    -- What completion.lua does for `alias.<tab>`: the registry is keyed by
+    -- the expanded URL, the buffer variable holds the template.
+    eq(#duckdb.get_attachments(url), 0, "the template is not a registry key")
+    eq(#duckdb.get_attachments(db.resolved_url(url)), 1, "the resolved URL is")
+    duckdb.detach("duckdb::memory:", "side")
+  end)
+end)
+
+-- ── summary ─────────────────────────────────────────────────────────────────
+
+print(string.format("\nsecrets_integration_spec: %d passed, %d failed", pass, fail))
+if fail > 0 then os.exit(1) end

--- a/tests/spec/secrets_spec.lua
+++ b/tests/spec/secrets_spec.lua
@@ -147,6 +147,92 @@ test("has_template detects placeholders", function()
   eq(secrets.has_template("postgresql://u:p@h/db"), false, "literal")
 end)
 
+-- ── an empty value is not a resolution ────────────────────────────────────
+-- `KEY=` with nothing after it is the usual shape of a committed .env
+-- template. Substituting it produced postgresql://u:@h/db, which is not a
+-- failure anywhere downstream: strip_password sees an empty password, sets no
+-- PGPASSWORD, and psql falls through to ~/.pgpass -- so the connection can
+-- succeed against a *different* credential. Vim's getenv() already reports an
+-- empty process variable as unset; this is the .env path agreeing with it.
+
+test("an empty .env value is an error, not an empty substitution", function()
+  with_env_file("PW=\n", function(path)
+    local url, err = secrets.expand("postgresql://u:${PW}@h/db", { env_file = path })
+    eq(url, nil, "no URL is produced")
+    assert(err and err:find("${PW}", 1, true), "names the variable: " .. tostring(err))
+    assert(err:find("empty", 1, true), "says it is empty, not that it is missing: " .. err)
+    assert(err:find(path, 1, true), "names the file it came from: " .. err)
+  end)
+end)
+
+test("a quoted-empty .env value is an error too", function()
+  with_env_file('PW=""\n', function(path)
+    local url, err = secrets.expand("postgresql://u:${PW}@h/db", { env_file = path })
+    eq(url, nil, 'PW="" is the same nothing as PW=')
+    assert(err and err:find("empty", 1, true), tostring(err))
+  end)
+end)
+
+test("an empty process variable is an error as well", function()
+  vim.fn.setenv("GRIP_SPEC_EMPTY_VAR", "")
+  local url, err = secrets.expand("postgresql://u:${GRIP_SPEC_EMPTY_VAR}@h/db", {})
+  vim.fn.setenv("GRIP_SPEC_EMPTY_VAR", vim.NIL)
+  eq(url, nil, "no URL is produced")
+  assert(err and err:find("GRIP_SPEC_EMPTY_VAR", 1, true), tostring(err))
+end)
+
+test("a non-empty value alongside an empty one still fails as a whole", function()
+  with_env_file("USER_NAME=api\nPW=\n", function(path)
+    local url, err = secrets.expand("postgresql://${USER_NAME}:${PW}@h/db", { env_file = path })
+    eq(url, nil, "one empty variable fails the whole URL")
+    assert(err and err:find("${PW}", 1, true), "and names the empty one: " .. tostring(err))
+  end)
+end)
+
+test("a value that is only whitespace is still a value", function()
+  -- Deliberately not treated as empty: " " is a legal password, and
+  -- guessing which whitespace was meant is worse than substituting it.
+  with_env_file('PW=" "\n', function(path)
+    eq(secrets.expand("u:${PW}@h", { env_file = path }), "u: @h", "substituted verbatim")
+  end)
+end)
+
+-- ── $${NAME}: the escape ──────────────────────────────────────────────────
+-- Without it a literal password containing ${WORD} became an unresolvable
+-- template the moment this feature shipped, with no way out but rotating the
+-- password.
+
+test("$${NAME} produces a literal ${NAME} and resolves nothing", function()
+  eq(secrets.expand("postgresql://u:pa$${X9}ss@h/db", {}),
+    "postgresql://u:pa${X9}ss@h/db", "the escape is consumed, the placeholder is not")
+end)
+
+test("an escaped placeholder still reaches the expander", function()
+  -- has_template gates expansion; if it said false here the URL would be
+  -- handed to the CLI with the "$$" still in it.
+  eq(secrets.has_template("postgresql://u:pa$${X9}ss@h/db"), true,
+    "an escape is a template as far as the gate is concerned")
+end)
+
+test("an escape does not need the variable to exist", function()
+  local url, err = secrets.expand("u:$${NO_SUCH_VAR_AT_ALL}@h", {})
+  eq(err, nil, "no lookup happens for an escaped placeholder")
+  eq(url, "u:${NO_SUCH_VAR_AT_ALL}@h", "left as literal text")
+end)
+
+test("escaped and real placeholders coexist in one URL", function()
+  with_env_file("PW=hunter2\n", function(path)
+    eq(secrets.expand("postgresql://u:${PW}@h/db?tag=$${PW}", { env_file = path }),
+      "postgresql://u:hunter2@h/db?tag=${PW}", "one resolved, one left alone")
+  end)
+end)
+
+test("a lone $$ that is not followed by a placeholder is untouched", function()
+  eq(secrets.has_template("postgresql://u:pa$$word@h/db"), false, "not a template")
+  eq(secrets.expand("postgresql://u:pa$$word@h/db", {}), "postgresql://u:pa$$word@h/db",
+    "the escape is only special immediately before {NAME}")
+end)
+
 test("a missing env_file is an error naming the path", function()
   local _, err = secrets.expand("${X}", { env_file = "/nonexistent/path/.env" })
   assert(err and err:find("/nonexistent/path/.env", 1, true), "names the path")

--- a/tests/spec/secrets_spec.lua
+++ b/tests/spec/secrets_spec.lua
@@ -1,0 +1,156 @@
+-- secrets_spec.lua -- characterization + regression tests for secrets.lua,
+-- the standalone ${VAR} resolver that lets a connection entry point at a
+-- project .env file instead of carrying a password in connections.json.
+local secrets = require("dadbod-grip.secrets")
+
+local pass = 0
+local fail = 0
+
+local function test(name, fn)
+  local ok, err = pcall(fn)
+  if ok then
+    pass = pass + 1
+  else
+    fail = fail + 1
+    print("FAIL: " .. name .. ": " .. tostring(err))
+  end
+end
+
+local function eq(a, b, msg)
+  assert(a == b, (msg or "") .. ": expected " .. tostring(b) .. ", got " .. tostring(a))
+end
+
+local function with_env_file(contents, fn)
+  local path = vim.fn.tempname()
+  vim.fn.writefile(vim.split(contents, "\n"), path)
+  secrets.clear_cache()
+  local ok, err = pcall(fn, path)
+  vim.fn.delete(path)
+  secrets.clear_cache()
+  if not ok then error(err) end
+end
+
+--- Write raw bytes to `path` via plain Lua io, not vim.fn.writefile().
+--- Needed for the git-crypt fixture below: vim.fn.writefile() auto-promotes
+--- a Lua string with an embedded NUL byte to a Blob and then rejects it
+--- inside a list ("E974: Expected a Number or a String, Blob found"), and
+--- even in "b" binary mode vim.fn.readfile() maps a file's NUL bytes onto
+--- NL when it hands them back as a List<String>. Neither survives a
+--- literal "\0GITCRYPT\0" round-trip, so the fixture and the production
+--- code (see secrets.lua's is_git_crypt_locked) both go around vim.fn.
+local function write_bytes(path, bytes)
+  local f = io.open(path, "wb")
+  f:write(bytes)
+  f:close()
+end
+
+test("parses plain, exported, and quoted assignments", function()
+  with_env_file([[
+# a comment
+PLAIN=value1
+export EXPORTED=value2
+DQ="double quoted"
+SQ='single quoted'
+
+HASH="has # inside"
+]], function(path)
+    local vars = secrets.parse_env_file(path)
+    eq(vars.PLAIN, "value1", "plain")
+    eq(vars.EXPORTED, "value2", "export prefix stripped")
+    eq(vars.DQ, "double quoted", "double quotes stripped")
+    eq(vars.SQ, "single quoted", "single quotes stripped")
+    eq(vars.HASH, "has # inside", "# inside quotes is not a comment")
+  end)
+end)
+
+test("expands a full-URL template", function()
+  with_env_file("DB_URL=postgresql://u:p@h:5432/db", function(path)
+    local url, err = secrets.expand("${DB_URL}", { env_file = path })
+    eq(err, nil, "no error")
+    eq(url, "postgresql://u:p@h:5432/db", "expanded")
+  end)
+end)
+
+test("expands a password embedded in a URL", function()
+  with_env_file("PW=s3cr3t", function(path)
+    local url = secrets.expand("postgresql://u:${PW}@h:5432/db", { env_file = path })
+    eq(url, "postgresql://u:s3cr3t@h:5432/db", "inline substitution")
+  end)
+end)
+
+test("an unresolved variable is an error, not an empty string", function()
+  with_env_file("OTHER=x", function(path)
+    local url, err = secrets.expand("${MISSING}", { env_file = path })
+    eq(url, nil, "no URL returned")
+    assert(err and err:find("MISSING", 1, true), "error names the variable: " .. tostring(err))
+  end)
+end)
+
+test("falls back to the process environment", function()
+  vim.fn.setenv("GRIP_SPEC_FALLBACK", "from-env")
+  local url = secrets.expand("${GRIP_SPEC_FALLBACK}", {})
+  eq(url, "from-env", "process env used when no env_file")
+  vim.fn.setenv("GRIP_SPEC_FALLBACK", vim.NIL)
+end)
+
+test("a git-crypt encrypted file produces an actionable error", function()
+  local path = vim.fn.tempname()
+  write_bytes(path, "\0GITCRYPT\0binary-garbage")
+  secrets.clear_cache()
+  local _, err = secrets.expand("${ANY}", { env_file = path })
+  assert(err and err:lower():find("git%-crypt"), "mentions git-crypt: " .. tostring(err))
+  assert(err:find(path, 1, true), "names the file: " .. tostring(err))
+  vim.fn.delete(path)
+  secrets.clear_cache()
+end)
+
+test("cache is invalidated when the file changes", function()
+  local path = vim.fn.tempname()
+  vim.fn.writefile({ "V=first" }, path)
+  secrets.clear_cache()
+  eq(secrets.expand("${V}", { env_file = path }), "first", "first read")
+  vim.fn.writefile({ "V=second" }, path)
+  vim.fn.system({ "touch", "-t", "203001010000", path })
+  eq(secrets.expand("${V}", { env_file = path }), "second", "re-read after mtime change")
+  vim.fn.delete(path)
+end)
+
+test("a failed read is never cached, so an unlock takes effect on the next call", function()
+  local path = vim.fn.tempname()
+  write_bytes(path, "\0GITCRYPT\0binary-garbage")
+  -- Pin both writes below to the identical mtime (second resolution),
+  -- so this reproduces the case the mtime cache key cannot distinguish
+  -- on its own: the interesting assertion is that the *error* branch
+  -- never wrote a cache entry in the first place, not that the mtime
+  -- changed.
+  vim.fn.system({ "touch", "-t", "202001010000", path })
+  secrets.clear_cache()
+
+  local _, err = secrets.expand("${V}", { env_file = path })
+  assert(err and err:lower():find("git%-crypt"), "first read is the git-crypt error: " .. tostring(err))
+
+  -- "Unlock" in place, at the same mtime, without calling clear_cache().
+  -- If the failed read above had been cached, this would return the
+  -- stale failure (or a silently cached nil) instead of re-parsing.
+  vim.fn.writefile({ "V=unlocked" }, path)
+  vim.fn.system({ "touch", "-t", "202001010000", path })
+
+  local url = secrets.expand("${V}", { env_file = path })
+  eq(url, "unlocked", "retried and picked up the unlocked content with no clear_cache()")
+
+  vim.fn.delete(path)
+  secrets.clear_cache()
+end)
+
+test("has_template detects placeholders", function()
+  eq(secrets.has_template("${X}"), true, "placeholder")
+  eq(secrets.has_template("postgresql://u:p@h/db"), false, "literal")
+end)
+
+test("a missing env_file is an error naming the path", function()
+  local _, err = secrets.expand("${X}", { env_file = "/nonexistent/path/.env" })
+  assert(err and err:find("/nonexistent/path/.env", 1, true), "names the path")
+end)
+
+print(string.format("\nsecrets_spec: %d passed, %d failed", pass, fail))
+if fail > 0 then os.exit(1) end


### PR DESCRIPTION
Three related changes to how a connection is described and connected, in three commits that can be read in order.

## 1. `fix(security)` — passwords out of argv and out of error messages

`psql -P`-style argv is readable by any user on the machine (`ps -eo args`), so the password now reaches the client through its environment instead: `PGPASSWORD` (percent-decoded, as libpq expects), `MYSQL_PWD` and `SQLCMDPASSWORD` (verbatim — `parse_dadbod_url` deliberately does not decode, and decoding those would break existing passwords containing `%`). `run_cmd`/`run_cmd_async` gained an `opts.env` that merges into the inherited environment.

Two limits, both stated in the docs rather than glossed:

- This protects against *other users*, not against a process running as you, which reads your environment as easily as your argv.
- **It does not cover DuckDB federation.** `ATTACH` inlines the attached DSN into the SQL string passed to `duckdb -c`, so an attachment's password is in `ps` for the lifetime of every query against that connection. Pre-existing, but this branch newly routes `${VAR}` secrets onto that path, so it is called out explicitly in the CHANGELOG, README and `:help`, and tracked in #39.

URLs in error text are redacted through a shared `sql.redact_url`, including the case where the password itself contains `@` — the authority splits on the last `@`, not the first, which previously left `p@ssw0rd` masked as `***@ssw0rd`. DuckDB's federation path needed more: it rewrites the DSN before echoing it back, so masking the DSN *string* cannot work. The password *value* is masked wherever it appears, across all four places grip spawns the duckdb CLI.

## 2. `feat(connections)` — `${VAR}` from a project `.env`

An entry can reference its password instead of storing it:

```json
{ "name": "dev",
  "url": "postgresql://api:${DEV_DB_PASSWORD}@dev.internal:5432/app",
  "env_file": "~/work/api/.env" }
```

Values come from `env_file` first, falling back to the process environment. An unresolved *or empty* placeholder is an error, never a silent substitution — an empty one matters because `psql` would then fall through to `~/.pgpass` and connect with a different credential rather than failing. Such an entry shows `?` in the picker and names the variable it wanted.

The design point: `vim.g.db` holds the **template**, and expansion happens at the single dispatch point `db.resolve()`. No write path can leak the secret because no write path ever holds it. That is deliberate in preference to keeping the expanded URL around and scrubbing the paths that persist it — that approach fails the first time someone adds a path and forgets.

`.env` contents are memoized on mtime, so a rotated password is picked up on the next query; failed reads are never cached, so `git-crypt unlock` takes effect on the very next connect. A still-locked file is reported as locked rather than as a parse error.

**The cost:** a templated URL is grip-only. vim-dadbod's `:DB` and any statusline reading `g:db` see the literal `${VAR}`. A literal password that happens to contain `${WORD}` needs the documented `$${` escape.

## 3. `feat(connections)` — read-only mode and accent colour

`"mode": "ro"` connects through the client's own read-only switch (`PGOPTIONS`; a merge into mysql's existing `--init-command`, since a second flag silently discards the first along with `sql_mode`; `-readonly` for sqlite/duckdb but only on a file that already exists). Grid editing is off, and seven DDL entry points decline locally instead of prompting and failing at the server. `r` in the picker connects in the opposite mode for one session, in memory, never written back.

**This is a guard against accidents, not a security boundary** — every mechanism is reversible from the query pad; the boundary is a database role that cannot write. Also documented: an `options=` already in a postgres URL beats `PGOPTIONS`, so such a connection reports `RO` while its session is not read-only.

`"color"` tints borders, grid rules and the sidebar title from the palette already in the theme, with a `ctermfg` for every accent so nothing needs truecolor.

## Notable bugs found and fixed along the way

- `:GripRename` executed its `ALTER` against a read-only connection with **no refusal at all** — it guarded the ambient connection while acting on `session.url`. `:GripFill` had the inverse.
- Resolving the mode from ambient `vim.b.db`/`vim.g.db` gave an unrelated **rw** connection `-readonly` whenever some other connection was ro.
- `run_cmd` blocks in `vim.wait`, which pumps the event loop, so a scheduled `db.*` call lands inside another call's spawn; the mode flag is now saved and restored rather than cleared.
- FK navigation never consulted `db.is_readonly`, so following an FK produced an editable grid even on sqlserver (pre-existing).

## Testing

`tests/spec/readonly_mode_spec.lua` and `conn_color_spec.lua` are new; `adapter_env_spec`, `redact_spec`, `secrets_spec`, `connections_fields_spec` and `secrets_integration_spec` came with the first two commits. Full suite passes on Neovim 0.12 **and on 0.10.0, the CI floor, against a real binary**; luacheck 0/0 across 135 files.

Every new assertion was mutation-verified — a spec that silently skips still prints "ALL TESTS PASSED" in this suite. That discipline caught five tests that could not fail, including two written during this work: one that built its own copy of the error message DuckDB never emits, and one whose ordering assertion stayed green when the ordering did not happen.

Live checks against real binaries rather than mocks: duckdb v1.5.5 (the ATTACH leak was reproduced and re-tested), a throwaway mysql:8 container (confirming both halves of the `--init-command` claim), sqlite and duckdb read-only file matrices, and a local PostgreSQL for `PGOPTIONS` on/off.

## Review

Each of the four tasks was reviewed and went through fix rounds; the branch then had a whole-branch review that ran 16 mutations of its own, the suite on both Neovim versions, and live checks against postgres, mysql and duckdb. It returned 0 Critical, 3 Important, 7 Minor; the three Importants and two of the Minors are fixed in this branch, and the rest are #39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)