### PR TITLE
docs: connection sources, dedup order, and the pooler read-only limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,24 @@ https://host/data.parquet  ← remote file via httpfs
 duckdb::memory:            ← single-query scratch (tables don't persist between queries)
 ```
 
+Beyond `name` and `url`, what an entry can carry depends on where it lives:
+
+| field | `connections.json` | `g:dbs` |
+|-------|--------------------|---------|
+| `name`, `url` | yes | yes |
+| `type` | yes | no |
+| `env_file` | yes | no |
+| `mode` | yes | no |
+| `color` | yes | no |
+| `attachments` | yes | no |
+
+`g:dbs` is read as the vim-dadbod-ui format, so a `color` or `mode` written there is discarded on
+read — those belong in `.grip/connections.json` or `~/.grip/connections.json`.
+
+Sources are deduplicated by URL in this order: discovered Docker containers, project file, global
+file, `g:dbs`, `$DATABASE_URL`, `g:db`. The first hit wins and later duplicates are dropped whole,
+so an entry can keep its URL in `g:dbs` while its `color` and `mode` live in the JSON file.
+
 ### Keeping the password out of the connection file
 
 A connection entry can reference its password instead of storing it. Any `${NAME}` in the URL is
@@ -185,7 +203,7 @@ reversible from the query pad: `begin; set transaction read write; …` on postg
 equivalents elsewhere. If a connection must not be able to write, give it a database role that
 cannot — that is the boundary; `mode` is the seatbelt.
 
-Two more limits worth knowing:
+Three more limits worth knowing:
 
 - If the postgres URL already carries its own `options=` parameter, that wins over `PGOPTIONS`, so
   the session is not actually read-only even though grip shows it as `RO`. Connecting such an entry
@@ -194,6 +212,32 @@ Two more limits worth knowing:
 - `-readonly` is applied only to a database file that already exists. `duckdb::memory:` and a
   not-yet-created sqlite file connect normally — the flag would abort the former outright and turn
   "create it" into an error for the latter.
+- A connection pooler refuses the option outright. Pgbouncer-compatible poolers (DigitalOcean's
+  pooler port, for instance) reject unknown startup parameters, so `PGOPTIONS` does not degrade the
+  session — it fails the connection with `FATAL: unsupported startup parameter in options:
+  default_transaction_read_only`. Unlike the two limits above, this is not an overstated `RO`
+  badge; there is no session at all. Point a `mode: "ro"` entry at the direct port rather than the
+  pooled one.
+
+### Colour-coding a connection
+
+An entry can carry `"color"`, and grip tints that connection's window borders, grid rules and
+schema sidebar title, so a red production connection does not look like a green local one:
+
+```json
+{ "name": "prod", "url": "postgresql://…", "mode": "ro", "color": "red" }
+```
+
+The value is one of `green`, `orange`, `red`, `blue`, `violet`, `yellow`, or a `#rrggbb` string.
+Every accent also carries a `ctermfg` — a hex value is approximated onto the nearest xterm palette
+entry — so none of this needs a truecolor terminal. An unknown value is ignored rather than raised.
+
+Three highlight groups carry it: `GripConnAccent`, `GripConnAccentBold` (the sidebar title), and
+`GripBorder`, which is *derived* from the accent. That derivation is what makes an entry without a
+`color` restore the default border instead of leaving the previous connection's tint behind. All
+three are redefined on every connection switch and re-applied whenever highlights are rebuilt, so
+they survive a `:colorscheme` change — and because they are redefined rather than merged, defining
+them yourself will not stick.
 
 ### Cross-database federation (DuckDB as hub)
 

--- a/doc/dadbod-grip.txt
+++ b/doc/dadbod-grip.txt
@@ -932,7 +932,18 @@ Add a new connection: >
 Or run `:GripConnect` with no arguments to pick from known connections
 or add a new one interactively.
 
-Connections are deduplicated by URL across all sources.
+Connections are deduplicated by URL across all sources. The order is:
+
+  1. discovered Docker containers
+  2. .grip/connections.json          (project)
+  3. ~/.grip/connections.json        (global)
+  4. g:dbs
+  5. $DATABASE_URL
+  6. g:db / b:db
+
+The first hit for a URL wins and later duplicates are dropped whole rather
+than merged. Because the files are read before `g:dbs`, an entry may keep
+its URL in `g:dbs` while its `color` and `mode` live in connections.json.
 
 Connection scope ~
 
@@ -983,6 +994,10 @@ Beyond `name` and `url`, an entry in either connections.json may carry:
              (green, orange, red, blue, violet, yellow) or "#rrggbb"
 
 All three are optional. An entry without them behaves exactly as before.
+
+These fields exist only in a connections.json entry. `g:dbs` is read as the
+vim-dadbod-ui format -- name and url and nothing else -- so a `color`,
+`mode`, `env_file` or `type` written there is discarded on read.
 
                                                           *grip-secrets*
 Secrets: ${VAR} in a connection URL ~
@@ -1062,7 +1077,7 @@ transaction read write; ...` is enough. If a connection must not be able to
 write, give it a database role that cannot. That is the boundary; `mode` is
 the seatbelt.
 
-Two further limits:
+Three further limits:
 
 - An `options=` already present in a postgres url wins over PGOPTIONS, so
   such a connection reports `RO` while its session is not read-only.
@@ -1072,6 +1087,16 @@ Two further limits:
   `duckdb::memory:` and a not-yet-created sqlite file connect normally: the
   flag aborts the former outright and turns "create it" into an error for
   the latter.
+- A connection pooler refuses the option outright. Pgbouncer-compatible
+  poolers reject unknown startup parameters, so PGOPTIONS does not degrade
+  the session, it fails the connection: >
+
+    FATAL: unsupported startup parameter in options:
+    default_transaction_read_only
+<
+  Unlike the two above, this is not an overstated `RO` badge -- there is no
+  session at all. Point a `mode: "ro"` entry at the direct port rather than
+  the pooled one.
 
                                                           *grip-accent*
 Connection colour ~


### PR DESCRIPTION
Four gaps found while setting up a coloured, read-only connection — each one currently requires reading `connections.lua` to answer.

- **`g:dbs` carries only `name` and `url`.** `read_gdbs()` (`connections.lua:391-403`) copies exactly two fields out of an entry, so a `color`, `mode`, `env_file` or `type` written there is dropped without a diagnostic. README listed `g:dbs` as a peer of connections.json. Now there is a field/source table.
- **Dedup order was undocumented.** "Deduplicated by URL across all sources" never said which source wins. Documenting it exposes the useful half: the files are read before `g:dbs`, so a URL can stay in `g:dbs` while its `color` and `mode` live in the JSON.
- **`mode: "ro"` is incompatible with a connection pooler.** Pgbouncer-compatible poolers reject unknown startup parameters, so `PGOPTIONS` fails the connection with `FATAL: unsupported startup parameter in options: default_transaction_read_only`. The two already-documented ro limits both say "the `RO` badge overstates things"; this one says "there is no connection". Verified against DigitalOcean managed Postgres: the pooler port fails as above, the direct port accepts the option and enforces it.
- **Connection colour was missing from README**, though `doc/` has covered it under `*grip-accent*` since the feature landed.

Deliberately excluded: `ignore_startup_parameters`. Pgbouncer's docs suggest a pooler configured to ignore the parameter would connect while not being read-only, which is worth knowing, but it is untested here.

Docs only — no behaviour change. Full suite green (`nvim --headless -u tests/minimal_init.lua -l tests/run_specs.lua` → ALL TESTS PASSED); new `doc/` lines stay within 78 columns.

A follow-up PR fixes a defect found while verifying the dedup order: Docker discovery silently discards a colliding file entry's `mode` and `color`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)