### PR TITLE
fix(ui): fit floats to the screen, not to their content

### DIFF
--- a/lua/dadbod-grip/editor.lua
+++ b/lua/dadbod-grip/editor.lua
@@ -116,11 +116,15 @@ function M.open(prompt, initial_value, on_save, opts)
   local pre_fill = initial_value or ""
   -- Split on newlines so nvim_buf_set_lines receives clean per-line strings
   local fill_lines = vim.split(pre_fill, "\n", { plain = true })
-  local height = math.min(opts.max_h or 20, math.max(3, #fill_lines))
+  -- Fitted here rather than left to the float: `float_row` below is derived
+  -- from the height, so the two have to agree on what the height is.
+  local height = ui.fit(math.min(opts.max_h or 20, math.max(3, #fill_lines)),
+                        vim.o.lines)
   -- Width from longest line
   local max_line_len = 0
   for _, l in ipairs(fill_lines) do max_line_len = math.max(max_line_len, #l) end
-  local width = math.min(opts.max_w or 100, math.max(40, max_line_len + 6))
+  local width = ui.fit(math.min(opts.max_w or 100, math.max(40, max_line_len + 6)),
+                       vim.o.columns)
 
   -- Create a scratch buffer for the editor
   local edit_buf = vim.api.nvim_create_buf(false, true)

--- a/lua/dadbod-grip/init.lua
+++ b/lua/dadbod-grip/init.lua
@@ -1552,15 +1552,11 @@ function M.open_welcome()
     end
     vim.api.nvim_buf_set_lines(sbuf, 0, -1, false, lines)
     local sh   = #lines
-    local swin = vim.api.nvim_open_win(sbuf, true, {
-      relative = "editor",
-      width    = sw,
-      height   = sh,
-      row      = math.floor((vim.o.lines   - sh - 4) / 2),
-      col      = math.floor((vim.o.columns - sw - 2) / 2),
-      style    = "minimal",
-      border   = ui.border(),
-      zindex   = 60,
+    local swin = ui.info_float({
+      buf    = sbuf,
+      width  = sw,
+      height = sh,
+      zindex = 60,
     })
     vim.bo[sbuf].modifiable = false
     vim.bo[sbuf].buftype    = "nofile"

--- a/lua/dadbod-grip/schema.lua
+++ b/lua/dadbod-grip/schema.lua
@@ -1107,14 +1107,10 @@ local function setup_keymaps(url)
         if key_end then sadd(ln, "Identifier", 2, key_end - 1) end
       end
     end
-    local win = vim.api.nvim_open_win(popup_buf, true, {
-      relative = "editor",
-      row = math.floor((vim.o.lines - #lines) / 2),
-      col = math.floor((vim.o.columns - max_w) / 2),
+    local win = ui.info_float({
+      buf = popup_buf,
       width = max_w,
       height = #lines,
-      style = "minimal",
-      border = ui.border(),
       title = " Schema Help ",
       title_pos = "center",
       zindex = 50,

--- a/lua/dadbod-grip/ui.lua
+++ b/lua/dadbod-grip/ui.lua
@@ -174,13 +174,60 @@ function M.confirm(prompt)
   return answer == "y" or answer == "yes"
 end
 
+--- Fit a float to the screen it is drawn on.
+---
+--- Callers size these floats to their content, and content is regularly larger
+--- than the editor: the `?` help is 164 rows. In a TUI Neovim clamps such a
+--- window for us, so it ends up shorter than its buffer and scrolls. Under
+--- `ext_multigrid` the UI draws windows itself and Neovim hands out the size
+--- that was asked for: the whole buffer then fits inside the window, so
+--- nothing ever scrolls and everything past the screen edge is unreachable --
+--- `<C-d>` and `G` both leave `topline` at 1. Neovide runs that way, and the
+--- help is unusable there without this.
+---
+--- The same four cells come off both axes, for different reasons: vertically
+--- two rows of border plus the status line and the command line, horizontally
+--- two columns of border plus one spare column on each side, which keeps a
+--- full-width frame off the screen edge. The offset is the one this module has
+--- always used, so a float that already fits opens exactly where it did
+--- before, and a fitted one lands on [1, total - 2] with its frame whole.
+---
+--- @param size  integer requested rows or columns
+--- @param total integer rows or columns the editor has
+--- @return integer size, integer offset
+function M.fit(size, total)
+  local fitted = math.min(size, math.max(1, total - 4))
+  return fitted, math.floor((total - fitted) / 2)
+end
+
+--- Keep a caller's own offset on screen. Counting its border, a float occupies
+--- [offset - 1, offset + size], so total - 1 - size is the last offset that
+--- leaves the far edge of the frame visible.
+---
+--- A caller that derives an offset from content it never clamped -- editor.lua
+--- centres its error float on its line count -- otherwise pushes the float off
+--- the top of the editor, and what runs off is unreachable there for the same
+--- reason an oversized float's tail is. Flush against the near edge is a
+--- placement a caller can mean, though, so 0 is left alone: only what would
+--- land outside the editor is pulled back.
+---
+--- @param offset integer requested row or column
+--- @param size   integer fitted rows or columns of the float
+--- @param total  integer rows or columns the editor has
+--- @return integer offset
+local function onscreen(offset, size, total)
+  return math.max(0, math.min(offset, total - 1 - size))
+end
+
 --- Open an editor-relative float and return its window and buffer.
 ---
 --- Covers only what the info floats across the plugin share: a scratch buffer,
---- centered geometry, style = "minimal" and the configured border. Sizing rules
---- stay with the caller — every float has its own idea of how wide it should be.
---- Keys left nil are not passed to nvim_open_win at all, so a caller that never
---- set `title`/`zindex` keeps the stock window it had before.
+--- centered geometry, style = "minimal" and the configured border. How big a
+--- float wants to be stays with the caller — every float has its own idea of
+--- how wide it should be — but how big it is allowed to be does not: whatever
+--- is asked for goes through M.fit, so no caller can ask for a float larger
+--- than the screen. Keys left nil are not passed to nvim_open_win at all, so a
+--- caller that never set `title`/`zindex` keeps the stock window it had before.
 ---
 --- @param opts table
 ---   lines      string[]|nil  fill a fresh scratch buffer with these
@@ -190,7 +237,12 @@ end
 ---   width      integer       required
 ---   height     integer       required
 ---   relative   string|nil    default "editor"
----   row, col   integer|nil   default: centered for width/height
+---   row, col   integer|nil   default: centered for the fitted width/height.
+---                            An editor-relative float is held on screen,
+---                            frame included, whether the offset is the
+---                            caller's or the default; against anything else
+---                            the caller's offset is passed through untouched
+---                            and defaults to 0.
 ---   enter      boolean|nil   focus the float (default true)
 ---   style, border, title, title_pos, zindex, footer, footer_pos
 ---                            forwarded as-is; style/border default to
@@ -205,12 +257,30 @@ function M.info_float(opts)
     end
   end
 
+  local relative    = opts.relative or "editor"
+  local height, row = M.fit(opts.height, vim.o.lines)
+  local width,  col = M.fit(opts.width,  vim.o.columns)
+
+  -- Both offsets are editor coordinates, so they only mean anything for an
+  -- editor-relative float: there the caller's own offset is held on screen
+  -- alongside the centred default. Against the cursor the caller owns its
+  -- placement outright -- editor.lua opens above the cursor row with a
+  -- negative offset, which clamping would throw away -- so nothing is imposed
+  -- on it beyond the size.
+  if relative == "editor" then
+    row = onscreen(opts.row or row, height, vim.o.lines)
+    col = onscreen(opts.col or col, width,  vim.o.columns)
+  else
+    row = opts.row or 0
+    col = opts.col or 0
+  end
+
   local cfg = {
-    relative  = opts.relative or "editor",
-    width     = opts.width,
-    height    = opts.height,
-    row       = opts.row or math.floor((vim.o.lines   - opts.height) / 2),
-    col       = opts.col or math.floor((vim.o.columns - opts.width) / 2),
+    relative  = relative,
+    width     = width,
+    height    = height,
+    row       = row,
+    col       = col,
     style     = opts.style or "minimal",
     border    = opts.border or M.border(),
     title     = opts.title,

--- a/lua/dadbod-grip/view.lua
+++ b/lua/dadbod-grip/view.lua
@@ -2750,14 +2750,10 @@ function M.show_help(opts)
         if key_end then hadd(ln, "Identifier", 2, key_end - 1) end
       end
     end
-    local win = vim.api.nvim_open_win(popup_buf, true, {
-      relative = "editor",
-      row = math.floor((vim.o.lines - #help) / 2),
-      col = math.floor((vim.o.columns - max_w) / 2),
+    local win = ui.info_float({
+      buf = popup_buf,
       width = max_w,
       height = #help,
-      style = "minimal",
-      border = ui.border(),
       title = " Help ",
       title_pos = "center",
       zindex = 50,

--- a/tests/spec/ui_spec.lua
+++ b/tests/spec/ui_spec.lua
@@ -164,6 +164,77 @@ test("info_float: fills a fresh scratch buffer with lines", function()
   end)
 end)
 
+test("fit: leaves a size that already fits where it was", function()
+  local size, offset = ui.fit(10, 40)
+  eq(size, 10, "size"); eq(offset, math.floor((40 - 10) / 2), "offset")
+end)
+
+test("fit: clamps a size the screen cannot show", function()
+  local size, offset = ui.fit(164, 40)
+  eq(size, 36, "size")
+  eq(offset >= 0 and offset + size + 2 <= 40, true, "border included, it stays on screen")
+end)
+
+-- The float asks Neovim for the size in its config, and that is what this
+-- pins: in a TUI Neovim clamps an oversized window on its own, so the window
+-- itself would look fine here either way. Under ext_multigrid the requested
+-- size is the size the window gets, the buffer fits inside it, and nothing
+-- scrolls -- which is the bug this guards.
+test("info_float: asks for no more rows than the screen has", function()
+  local lines = {}
+  for i = 1, 164 do lines[i] = "line " .. i end
+  with_float({ lines = lines, width = 40, height = #lines }, function(_, _, cfg)
+    eq(cfg.height, 36, "height fitted to the 40-row screen")
+    eq(cfg.height < #lines, true, "shorter than its buffer, so it scrolls")
+  end)
+end)
+
+-- The width axis runs through the same fit as the height, and nothing else in
+-- this file would notice if it stopped: every other case asks for a width the
+-- 120-column screen can show.
+test("info_float: asks for no more columns than the screen has", function()
+  with_float({ lines = { "x" }, width = 400, height = 4 }, function(_, _, cfg)
+    eq(cfg.width, 116, "width fitted to the 120-column screen")
+    eq(cfg.col + cfg.width + 1 <= 120, true, "frame included, it stays on screen")
+  end)
+end)
+
+-- editor.lua's error float is the live caller doing this: it centres on its
+-- own line count, which it never clamps, so a tall one asks for a negative
+-- row. Neovim takes that literally under ext_multigrid and the top of the
+-- float is then off the editor, unreachable for the same reason an oversized
+-- one's tail is.
+test("info_float: an explicit row off the top of the editor is pulled back", function()
+  with_float({ lines = { "x" }, width = 30, height = 100, row = -60 },
+    function(_, _, cfg)
+      eq(cfg.row >= 0, true, "row is on screen")
+      eq(cfg.row + cfg.height + 1 <= 40, true, "and so is the rest of the frame")
+    end)
+end)
+
+test("info_float: an explicit row past the bottom is pulled back", function()
+  with_float({ lines = { "x" }, width = 30, height = 4, row = 200 },
+    function(_, _, cfg)
+      eq(cfg.row, 40 - 1 - 4, "row is the last one that shows the whole frame")
+    end)
+end)
+
+-- A cursor-relative offset is not an editor coordinate, so it is not the
+-- clamp's business: editor.lua opens the cell editor above the cursor row with
+-- a negative row on purpose, and clamping that to the editor would drop it
+-- back onto the cursor.
+-- nvim_win_get_config reports a cursor-relative float back as window-relative
+-- against the window the cursor was in, offsets verbatim, so `relative` is
+-- read as "win" here and the row is what carries the assertion.
+test("info_float: a cursor-relative float keeps its own negative row", function()
+  with_float({ lines = { "x" }, width = 30, height = 4,
+               relative = "cursor", row = -5, col = 0 },
+    function(_, _, cfg)
+      eq(cfg.relative, "win", "resolved against the cursor's window")
+      eq(cfg.row, -5, "row untouched"); eq(cfg.col, 0, "col untouched")
+    end)
+end)
+
 test("info_float: centers on the editor by default", function()
   with_float({ lines = { "x" }, width = 40, height = 10 }, function(_, _, cfg)
     eq(cfg.relative, "editor", "relative")


### PR DESCRIPTION
A float sized to its content is clamped to the screen by Neovim in a TUI, so it ends up shorter than its buffer and scrolls. Under ext_multigrid the UI draws the window itself and the requested size is the size it gets: the whole buffer fits inside the window, nothing ever scrolls, and everything past the screen edge is unreachable. The 164-row `?` help is unusable in Neovide because of it.

ui.fit clamps a requested size to the screen and centres what is left, and info_float applies it to width and height. An offset the caller worked out itself is held on screen the same way, frame included, because a caller that derives one from unclamped content -- editor.lua centres its error float on its line count -- otherwise asks for a negative row and loses the top of the float for the same reason. Only editor-relative floats are placed this way; against the cursor the caller keeps its offsets, negative ones included, since that is how the cell editor opens above the cursor row.

The floats that built their own geometry now go through info_float as well: both help floats and the connection easter egg. The cell editor keeps its own nvim_open_win -- it is cursor-relative and derives its row from its height -- and calls ui.fit on the size instead.

## What does this PR do?

<!-- Brief description of the change -->

## How to test

<!-- Steps to verify the change works -->

## Checklist

- [x] `just test` passes (all specs green)
- [x] No new warnings or errors in `:messages`
- [x] Tested with at least one adapter (pg/sqlite/duckdb/mysql)
