### PR TITLE
fix(duckdb): give a first-use scanner INSTALL room to finish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cursor on the type row those three could aggregate, filter or build a filter against a
   neighbouring column. All four now call `ctx.cursor_column()`, which resolves through
   `resolve_row_bp` — the row-type-aware path the fourth copy (`=`, column width) already used.
+- **The first attach of a scanner-backed database could time out and report itself as a broken
+  DSN.** Attaching a `postgres:`/`mysql:`/`sqlite:`/`md:` database makes DuckDB fetch the matching
+  scanner extension from `extensions.duckdb.org`, and that download had to fit inside the ordinary
+  10-second query budget — together with the query itself. When it did not, `duckdb` was killed at
+  code 124 and the failure surfaced as `Failed to attach database`, blaming a DSN that was
+  perfectly good; on an already-attached connection the same 10 seconds covered a first query,
+  a first DML statement or the completion pre-warm, whose budget is shorter still. A call whose
+  `INSTALL` may actually have to fetch something now gets the same 60-second allowance an `httpfs`
+  query has always had, across all four paths that spawn the CLI. The allowance is deliberately
+  not unconditional: a warm `INSTALL` is a local no-op, so it is spent once per extension per
+  session, and an attached database that has gone unreachable still fails in 10 seconds rather
+  than 60. This is the same fetch that made CI's `test (stable)` leg fail 13 assertions about
+  catalogs that were never attached, while the `v0.10.0` leg passed the same specs.
 - **`s`, `S` and `gS` refused to work off a data row.** Sorting and column statistics are
   column-scoped, so pressing them with the cursor on the header — the most natural place to reach
   for a sort — did nothing but print "Move cursor to a column". `_snap_col`'s own docblock names
@@ -136,6 +149,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   DuckDB minors; a bump should be a deliberate commit. The three specs still skip locally when
   `duckdb` is absent, but CI sets `GRIP_REQUIRE_DUCKDB=1`, which turns a missing binary into a
   failure so the install step cannot be dropped without the suite going red.
+
+- **CI installs the DuckDB sqlite scanner before the suite runs.** The runner unzips a fresh CLI
+  into `RUNNER_TEMP` each job, so `~/.duckdb` starts empty and the first federated query paid for
+  the extension download inside its own timeout — which is how `test (stable)` went red on a
+  commit that had nothing to do with it while `test (v0.10.0)`, on a different runner, passed.
+  The install is now its own step, retried up to three times, so a slow fetch costs seconds
+  instead of a spurious failure and an unreachable extension repository fails in a step that says
+  so rather than as thirteen assertions about missing catalogs.
 
 - **luacheck now covers `tests/` too, and the specs it flagged were fixed rather than silenced.**
   Excluding the suite from the gate in 3.9.0 left 15 warnings unexamined; read individually, most

--- a/lua/dadbod-grip/adapters/duckdb.lua
+++ b/lua/dadbod-grip/adapters/duckdb.lua
@@ -10,12 +10,21 @@ local esc      = sql_util.escape_literal
 local M = {}
 
 local DEFAULT_TIMEOUT = 10000
-local HTTP_TIMEOUT    = 60000
+--- Budget for a CLI call that may have to reach the network before it can answer:
+--- an httpfs query fetching the remote file, or a first-use INSTALL fetching a
+--- scanner extension from extensions.duckdb.org. Both are the same shape of cost,
+--- and neither fits in DEFAULT_TIMEOUT on a cold cache.
+local NETWORK_TIMEOUT = 60000
 
 --- Track whether httpfs has been loaded in this Neovim session.
 --- INSTALL is only needed once; after that LOAD suffices.
 --- Reset to nil if an httpfs error occurs so the next query retries INSTALL.
 local _httpfs_state = nil  -- nil = unknown, "installed" = ready, "failed" = unavailable
+
+--- Scanner extensions whose INSTALL has already come back clean this session:
+--- extension name -> true. Only read to decide a timeout, never to change the
+--- SQL -- see attach_install_pending().
+local _installed_ext = {}
 
 --- Attachment registry: url -> { {dsn, alias, extension}, ... }
 --- Populated by M.attach(), persisted via connections.lua.
@@ -201,6 +210,29 @@ local function build_attach_prefix(url)
   return table.concat(parts, "\n") .. "\n"
 end
 
+--- True when the INSTALL statements build_attach_prefix() just emitted may still
+--- have to fetch something. The prefix always carries them -- a warm INSTALL is a
+--- local no-op, so there is no reason to vary the SQL -- but the first one per
+--- extension is a download, and that is the only case worth widening the timeout
+--- for. Keeping it conditional is what stops an unreachable attached database
+--- from taking NETWORK_TIMEOUT to report itself on every single query.
+local function attach_install_pending(url)
+  for _, a in ipairs(_attachments[url] or {}) do
+    if a.extension and not _installed_ext[a.extension] then return true end
+  end
+  return false
+end
+
+--- Record the extensions a finished call had in its prefix as installed.
+--- Only a clean exit counts: a non-zero code can mean the fetch itself failed,
+--- and remembering that as installed would cost the retry its headroom.
+local function note_ext_installed(url, code)
+  if code ~= 0 then return end
+  for _, a in ipairs(_attachments[url] or {}) do
+    if a.extension then _installed_ext[a.extension] = true end
+  end
+end
+
 --- Extract file path from dadbod's duckdb: URL format.
 --- "duckdb:path/to/db.duckdb"    -> "path/to/db.duckdb"
 --- "duckdb:/absolute/path.db"    -> "/absolute/path.db"
@@ -308,6 +340,9 @@ local function duckdb(db_path, sql_str, timeout_ms, url)
   -- Prepend ATTACH statements for cross-database federation
   if url then
     effective_sql = build_attach_prefix(url) .. effective_sql
+    if attach_install_pending(url) then
+      effective_timeout = math.max(effective_timeout, NETWORK_TIMEOUT)
+    end
   end
 
   if sql_str:find("https?://") then
@@ -319,7 +354,7 @@ local function duckdb(db_path, sql_str, timeout_ms, url)
       prefix = "INSTALL httpfs; LOAD httpfs;\n"
     end
     effective_sql = prefix .. effective_sql
-    effective_timeout = math.max(effective_timeout, HTTP_TIMEOUT)
+    effective_timeout = math.max(effective_timeout, NETWORK_TIMEOUT)
   end
 
   local args = duckdb_args(db_path, adapters.session_opts(), { "-csv", "-header" })
@@ -336,6 +371,8 @@ local function duckdb(db_path, sql_str, timeout_ms, url)
       _httpfs_state = "installed"
     end
   end
+
+  if url then note_ext_installed(url, code) end
 
   -- The ATTACH prefix carried the attachment DSNs into this process; a failing
   -- attachment gets them quoted back. Masked here rather than at each of the
@@ -364,11 +401,17 @@ end
 --- from the main Neovim loop via vim.schedule. Used for schema pre-warming.
 local function duckdb_async(db_path, sql_str, timeout_ms, url, callback)
   local effective_sql = url and (build_attach_prefix(url) .. sql_str) or sql_str
+  local effective_timeout = timeout_ms or 8000
+  -- Same one-off extension fetch as in duckdb(), from a shorter starting budget.
+  if url and attach_install_pending(url) then
+    effective_timeout = math.max(effective_timeout, NETWORK_TIMEOUT)
+  end
   local args = duckdb_args(db_path, adapters.session_opts(), { "-csv", "-header" })
   args[#args + 1] = "-c"
   args[#args + 1] = effective_sql
-  vim.system(args, { text = true, timeout = timeout_ms or 8000 }, function(out)
+  vim.system(args, { text = true, timeout = effective_timeout }, function(out)
     vim.schedule(function()
+      if url then note_ext_installed(url, out.code) end
       -- Same reason as in duckdb(): the ATTACH prefix is in this SQL.
       callback(out.stdout or "", redact_query_error(out.stderr or "", url), out.code)
     end)
@@ -378,8 +421,14 @@ end
 --- Run DML without CSV mode (to get change count output).
 local function duckdb_exec(db_path, sql_str, timeout_ms, url)
   local effective_sql = sql_str
+  local effective_timeout = timeout_ms or DEFAULT_TIMEOUT
   if url then
     effective_sql = build_attach_prefix(url) .. effective_sql
+    -- Same one-off extension fetch as in duckdb(): a DML statement against an
+    -- attached table is as likely to be the first call of the session as a SELECT.
+    if attach_install_pending(url) then
+      effective_timeout = math.max(effective_timeout, NETWORK_TIMEOUT)
+    end
   end
 
   local args = duckdb_args(db_path, adapters.session_opts())
@@ -387,7 +436,8 @@ local function duckdb_exec(db_path, sql_str, timeout_ms, url)
   args[#args + 1] = effective_sql
 
   -- Same reason as in duckdb(): the ATTACH prefix is in this SQL.
-  local stdout, stderr, code = adapters.run_cmd(args, timeout_ms or DEFAULT_TIMEOUT)
+  local stdout, stderr, code = adapters.run_cmd(args, effective_timeout)
+  if url then note_ext_installed(url, code) end
   return stdout, redact_query_error(stderr, url), code
 end
 
@@ -1113,8 +1163,14 @@ function M.attach(url, dsn, alias, template)
   -- Validate: try the ATTACH before storing (a broken attachment kills all queries)
   local ext = detect_extension(dsn)
   local test_sql = ""
+  local timeout = DEFAULT_TIMEOUT
   if ext then
     test_sql = string.format("INSTALL %s; LOAD %s;\n", ext, ext)
+    -- This is the first INSTALL of the scanner in most sessions -- the attachment
+    -- has to exist before any query can carry the prefix -- so this is the call
+    -- most likely to be paying for the download. Validation that times out at 10s
+    -- rejects a perfectly good DSN with "Failed to attach database".
+    if not _installed_ext[ext] then timeout = NETWORK_TIMEOUT end
   end
   test_sql = test_sql .. string.format("ATTACH IF NOT EXISTS '%s' AS %s;\n", esc(dsn), alias)
   test_sql = test_sql .. "SELECT 42;"
@@ -1124,13 +1180,17 @@ function M.attach(url, dsn, alias, template)
   -- (both also open the same file), causing "Failed to lock file" on connection switch.
   local args = { "duckdb", "-c", test_sql }
 
-  local _, stderr_attach, code_attach = adapters.run_cmd(args, 10000)
+  local _, stderr_attach, code_attach = adapters.run_cmd(args, timeout)
   if code_attach ~= 0 then
     -- The DSN is in the SQL the CLI just rejected, so its stderr can quote
     -- the credentials straight back at us. Never return it raw.
     local msg = redact_attach_error(stderr_attach:gsub("%s+$", ""), dsn)
     return msg ~= "" and msg or "Failed to attach database"
   end
+
+  -- The validation call above ran the INSTALL and came back clean, so the queries
+  -- that follow do not have to budget for the fetch a second time.
+  if ext then _installed_ext[ext] = true end
 
   store_attachment(url, dsn, alias, template)
   -- warm_schema is NOT scheduled here: the caller (connections.switch or GripAttach)
@@ -1317,5 +1377,9 @@ M._unsupported_attach_scheme = unsupported_attach_scheme
 M._make_schema_batch_sql = _make_schema_batch_sql
 M._main_catalog_name = main_catalog_name
 M._nested_json_sql = nested_json_sql
+--- Drop the record of which scanners are installed. Test-only: the timeout a
+--- query gets depends on that state, so a spec asserting on either branch has to
+--- be able to start from a cold session.
+M._forget_installed_extensions = function() _installed_ext = {} end
 
 return M

--- a/tests/spec/adapter_spec.lua
+++ b/tests/spec/adapter_spec.lua
@@ -685,6 +685,95 @@ test("duckdb query: http URL also triggers httpfs", function()
   end)
 end)
 
+-- ── DuckDB scanner extension install timeout ────────────────────────────────
+-- The ATTACH prefix carries "INSTALL <scanner>" into every query on an attached
+-- connection, and the first one has to fetch that extension from
+-- extensions.duckdb.org -- the same cost the httpfs block above already buys
+-- headroom for. Without it the fetch has to fit inside the 10s query timeout,
+-- which is what took CI's test (stable) down on the run for 010d91d: duckdb
+-- killed at 124, and 13 assertions failing about catalogs that were never
+-- attached. The headroom is deliberately not unconditional -- a warm INSTALL is
+-- a local no-op, and an unreachable database should still fail in 10s, not 60.
+
+test("duckdb query: a cold scanner INSTALL gets the network timeout", function()
+  duckdb._forget_installed_extensions()
+  local url = "duckdb:cold_scanner.db"
+  duckdb._attach_unchecked(url, "sqlite:legacy.db", "legacy")
+  with_executable(function()
+    local _, opts = capture_system_call("col\nval\n", function()
+      duckdb.query("SELECT * FROM legacy.orders", url)
+    end)
+    assert(opts.timeout >= 60000,
+      "a cold scanner fetch needs >= 60000, got " .. tostring(opts.timeout))
+  end)
+  duckdb.detach(url, "legacy")
+end)
+
+test("duckdb query: a scanner installed earlier this session keeps the default timeout", function()
+  duckdb._forget_installed_extensions()
+  local url = "duckdb:warm_scanner.db"
+  duckdb._attach_unchecked(url, "sqlite:legacy.db", "legacy")
+  with_executable(function()
+    -- Arrange: one clean exit, which is what marks the scanner installed.
+    capture_system_call("col\nval\n", function() duckdb.query("SELECT 1", url) end)
+    local _, opts = capture_system_call("col\nval\n", function()
+      duckdb.query("SELECT 1", url)
+    end)
+    eq(opts.timeout, 10000, "a warm scanner must not buy network headroom")
+  end)
+  duckdb.detach(url, "legacy")
+end)
+
+test("duckdb query: a query with no attachments keeps the default timeout", function()
+  duckdb._forget_installed_extensions()
+  with_executable(function()
+    local _, opts = capture_system_call("col\nval\n", function()
+      duckdb.query("SELECT 1", "duckdb::memory:")
+    end)
+    eq(opts.timeout, 10000, "an unattached query has no INSTALL to wait for")
+  end)
+end)
+
+test("duckdb query: a scanner whose query failed keeps the network timeout next time", function()
+  duckdb._forget_installed_extensions()
+  local url = "duckdb:failed_scanner.db"
+  duckdb._attach_unchecked(url, "postgres:dbname=sales", "pg")
+  with_executable(function()
+    -- A non-zero exit says nothing about whether the fetch got through, so it
+    -- must not be remembered as an install that succeeded.
+    with_system_mock("", 'Extension "postgres_scanner" not found', 1, function()
+      duckdb.query("SELECT 1", url)
+    end)
+    local _, opts = capture_system_call("col\nval\n", function()
+      duckdb.query("SELECT 1", url)
+    end)
+    assert(opts.timeout >= 60000,
+      "a failed install must not count as installed, got " .. tostring(opts.timeout))
+  end)
+  duckdb.detach(url, "pg")
+end)
+
+test("duckdb attach: validating a scanner-backed DSN gets the network timeout", function()
+  duckdb._forget_installed_extensions()
+  local url = "duckdb:attach_scanner.db"
+  local _, opts = capture_system_call("42\n", function()
+    duckdb.attach(url, "md:cloud_db", "cloud")
+  end)
+  assert(opts.timeout >= 60000,
+    "attach validation runs the very first INSTALL, got " .. tostring(opts.timeout))
+  duckdb.detach(url, "cloud")
+end)
+
+test("duckdb attach: a DSN with no scanner keeps the default validation timeout", function()
+  duckdb._forget_installed_extensions()
+  local url = "duckdb:attach_plain.db"
+  local _, opts = capture_system_call("42\n", function()
+    duckdb.attach(url, "/tmp/plain.duckdb", "plain")
+  end)
+  eq(opts.timeout, 10000, "no scanner means no fetch to wait for")
+  duckdb.detach(url, "plain")
+end)
+
 -- ── SQLite get_constraints ───────────────────────────────────────────────────
 
 test("sqlite get_constraints: queries sqlite_master with table name", function()
@@ -1140,6 +1229,23 @@ for _, case in ipairs(BATCH_ARGV_CASES) do
     eq_argv(async_argv, sync_argv, case.name .. " async argv must match sync argv")
   end)
 end
+
+-- Lives here rather than beside the other scanner-timeout tests because it needs
+-- await_batch. The pre-warm path prepends the same ATTACH prefix, so it pays the
+-- same one-off extension fetch -- and it starts from a *shorter* budget than a
+-- foreground query, so without the headroom it is the first thing to time out on
+-- a cold connection.
+test("duckdb get_schema_batch_async: a cold scanner INSTALL gets the network timeout", function()
+  duckdb._forget_installed_extensions()
+  local url = "duckdb:async_scanner.db"
+  duckdb._attach_unchecked(url, "sqlite:legacy.db", "legacy")
+  local _, opts = capture_system_call("", function()
+    await_batch(function(cb) duckdb.get_schema_batch_async(url, cb) end)
+  end)
+  assert(opts.timeout >= 60000,
+    "the pre-warm path pays the same fetch, got " .. tostring(opts.timeout))
+  duckdb.detach(url, "legacy")
+end)
 
 -- Adapters must not silently lose the async variant: warm_schema is a no-op
 -- without it, which is exactly the regression this section exists to prevent.


### PR DESCRIPTION
## Why

The CI-side companion to #41, on the production side. Attaching a `postgres:`/`mysql:`/`sqlite:`/`md:` database makes DuckDB fetch the matching scanner extension from `extensions.duckdb.org`. Every path that can trigger that fetch budgeted `DEFAULT_TIMEOUT` (10s) for it — and had to fit the actual query into the same 10s:

- `M.attach`'s validation call, which in most sessions is where the very first `INSTALL` of that scanner runs. A fetch that overran it returned `Failed to attach database` against a DSN that was perfectly good.
- `duckdb()` and `duckdb_exec()`, for the first query or DML on an attached connection.
- `duckdb_async()`, the completion pre-warm, from a shorter 8s budget still.

`httpfs` already had this exact problem and this exact answer — 60s when the query has to reach the network. The constant is now named for what both uses have in common (`NETWORK_TIMEOUT`), and the ATTACH prefix gets the same allowance.

Measured against a cold `~/.duckdb`: the `sqlite_scanner` fetch alone is 1.3s on a fast connection. On a congested runner it is what killed the `test (stable)` leg at code 124 on the run for `010d91d`, with 13 assertions failing about catalogs that were never attached, while `test (v0.10.0)` passed the same specs.

## What changed

The allowance is **conditional**, tracked per extension in `_installed_ext`:

- A warm `INSTALL` is a local no-op, so the headroom is spent once per extension per session.
- An attached database that has gone unreachable still reports itself in 10s, not 60.
- Only a clean exit marks an extension installed — a non-zero code can mean the fetch itself failed, and remembering that as success would cost the retry its headroom.
- The SQL is unchanged: the prefix still always carries `INSTALL`, since varying it would buy nothing and churn the attach-prefix assertions for no reason.

## Verification

Seven specs, each watched failing first (`10000`/`8000` against the required `>= 60000`). The three that pin the *absence* of the allowance were checked against deliberately broken builds, because a test that passes the moment it is written proves nothing:

| Guard test | Mutation that makes it fail |
|---|---|
| a warm scanner keeps the default timeout | unconditional raise in `duckdb()` |
| a query with no attachments keeps the default | same |
| a DSN with no scanner keeps the default | raise moved outside `if ext` in `M.attach` |
| a failed query does not count as installed | `code ~= 0` guard removed from `note_ext_installed` |

- Full suite with `GRIP_REQUIRE_DUCKDB=1`, so the 66 gated DuckDB assertions actually ran: `ALL TESTS PASSED` (`adapter_spec` 115 → 122).
- `luacheck lua/ plugin/ lazy.lua tests/`: 0 warnings / 0 errors in 136 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)