### PR TITLE
fix(connections): keep mode/color when Docker discovery shadows a saved URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,11 @@ Beyond `name` and `url`, what an entry can carry depends on where it lives:
 read — those belong in `.grip/connections.json` or `~/.grip/connections.json`.
 
 Sources are deduplicated by URL in this order: discovered Docker containers, project file, global
-file, `g:dbs`, `$DATABASE_URL`, `g:db`. The first hit wins and later duplicates are dropped whole,
-so an entry can keep its URL in `g:dbs` while its `color` and `mode` live in the JSON file.
+file, `g:dbs`, `$DATABASE_URL`, `g:db`. The first hit wins, so an entry can keep its URL in `g:dbs`
+while its `color` and `mode` live in the JSON file. One case merges rather than discards: a
+discovered container colliding with a `connections.json` entry keeps the container's name and
+adopts the file entry's `type`, `env_file`, `mode`, `color` and `attachments` — discovery
+contributes liveness, the file contributes configuration.
 
 ### Keeping the password out of the connection file
 

--- a/doc/dadbod-grip.txt
+++ b/doc/dadbod-grip.txt
@@ -941,9 +941,16 @@ Connections are deduplicated by URL across all sources. The order is:
   5. $DATABASE_URL
   6. g:db / b:db
 
-The first hit for a URL wins and later duplicates are dropped whole rather
-than merged. Because the files are read before `g:dbs`, an entry may keep
-its URL in `g:dbs` while its `color` and `mode` live in connections.json.
+The first hit for a URL wins. Because the files are read before `g:dbs`, an
+entry may keep its URL in `g:dbs` while its `color` and `mode` live in
+connections.json.
+
+One case merges rather than discards: a discovered container colliding with
+a connections.json entry keeps the container's name and adopts the file
+entry's `type`, `env_file`, `mode`, `color` and `attachments`. Discovery
+contributes liveness, the file contributes configuration -- without this, a
+connection saved as `"mode": "ro"` would connect writable whenever its
+Docker stack happened to be up.
 
 Connection scope ~
 

--- a/lua/dadbod-grip/connections.lua
+++ b/lua/dadbod-grip/connections.lua
@@ -423,17 +423,41 @@ function M.list()
   local all = {}
   local seen = {}  -- keyed by URL; URL is the canonical identifier
 
+  -- Read the files once: the discovery loop below needs them to enrich a
+  -- colliding entry, and the loop after it needs them to add the rest.
+  local file_conns = read_file_connections()
+  local file_by_url = {}
+  for _, c in ipairs(file_conns) do
+    if not file_by_url[c.url] then file_by_url[c.url] = c end
+  end
+
   -- Discovered connections first: live containers beat hand-edited static.
   -- A user spinning up `just up` expects to see that stack at the top.
+  --
+  -- On a URL collision the discovered entry wins the *identity* -- its name is
+  -- the running container's, which is what the user is looking for in the
+  -- picker -- but the file entry still owns the settings the user configured.
+  -- Dropping it whole used to take `mode` with it, so a connection saved as
+  -- read-only connected writable whenever its stack happened to be up.
   for _, c in ipairs(read_discovered_connections()) do
     if not seen[c.url] then
       seen[c.url] = true
+      local filed = file_by_url[c.url]
+      if filed then
+        -- Copy before writing: docker_localdb.fetch() memoizes its table for
+        -- a 2s TTL, and mutating it would leak these settings into a later
+        -- fetch whose file entry no longer carries them.
+        c = vim.tbl_extend("force", {}, c)
+        for _, field in ipairs({ "type", "env_file", "mode", "color", "attachments" }) do
+          if c[field] == nil then c[field] = filed[field] end
+        end
+      end
       table.insert(all, c)
     end
   end
 
   -- File connections second (user-managed, sorted by last_used in pick())
-  for _, c in ipairs(read_file_connections()) do
+  for _, c in ipairs(file_conns) do
     if not seen[c.url] then
       seen[c.url] = true
       table.insert(all, c)

--- a/tests/spec/discovery_merge_spec.lua
+++ b/tests/spec/discovery_merge_spec.lua
@@ -1,0 +1,154 @@
+-- discovery_merge_spec.lua: a discovered container and a connections.json
+-- entry that share a URL must yield one entry carrying the container's
+-- identity and the file's settings.
+--
+-- Before the merge landed, M.list() dropped the file entry whole and its
+-- mode/color went with it -- a `mode: "ro"` seatbelt that silently unfastened
+-- whenever the matching Docker stack happened to be up.
+local paths = require("dadbod-grip.paths")
+local grip = require("dadbod-grip")
+
+-- Rebound to a freshly loaded module by every with_real_file() below.
+local connections = require("dadbod-grip.connections")
+
+local pass = 0
+local fail = 0
+
+local function test(name, fn)
+  local ok, err = pcall(fn)
+  if ok then
+    pass = pass + 1
+  else
+    fail = fail + 1
+    print("FAIL: " .. name .. ": " .. tostring(err))
+  end
+end
+
+local function eq(a, b, msg)
+  assert(a == b, (msg or "") .. ": expected " .. tostring(b) .. ", got " .. tostring(a))
+end
+
+local DOCKER_URL = "postgresql://postgres:postgres@localhost:6810/app"
+
+-- ── harness ───────────────────────────────────────────────────────────────
+-- The file/home patching is the one from connections_fields_spec.lua:43 --
+-- see that file for why each patch exists. Added here: the discovery source
+-- is stubbed, since M.list() consults it before anything else and the real
+-- one shells out to `docker ps`.
+local function with_real_file(discovered, fn)
+  local project_dir = vim.fn.tempname() .. "_grip_disc_merge_test"
+  local fake_home = project_dir .. "_home"
+  vim.fn.mkdir(project_dir, "p")
+  vim.fn.mkdir(fake_home, "p")
+
+  local orig_project_root = paths.project_root
+  local orig_expand = vim.fn.expand
+  local orig_notify = vim.notify
+  local orig_opts = grip.get_opts()
+  local orig_connections = package.loaded["dadbod-grip.connections"]
+  local orig_docker = package.loaded["dadbod-grip.sources.docker_localdb"]
+
+  paths.project_root = function() return project_dir end
+  vim.fn.expand = function(a, ...)
+    if a == "~" then return fake_home end
+    return orig_expand(a, ...)
+  end
+  vim.notify = function() end
+  grip.setup({}) -- deterministic OPTS baseline (discovery on, connections_path nil)
+  package.loaded["dadbod-grip.sources.docker_localdb"] = {
+    fetch = function() return { connections = discovered } end,
+  }
+  package.loaded["dadbod-grip.connections"] = nil
+  connections = require("dadbod-grip.connections")
+
+  local ok, err = pcall(fn, project_dir .. "/.grip")
+
+  paths.project_root = orig_project_root
+  vim.fn.expand = orig_expand
+  vim.notify = orig_notify
+  grip.setup(orig_opts)
+  package.loaded["dadbod-grip.connections"] = orig_connections
+  package.loaded["dadbod-grip.sources.docker_localdb"] = orig_docker
+  connections = orig_connections
+
+  vim.fn.delete(project_dir, "rf")
+  vim.fn.delete(fake_home, "rf")
+  if not ok then error(err) end
+end
+
+local function write_conns(dir, entries)
+  paths.ensure_dir(dir)
+  vim.fn.writefile({ vim.fn.json_encode(entries) }, dir .. "/connections.json")
+end
+
+local function find(list, url)
+  for _, c in ipairs(list) do
+    if c.url == url then return c end
+  end
+end
+
+local function container(name, url)
+  return { name = name, url = url, source = "docker" }
+end
+
+-- ── the defect ────────────────────────────────────────────────────────────
+
+test("a collision keeps the file entry's mode and color", function()
+  with_real_file({ container("app (docker)", DOCKER_URL) }, function(dir)
+    write_conns(dir, { { name = "app", url = DOCKER_URL, mode = "ro", color = "red" } })
+    local c = find(connections.list(), DOCKER_URL)
+    assert(c, "entry present")
+    eq(c.mode, "ro", "mode merged from the file entry")
+    eq(c.color, "red", "color merged from the file entry")
+  end)
+end)
+
+test("a collision keeps env_file and type", function()
+  with_real_file({ container("app (docker)", DOCKER_URL) }, function(dir)
+    write_conns(dir, {
+      { name = "app", url = DOCKER_URL, env_file = "~/p/.env", type = "postgresql" },
+    })
+    local c = find(connections.list(), DOCKER_URL)
+    assert(c, "entry present")
+    eq(c.env_file, "~/p/.env", "env_file merged")
+    eq(c.type, "postgresql", "type merged")
+  end)
+end)
+
+-- ── what must not change ──────────────────────────────────────────────────
+
+test("a collision keeps the container's name", function()
+  with_real_file({ container("app (docker)", DOCKER_URL) }, function(dir)
+    write_conns(dir, { { name = "app", url = DOCKER_URL, mode = "ro", color = "red" } })
+    local c = find(connections.list(), DOCKER_URL)
+    assert(c, "entry present")
+    eq(c.name, "app (docker)", "the live container names the entry")
+  end)
+end)
+
+test("a discovered entry with no file counterpart is unchanged", function()
+  local solo = "postgresql://u:p@localhost:6811/solo"
+  with_real_file({ container("solo (docker)", solo) }, function(dir)
+    write_conns(dir, { { name = "other", url = "postgresql://u:p@localhost:9999/other" } })
+    local c = find(connections.list(), solo)
+    assert(c, "discovered entry present")
+    eq(c.mode, nil, "no mode invented")
+    eq(c.color, nil, "no color invented")
+  end)
+end)
+
+test("a file entry with no container is unchanged", function()
+  local filed = "postgresql://u:p@localhost:7000/db"
+  with_real_file({}, function(dir)
+    write_conns(dir, { { name = "filed", url = filed, mode = "ro", color = "green" } })
+    local c = find(connections.list(), filed)
+    assert(c, "file entry present")
+    eq(c.mode, "ro", "mode intact")
+    eq(c.color, "green", "color intact")
+  end)
+end)
+
+-- ── summary ───────────────────────────────────────────────────────────────
+
+print(string.format("\ndiscovery_merge_spec: %d passed, %d failed", pass, fail))
+if fail > 0 then os.exit(1) end


### PR DESCRIPTION
Found while verifying the dedup order documented in #43.

## The defect

`M.list()` consults Docker discovery before the connections files and deduplicates by URL, dropping the later duplicate **whole**. When a labelled container and a saved entry share a URL, the saved entry's `mode` and `color` go with it — so a connection the user marked read-only connects **writable, with no warning**, whenever its stack happens to be up. `README.md:183` sells `mode` as a seatbelt against accidents; this unfastens it silently.

Reproduced with the discovery source stubbed (`tests/spec/discovery_merge_spec.lua`), before the fix:

```
FAIL: a collision keeps the file entry's mode and color: mode merged from the file entry: expected ro, got nil
FAIL: a collision keeps env_file and type: env_file merged: expected ~/p/.env, got nil
discovery_merge_spec: 3 passed, 2 failed
```

A second, milder symptom: the pass at `connections.lua:483` relabels such an entry `global`, so the picker shows the badge of a stored connection whose stored settings were ignored.

## The fix

On a collision the discovered entry keeps its **identity** — the name is the running container's, which is what you scan the picker for — and adopts `type`, `env_file`, `mode`, `color` and `attachments` from the file entry it shadows. Discovery contributes liveness; the file contributes configuration.

`last_used` is deliberately not merged: it drives `pick()` ordering, and changing that is a separate decision.

The discovered table is copied before being written to. `docker_localdb.fetch()` memoizes its result for a 2s TTL, so mutating it in place would leak these settings into a later fetch whose file entry no longer carries them.

## Verification

- New spec fails 2/5 before the fix (output above), passes 5/5 after.
- The three tests that pass either way are regression guards, not the point of the fix, so the name-preservation assertion was mutation-tested: letting the file entry overwrite identity (`vim.tbl_extend("force", {}, c, filed)`) makes it fail with `expected app (docker), got app`. It can fail.
- Full suite: ALL TESTS PASSED.
- `luacheck` could not run locally (broken install against this machine's Lua 5.5) — leaving it to CI rather than claiming it passed.

Docs updated: the "dropped whole" sentence #43 added is now wrong and says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)