### PR TITLE
ci: install the DuckDB sqlite scanner before the query timeout applies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,24 @@ jobs:
       # is not redundant with GRIP_REQUIRE_DUCKDB below: this one names the cause.
       - name: Verify DuckDB is on PATH
         run: duckdb --version
+      # The ATTACH prefix the adapter prepends to a query carries "INSTALL
+      # sqlite_scanner" with it, so on a runner with an empty ~/.duckdb the fetch
+      # from extensions.duckdb.org has to fit inside the 10s query timeout. When it
+      # doesn't, duckdb dies with code 124 and duckdb_federation_spec reports 11
+      # failures that have nothing to do with the commit under test. Installing it
+      # here leaves that in-query INSTALL a local no-op; the retries stop one slow
+      # fetch from failing the run, and a genuinely unreachable extension repo fails
+      # in this step, where the message says so.
+      - name: Pre-install the DuckDB sqlite scanner
+        run: |
+          for attempt in 1 2 3; do
+            if duckdb -c "INSTALL sqlite_scanner; LOAD sqlite_scanner;"; then
+              exit 0
+            fi
+            echo "sqlite_scanner install failed (attempt $attempt of 3)"
+            sleep 5
+          done
+          exit 1
       - name: Run unit tests
         # Turns a missing duckdb/sqlite3 into a failure instead of a silent skip,
         # so removing the step above can't quietly take those 66 assertions with it.


### PR DESCRIPTION
## Why

`test (stable)` failed on attempt 1 of the run for `010d91d` (PR #38) with 11 failures in `duckdb_federation_spec` and 2 in `secrets_integration_spec`, the latter naming `duckdb exited with code 124`. A re-run passed with no change to the code, and `test (v0.10.0)` had passed the same specs on its own runner.

The cause is not the commit under test. `build_attach_prefix()` prepends `INSTALL sqlite_scanner; LOAD sqlite_scanner;` to every query on a connection that has attachments, and the federation specs attach a `sqlite:` DSN. The CLI is unzipped fresh into `$RUNNER_TEMP` each job, so `~/.duckdb` is empty and that `INSTALL` is a download from `extensions.duckdb.org` — which has to complete inside the 10s query timeout together with the query itself. The failing job's log shows two clean ten-second gaps where it did not.

This never reproduces locally: the extension is already in `~/.duckdb/extensions/v1.5.5/`.

## What changed

One step, after the one that puts `duckdb` on `PATH`:

- The install happens outside the query timeout, so the in-query `INSTALL` becomes a local no-op.
- Three attempts, so one slow fetch does not fail the run.
- An extension repo that really is unreachable now fails in a step whose name says what broke, rather than as thirteen assertions about missing catalogs.

## Verification

- Both paths of the new step exercised locally: success exits 0, three failures exit 1.
- `.github/workflows/test.yml` parses, with the step between `Verify DuckDB is on PATH` and `Run unit tests`.
- Full suite green locally under `GRIP_REQUIRE_DUCKDB=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)