### PR TITLE
fix(tests): keep the suite off the developer's system clipboard

### DIFF
--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -5,4 +5,30 @@ vim.opt.rtp:prepend(".")
 -- the name works no matter which cwd nvim was launched from.
 package.path = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h")
   .. "/?.lua;" .. package.path
+
+-- An in-memory clipboard, so a test run cannot touch the developer's real one.
+--
+-- Copying to "+" is a deliberate feature of several keymaps -- json_tree's gy
+-- (JSONPath), the sidebar yank, the grid exports -- and specs drive them through
+-- feedkeys. Neovim's own provider shells out to pbcopy/xclip, so those specs
+-- replaced whatever was on the system clipboard: json_tree_spec's gy assertion
+-- left "$.nested.deep" there on every run, to surface in the developer's next
+-- paste. Registers are kept per-selection rather than aliased, and the paste
+-- handlers are wired up (cache_enabled = 0) so getreg("+") keeps reporting what
+-- the plugin wrote and the assertions on it stay meaningful.
+-- Guarded by tests/spec/clipboard_isolation_spec.lua.
+local selections = { ["+"] = { { "" }, "v" }, ["*"] = { { "" }, "v" } }
+local function copy_to(reg)
+  return function(lines, regtype) selections[reg] = { lines, regtype } end
+end
+local function paste_from(reg)
+  return function() return selections[reg][1], selections[reg][2] end
+end
+vim.g.clipboard = {
+  name = "grip-tests-in-memory",
+  copy = { ["+"] = copy_to("+"), ["*"] = copy_to("*") },
+  paste = { ["+"] = paste_from("+"), ["*"] = paste_from("*") },
+  cache_enabled = 0,
+}
+
 -- Do not call setup() for pure module tests

--- a/tests/spec/clipboard_isolation_spec.lua
+++ b/tests/spec/clipboard_isolation_spec.lua
@@ -1,0 +1,121 @@
+-- clipboard_isolation_spec.lua: the harness must never reach the OS clipboard.
+--
+-- Several keymaps copy to the "+" register on purpose -- json_tree's gy
+-- (JSONPath), the sidebar yank, the grid exports -- and specs drive those
+-- keymaps through feedkeys. With Neovim's real provider that shells out to
+-- pbcopy/xclip, so a plain `just test` replaced whatever the developer had
+-- copied: json_tree_spec's gy assertion left "$.nested.deep" on the macOS
+-- clipboard on every run, which then landed in the next paste.
+--
+-- Nothing inside nvim notices that, hence this spec. It pins the three
+-- properties the in-memory provider in tests/minimal_init.lua has to hold:
+-- it is in-process, it still round-trips so the "+"-asserting specs keep
+-- passing, and a write to "+" does not leave the process.
+
+local pass = 0
+local fail = 0
+
+local function test(name, fn)
+  local ok, err = pcall(fn)
+  if ok then
+    pass = pass + 1
+  else
+    fail = fail + 1
+    print("FAIL: " .. name .. ": " .. tostring(err))
+  end
+end
+
+local function eq(a, b, msg)
+  assert(a == b, (msg or "") .. ": expected " .. tostring(b) .. ", got " .. tostring(a))
+end
+
+local function truthy(a, msg)
+  assert(a, (msg or "") .. ": expected truthy, got " .. tostring(a))
+end
+
+--- Reads the real OS clipboard, bypassing Neovim entirely. Returns nil when the
+--- platform has no reader on PATH -- the CI runner is a headless ubuntu image
+--- with neither xclip nor a wayland socket, so the last test skips there.
+--- @return string|nil
+local function os_clipboard()
+  local readers = {
+    { "pbpaste" },                                  -- macOS
+    { "xclip", "-selection", "clipboard", "-o" },   -- X11
+    { "wl-paste", "--no-newline" },                 -- Wayland
+  }
+  for _, cmd in ipairs(readers) do
+    if vim.fn.executable(cmd[1]) == 1 then
+      local out = vim.fn.system(cmd)
+      if vim.v.shell_error == 0 then return out end
+      return nil -- reader present but unusable (no DISPLAY, no wayland socket)
+    end
+  end
+  return nil
+end
+
+-- ── provider shape ───────────────────────────────────────────────────────────
+
+test("harness installs a named in-memory clipboard provider", function()
+  local cb = vim.g.clipboard
+  truthy(cb, "tests/minimal_init.lua sets vim.g.clipboard")
+  eq(cb.name, "grip-tests-in-memory", "provider name")
+end)
+
+test("provider handlers are Lua functions, not shell commands", function()
+  local cb = vim.g.clipboard
+  for _, reg in ipairs({ "+", "*" }) do
+    -- A provider may also be declared as an argv table (e.g. { "pbcopy" }).
+    -- That is exactly the shape that would leave the process, so assert the
+    -- handlers are callables rather than merely non-nil.
+    eq(type(cb.copy[reg]), "function", "copy handler for " .. reg)
+    eq(type(cb.paste[reg]), "function", "paste handler for " .. reg)
+  end
+end)
+
+-- ── still behaves like a clipboard ───────────────────────────────────────────
+
+test("setreg/getreg round-trip through the provider", function()
+  for _, reg in ipairs({ "+", "*" }) do
+    vim.fn.setreg(reg, "round-trip via " .. reg)
+    eq(vim.fn.getreg(reg), "round-trip via " .. reg, "round-trip for " .. reg)
+  end
+end)
+
+-- Per-selection slots, the X11 model. macOS backs both registers with the one
+-- pasteboard, but no plugin code writes to "*", so the harness picks the shape
+-- that catches an implementation aliasing the two handlers onto one slot.
+test("the two selection registers stay independent", function()
+  vim.fn.setreg("+", "plus value")
+  vim.fn.setreg("*", "star value")
+  eq(vim.fn.getreg("+"), "plus value", "+ unaffected by a * write")
+  eq(vim.fn.getreg("*"), "star value", "* holds its own value")
+end)
+
+test("linewise yanks keep their regtype", function()
+  vim.fn.setreg("+", { "one", "two" }, "l")
+  eq(vim.fn.getreg("+"), "one\ntwo\n", "linewise text")
+  eq(vim.fn.getregtype("+"), "V", "linewise regtype survives the round-trip")
+end)
+
+-- ── the actual regression ────────────────────────────────────────────────────
+
+test("a write to \"+\" does not reach the OS clipboard", function()
+  local before = os_clipboard()
+  if before == nil then
+    print("clipboard_isolation_spec: SKIPPED os-clipboard check (no reader on PATH)")
+    return
+  end
+  -- Asserted against the sentinel rather than against `before`, so a copy made
+  -- by another app while this spec runs cannot flake it. If the provider ever
+  -- shells out again, the sentinel is what shows up.
+  local sentinel = "grip-clipboard-isolation-sentinel"
+  vim.fn.setreg("+", sentinel)
+  local after = os_clipboard()
+  truthy(after ~= nil, "os clipboard still readable after the write")
+  truthy(not vim.startswith(after, sentinel), "sentinel must not escape to the OS clipboard")
+end)
+
+-- ── summary ──────────────────────────────────────────────────────────────────
+
+print(string.format("\nclipboard_isolation_spec: %d passed, %d failed", pass, fail))
+if fail > 0 then os.exit(1) end


### PR DESCRIPTION
## Problem

Copying to the `+` register is a deliberate feature of several keymaps — `json_tree`'s `gy` (JSONPath), the sidebar yank, the grid exports — and specs drive those keymaps through `feedkeys`. Neovim's real provider shells out to `pbcopy`/`xclip`, so **running the test suite replaced whatever the developer had on their clipboard.**

`json_tree_spec`'s `gy` assertion was the loudest case — every run left `$.nested.deep` on the macOS clipboard, which then turned up in the next paste long after the run was forgotten:

```
$ printf 'MARKER' | pbcopy
$ nvim --headless -u tests/minimal_init.lua -l tests/spec/json_tree_spec.lua
json_tree_spec: 36 passed, 0 failed
$ pbpaste
$.nested.deep
```

The macOS clipboard history on the machine where this was found had 122 copies of that one string.

Writes to `+` also come from `schema.lua`, `view/keymaps_edit.lua` (4 sites) and `view/keymaps_aggregate.lua`, so the leak is not specific to one spec. Nothing inside nvim reports it, which is why it went unnoticed.

## Fix

`tests/minimal_init.lua` installs an in-memory `g:clipboard` provider. Specs are unaffected: the handlers are Lua closures, so `setreg`/`getreg("+")` still round-trip and assertions on the register stay meaningful — the value just never leaves the process. Registers are kept per-selection and the paste handlers are wired up (`cache_enabled = 0`) rather than relying on Neovim's cache.

## Test

`tests/spec/clipboard_isolation_spec.lua` (6 assertions) pins the provider's shape, the round-trip incl. linewise regtype, and the regression itself — it reads the OS clipboard back through `pbpaste`/`xclip`/`wl-paste` and asserts a sentinel written to `+` did not escape. It compares against the sentinel rather than a before/after snapshot, so a copy made by another app mid-run cannot flake it, and it skips cleanly where no reader is on `PATH` (the CI image has none).

Written failing first — before the fix: `2 passed, 4 failed`, and the run itself left the sentinel on the clipboard.

## Verification

- `nvim --headless -u tests/minimal_init.lua -l tests/run_specs.lua` → `RESULT: ALL TESTS PASSED`, and the clipboard still held its pre-run marker afterwards
- `luacheck lua/ plugin/ lazy.lua tests/` → 0 warnings / 0 errors in 136 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)