### PR TITLE
chore(gitignore): English comment, and ignore local notes dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,9 @@ demo/*.db
 assets/*.png
 assets/*.gif
 docs/plans
+docs/superpowers/
 .claude
+.superpowers/
 
-# Внутренний протокол код-ревью — держим локально, не в публичном репо
+# Internal review notes and working documents — kept local, out of the public repo
 CODE_REVIEW.md


### PR DESCRIPTION
The trailing comment in `.gitignore` was the only non-English prose in a tracked file — translated it.

While there: `docs/superpowers/` and `.superpowers/` hold agent working notes that are never meant to ship. They were kept out by a `.git/info/exclude` entry, which is per-clone — a fresh clone or a new machine loses the rule, and the next `git add -A` sweeps them in. Moved the rule into the tracked ignore file so it travels with the repo.

Verified by dropping the local `exclude` entry: both paths are now matched by `.gitignore` (`git check-ignore -v` points at lines 14 and 16) and `git status -uall` is clean.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)