### PR TITLE
fix(ui): keep the spinner up until the grid is on screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Opening a table dropped the spinner, then froze.** `init.open()` ran three round-trips —
+  the `SELECT`, the primary-key lookup, and the pagination `COUNT` — but only the `SELECT` was
+  inside the float. On a remote connection the spinner vanished, the editor sat frozen through
+  two more adapter invocations, and only then did the grid appear. All three now run under one
+  spinner, and the `COUNT` moving ahead of `view.open()` means the grid is rendered **once**
+  instead of twice: `view.open()` takes `query_spec` and `total_rows` in its opts, so the first
+  paint already reads `Page 1/N (M rows)` and the follow-up re-render is gone.
+- **The loading spinner only covered the first query.** `init.open()` wrapped its opening
+  query in `ui.blocking`, but every later reload went straight to `db.query`: sorting (`s`, `S`),
+  filtering (`f`, `<C-f>`, `F`, `gn`, `gF`, presets), pagination (`H`/`L`, `[p`/`]p`, `[P`/`]P`),
+  reset (`X`), refresh (`R`) and FK jumps (`gf`, `gm`). On anything slower than a local SQLite file
+  those keys froze the editor with no indicator at all, so the grid looked hung. `do_refresh` is
+  now split into `fetch_refresh` (the db round-trips) and `apply_refresh` (the render), and every
+  reload path runs the fetch inside one spinner — `on_requery`'s COUNT and its page query share a
+  single float instead of flashing two, and the FK jumps put their three or four round-trips behind
+  one. Note for future callers: `ui.blocking()` forwards its `fn`'s returns through `table.unpack`,
+  which drops everything after a leading `nil`, so work run inside it returns a single table
+  (`{ result = ..., err = ... }`) rather than `nil, err` — otherwise the real db error is lost and
+  the user is told "unknown error".
 - **`F` and `X` dropped you out of an FK context without saying so.** An FK jump (`gf`, `gm`)
   scopes the grid with a WHERE clause of its own — `"categoryId" = 15` for "the CategoryVersion
   rows referencing Category 15". That clause lived in `query_spec.filters` indistinguishable from

--- a/lua/dadbod-grip/init.lua
+++ b/lua/dadbod-grip/init.lua
@@ -1080,7 +1080,7 @@ function M.open(arg, url, opts)
       -- Sort / filter / page changes are two round-trips (COUNT then the page
       -- itself). Both run inside one spinner: do_refresh's own float would
       -- otherwise only cover the second, leaving the COUNT looking like a hang.
-      local new_sql, fetched
+      local new_sql, page_fetch
       ui.blocking("  querying " .. spinner_label(table_name_arg) .. "...", function()
         -- Run count query for pagination
         local count_sql = query.build_count_sql(new_spec)
@@ -1098,12 +1098,12 @@ function M.open(arg, url, opts)
         end
 
         new_sql = query.build_sql(new_spec)
-        fetched = fetch_refresh(conn, new_sql, table_name_arg)
+        page_fetch = fetch_refresh(conn, new_sql, table_name_arg)
       end)
 
       s.query_spec = new_spec
       s.query_sql = new_sql
-      apply_refresh(bid, fetched)
+      apply_refresh(bid, page_fetch)
     end,
     on_apply = function(bid)
       do_apply(bid, conn)

--- a/lua/dadbod-grip/init.lua
+++ b/lua/dadbod-grip/init.lua
@@ -475,14 +475,26 @@ local function do_apply(bufnr, url)
 end
 
 -- ── refresh ───────────────────────────────────────────────────────────────
-local function do_refresh(bufnr, url, query_sql, table_name)
+
+--- Spinner label for a grid reload: the bare table name (no schema prefix),
+--- one line, capped so a long name cannot outgrow the float.
+local function spinner_label(table_name)
+  local label = table_name and (table_name:match("[^.]+$") or table_name) or "result"
+  return ((label:match("^([^\n]+)") or "query"):sub(1, 50))
+end
+
+--- Every db round-trip one refresh needs. Split out of do_refresh so a caller
+--- that has its own db work to do first (on_requery runs a COUNT) can put the
+--- whole batch inside one ui.blocking float instead of flashing two.
+---
+--- Returns ONE table, never a bare `nil, err`: ui.blocking() forwards its fn's
+--- returns through table.unpack, which drops everything after a leading nil.
+--- @return table { result: table|nil, err: string|nil, elapsed_ms: number }
+local function fetch_refresh(url, query_sql, table_name)
   local t0 = vim.uv.hrtime()
   local result, err = db.query(query_sql, url)
   local elapsed_ms = math.floor((vim.uv.hrtime() - t0) / 1e6)
-  if err then
-    vim.notify("Grip: query failed: " .. err, vim.log.levels.ERROR)
-    return
-  end
+  if err then return { err = err, elapsed_ms = elapsed_ms } end
 
   -- Empty result: fetch columns from schema (adapter returns none for 0 rows)
   if (#result.columns == 0) and table_name then
@@ -506,14 +518,31 @@ local function do_refresh(bufnr, url, query_sql, table_name)
   result.table_name = table_name
   result.url = url
   result.sql = query_sql
+  return { result = result, elapsed_ms = elapsed_ms }
+end
 
-  local new_state = data.new(result)
+--- Render what fetch_refresh returned. Kept outside the spinner float so the
+--- grid repaints after it is torn down, the same order init.open() uses.
+local function apply_refresh(bufnr, fetched)
+  if not fetched or not fetched.result then
+    vim.notify("Grip: query failed: " .. tostring((fetched and fetched.err) or "unknown error"),
+      vim.log.levels.ERROR)
+    return
+  end
+  local new_state = data.new(fetched.result)
   local session = view._sessions[bufnr]
   if session then
-    session.elapsed_ms = elapsed_ms
+    session.elapsed_ms = fetched.elapsed_ms
     session.last_action = "query"
   end
   view.render(bufnr, new_state)
+end
+
+local function do_refresh(bufnr, url, query_sql, table_name)
+  local fetched = ui.blocking("  querying " .. spinner_label(table_name) .. "...", function()
+    return fetch_refresh(url, query_sql, table_name)
+  end)
+  apply_refresh(bufnr, fetched)
 end
 
 -- ── edit cell ─────────────────────────────────────────────────────────────
@@ -962,39 +991,26 @@ function M.open(arg, url, opts)
       or table_name_arg and (table_name_arg:match("[^.]+$") or table_name_arg)
       or "result"
   short_label = (short_label:match("^([^\n]+)") or "query"):sub(1, 50)
-  local result, qerr
-  local elapsed_ms = ui.blocking("  querying " .. short_label .. "...", function()
-    local t_start = vim.uv.hrtime()
-    result, qerr = db.query(query_sql, conn)
-    return math.floor((vim.uv.hrtime() - t_start) / 1e6)
+  -- Opening a table is three round-trips: the SELECT, the primary keys, and the
+  -- pagination COUNT. All three run under one spinner. With only the SELECT
+  -- covered, the float vanished and the editor then froze through the other two
+  -- before the grid ever appeared -- which reads as the plugin hanging.
+  local fetched, total_rows
+  ui.blocking("  querying " .. short_label .. "...", function()
+    fetched = fetch_refresh(conn, query_sql, table_name_arg)
+    if not fetched.result then return end
+    local count_result = db.query(query.build_count_sql(spec), conn)
+    if count_result and count_result.rows[1] then
+      total_rows = tonumber(count_result.rows[1][1]) or 0
+    end
   end)
+
+  local result = fetched.result
   if not result then
-    vim.notify("Grip: " .. (qerr or "query failed"), vim.log.levels.ERROR)
+    vim.notify("Grip: " .. (fetched.err or "query failed"), vim.log.levels.ERROR)
     return
   end
-
-  -- Empty result: adapter may not return columns. Fetch from table schema.
-  if (#result.columns == 0) and table_name_arg then
-    local col_info = db.get_column_info(table_name_arg, conn)
-    if col_info then
-      for _, ci in ipairs(col_info) do
-        table.insert(result.columns, ci.column_name)
-      end
-    end
-  end
-
-  -- Fetch primary keys if we have a table name
-  result.readonly = db.is_readonly(conn)
-  if table_name_arg and not result.readonly then
-    local pks, _ = db.get_primary_keys(table_name_arg, conn)
-    result.primary_keys = pks or {}
-  else
-    result.primary_keys = {}
-  end
-
-  result.table_name = table_name_arg
-  result.url = conn
-  result.sql = query_sql
+  local elapsed_ms = fetched.elapsed_ms
   result.elapsed_ms = elapsed_ms
 
   local history = require("dadbod-grip.history")
@@ -1003,7 +1019,14 @@ function M.open(arg, url, opts)
   local state = data.new(result)
 
   -- Open the view
-  local view_opts = vim.tbl_extend("force", { max_col_width = OPTS.max_col_width, elapsed_ms = elapsed_ms }, opts or {})
+  -- query_spec/total_rows go in up front so the first render already draws the
+  -- page counter; without them the grid had to be rendered a second time.
+  local view_opts = vim.tbl_extend("force", {
+    max_col_width = OPTS.max_col_width,
+    elapsed_ms    = elapsed_ms,
+    query_spec    = spec,
+    total_rows    = total_rows,
+  }, opts or {})
   local bufnr = view.open(state, conn, query_sql, view_opts)
 
   -- Auto-sync query pad with the current grid query (passive background update).
@@ -1021,16 +1044,10 @@ function M.open(arg, url, opts)
   if session then
     -- For file-as-table, store the file path so the schema sidebar can show columns
     if file_path then session.file_path = file_path end
+    -- Both were handed to view.open() above and are already on the session; the
+    -- assignments stay so a caller that reuses an existing buffer still gets them.
     session.query_spec = spec
-    -- Run count query for pagination
-    local count_sql = query.build_count_sql(spec)
-    local count_result = db.query(count_sql, conn)
-    if count_result and count_result.rows[1] then
-      session.total_rows = tonumber(count_result.rows[1][1]) or 0
-      -- Re-render: view.open() rendered before total_rows was set, so the status bar
-      -- showed "N rows" instead of "Page X/Y (N rows)". Render again now that we have it.
-      M._render_if_visible(bufnr)
-    end
+    session.total_rows = total_rows
     -- Auto-fetch column info for conditional formatting
     if table_name_arg and not session._column_info then
       vim.schedule(function()
@@ -1060,25 +1077,33 @@ function M.open(arg, url, opts)
       local s = view._sessions[bid]
       if not s then return end
 
-      -- Run count query for pagination
-      local count_sql = query.build_count_sql(new_spec)
-      local count_result = db.query(count_sql, conn)
-      if count_result and count_result.rows[1] then
-        s.total_rows = tonumber(count_result.rows[1][1]) or 0
-      end
-
-      -- Clamp page to valid range
-      if s.total_rows then
-        local total_pages = math.max(1, math.ceil(s.total_rows / new_spec.page_size))
-        if new_spec.page > total_pages then
-          new_spec = query.set_page(new_spec, total_pages)
+      -- Sort / filter / page changes are two round-trips (COUNT then the page
+      -- itself). Both run inside one spinner: do_refresh's own float would
+      -- otherwise only cover the second, leaving the COUNT looking like a hang.
+      local new_sql, fetched
+      ui.blocking("  querying " .. spinner_label(table_name_arg) .. "...", function()
+        -- Run count query for pagination
+        local count_sql = query.build_count_sql(new_spec)
+        local count_result = db.query(count_sql, conn)
+        if count_result and count_result.rows[1] then
+          s.total_rows = tonumber(count_result.rows[1][1]) or 0
         end
-      end
+
+        -- Clamp page to valid range
+        if s.total_rows then
+          local total_pages = math.max(1, math.ceil(s.total_rows / new_spec.page_size))
+          if new_spec.page > total_pages then
+            new_spec = query.set_page(new_spec, total_pages)
+          end
+        end
+
+        new_sql = query.build_sql(new_spec)
+        fetched = fetch_refresh(conn, new_sql, table_name_arg)
+      end)
 
       s.query_spec = new_spec
-      local new_sql = query.build_sql(new_spec)
       s.query_sql = new_sql
-      do_refresh(bid, conn, new_sql, table_name_arg)
+      apply_refresh(bid, fetched)
     end,
     on_apply = function(bid)
       do_apply(bid, conn)

--- a/lua/dadbod-grip/view.lua
+++ b/lua/dadbod-grip/view.lua
@@ -1383,7 +1383,10 @@ function M.open(state, url, query_sql, opts)
   end
   pcall(vim.api.nvim_buf_set_name, bufnr, buf_name)
 
-  -- Register session before rendering
+  -- Register session before rendering. query_spec/total_rows are optional: a
+  -- caller that already has them (init.open fetches the COUNT inside its
+  -- spinner) hands them over here so the very first render can draw
+  -- "Page 1/N (M rows)" instead of rendering twice.
   M._sessions[bufnr] = {
     state = state,
     url = url,
@@ -1393,6 +1396,8 @@ function M.open(state, url, query_sql, opts)
     elapsed_ms = opts and opts.elapsed_ms or nil,
     write_mode = (opts and opts.write == true) and true or false,
     pinned = false,
+    query_spec = opts and opts.query_spec or nil,
+    total_rows = opts and opts.total_rows or nil,
   }
 
   -- Open in existing window (reuse_win) or a new horizontal split below
@@ -2179,39 +2184,49 @@ function M._fk_referencing(bufnr)
       { pinned = true })
     local ref_sql = qmod.build_sql(ref_spec)
 
-    local result, err = db.query(ref_sql, session.state.url)
-    if err then
-      table.remove(session.nav_stack) -- pop on failure
-      vim.notify("Reverse FK query failed: " .. err, vim.log.levels.WARN)
-      return
-    end
+    -- Four round-trips (rows, columns, PKs, COUNT) behind one spinner: without
+    -- it the jump is a dead editor for as long as the connection takes.
+    -- One table out, never a bare `nil, err`: ui.blocking() forwards through
+    -- table.unpack, which drops everything after a leading nil.
+    local row_count
+    local fetched = ui.blocking("  querying " .. ref.table .. "...", function()
+      local res, qerr = db.query(ref_sql, session.state.url)
+      if qerr then return { err = qerr } end
 
-    -- Empty result: fetch columns from schema (same guard as grid_fk_follow)
-    if #result.columns == 0 then
-      local col_info = db.get_column_info(ref.table, session.state.url)
-      if col_info then
-        for _, ci in ipairs(col_info) do
-          table.insert(result.columns, ci.column_name)
+      -- Empty result: fetch columns from schema (same guard as grid_fk_follow)
+      if #res.columns == 0 then
+        local col_info = db.get_column_info(ref.table, session.state.url)
+        if col_info then
+          for _, ci in ipairs(col_info) do
+            table.insert(res.columns, ci.column_name)
+          end
         end
       end
-    end
 
-    -- Fetch PKs for the referencing table
-    local pks = db.get_primary_keys(ref.table, session.state.url) or {}
-    result.primary_keys = pks
-    -- FK navigation lands on a different table but the same connection, so a
-    -- read-only one stays read-only here too.
-    result.readonly = db.is_readonly(session.state.url)
-    result.table_name = ref.table
-    result.url = session.state.url
-    result.sql = ref_sql
+      -- Fetch PKs for the referencing table
+      res.primary_keys = db.get_primary_keys(ref.table, session.state.url) or {}
+      -- FK navigation lands on a different table but the same connection, so a
+      -- read-only one stays read-only here too.
+      res.readonly = db.is_readonly(session.state.url)
+      res.table_name = ref.table
+      res.url = session.state.url
+      res.sql = ref_sql
 
-    -- Single cheap COUNT (after selection) for pagination + notify
-    local row_count = #result.rows
-    local count_result = db.query(qmod.build_count_sql(ref_spec), session.state.url)
-    if count_result and count_result.rows[1] then
-      row_count = tonumber(count_result.rows[1][1]) or row_count
+      -- Single cheap COUNT (after selection) for pagination + notify
+      row_count = #res.rows
+      local count_result = db.query(qmod.build_count_sql(ref_spec), session.state.url)
+      if count_result and count_result.rows[1] then
+        row_count = tonumber(count_result.rows[1][1]) or row_count
+      end
+      return { result = res }
+    end)
+    if not fetched or not fetched.result then
+      table.remove(session.nav_stack) -- pop on failure
+      vim.notify("Reverse FK query failed: " .. tostring((fetched and fetched.err) or "unknown error"),
+        vim.log.levels.WARN)
+      return
     end
+    local result = fetched.result
 
     local new_state = data.new(result)
     session.query_spec = ref_spec

--- a/lua/dadbod-grip/view/keymaps_fk.lua
+++ b/lua/dadbod-grip/view/keymaps_fk.lua
@@ -7,6 +7,7 @@ local data   = require("dadbod-grip.data")
 local sql    = require("dadbod-grip.sql")
 local db     = require("dadbod-grip.db")
 local qmod   = require("dadbod-grip.query")
+local ui     = require("dadbod-grip.ui")
 
 local M = {}
 
@@ -76,32 +77,41 @@ function M.setup(bufnr, ctx)
       { pinned = true })
     local ref_sql = qmod.build_sql(ref_spec)
 
-    local result, err = db.query(ref_sql, session_fk.state.url)
-    if err then
-      table.remove(session_fk.nav_stack) -- pop on failure
-      vim.notify("FK query failed: " .. err, vim.log.levels.WARN)
-      return
-    end
+    -- Three round-trips (rows, columns, PKs) behind one spinner: without it the
+    -- jump is a dead editor for as long as the connection takes to answer.
+    -- One table out, never a bare `nil, err`: ui.blocking() forwards through
+    -- table.unpack, which drops everything after a leading nil.
+    local fetched = ui.blocking("  querying " .. fk_info.ref_table .. "...", function()
+      local res, qerr = db.query(ref_sql, session_fk.state.url)
+      if qerr then return { err = qerr } end
 
-    -- Empty result: fetch columns from schema (same guard as do_refresh in init.lua)
-    if #result.columns == 0 then
-      local col_info = db.get_column_info(fk_info.ref_table, session_fk.state.url)
-      if col_info then
-        for _, ci in ipairs(col_info) do
-          table.insert(result.columns, ci.column_name)
+      -- Empty result: fetch columns from schema (same guard as do_refresh in init.lua)
+      if #res.columns == 0 then
+        local col_info = db.get_column_info(fk_info.ref_table, session_fk.state.url)
+        if col_info then
+          for _, ci in ipairs(col_info) do
+            table.insert(res.columns, ci.column_name)
+          end
         end
       end
-    end
 
-    -- Fetch PKs for referenced table
-    local pks = db.get_primary_keys(fk_info.ref_table, session_fk.state.url) or {}
-    result.primary_keys = pks
-    -- Same connection as the grid we jumped from: a read-only one stays
-    -- read-only on the referenced table too.
-    result.readonly = db.is_readonly(session_fk.state.url)
-    result.table_name = fk_info.ref_table
-    result.url = session_fk.state.url
-    result.sql = ref_sql
+      -- Fetch PKs for referenced table
+      res.primary_keys = db.get_primary_keys(fk_info.ref_table, session_fk.state.url) or {}
+      -- Same connection as the grid we jumped from: a read-only one stays
+      -- read-only on the referenced table too.
+      res.readonly = db.is_readonly(session_fk.state.url)
+      res.table_name = fk_info.ref_table
+      res.url = session_fk.state.url
+      res.sql = ref_sql
+      return { result = res }
+    end)
+    if not fetched or not fetched.result then
+      table.remove(session_fk.nav_stack) -- pop on failure
+      vim.notify("FK query failed: " .. tostring((fetched and fetched.err) or "unknown error"),
+        vim.log.levels.WARN)
+      return
+    end
+    local result = fetched.result
 
     local new_state = data.new(result)
     session_fk.query_spec = ref_spec

--- a/tests/spec/requery_spinner_spec.lua
+++ b/tests/spec/requery_spinner_spec.lua
@@ -1,0 +1,222 @@
+-- requery_spinner_spec.lua: every grid reload shows the ui.blocking spinner,
+-- not just the first query.
+--
+-- init.open() wrapped its opening query in ui.blocking, but on_requery (sort,
+-- filter, pagination -- H/L, [p/]p, X) and on_refresh (R) called db.query
+-- straight through. On a slow connection those keys froze the editor with no
+-- indicator at all, so the grid looked hung.
+--
+-- Uses tests/seed_sqlite.db.
+
+local grip = require("dadbod-grip")
+local view = require("dadbod-grip.view")
+local qmod = require("dadbod-grip.query")
+local ui   = require("dadbod-grip.ui")
+
+local url = "sqlite:tests/seed_sqlite.db"
+
+local pass = 0
+local fail = 0
+
+local function test(name, fn)
+  local ok, err = pcall(fn)
+  if ok then
+    pass = pass + 1
+  else
+    fail = fail + 1
+    print("FAIL: " .. name .. ": " .. tostring(err))
+  end
+end
+
+local function truthy(a, msg)
+  assert(a, (msg or "") .. ": expected truthy, got " .. tostring(a))
+end
+
+local function contains(s, pattern, msg)
+  assert(type(s) == "string" and s:find(pattern, 1, true),
+    (msg or "") .. ": expected '" .. tostring(s) .. "' to contain '" .. pattern .. "'")
+end
+
+-- ── harness ───────────────────────────────────────────────────────────────
+
+-- Record every spinner message while still running the wrapped work, so the
+-- grid ends up in the same state it would in a real session. `depth` tracks
+-- whether we are currently inside a float, so a test can assert *where* the db
+-- round-trips happen, not just that a spinner appeared at some point.
+local spins = {}
+local depth = 0
+local real_blocking = ui.blocking
+local function stub_blocking(msg, fn)
+  table.insert(spins, msg)
+  depth = depth + 1
+  local rets = { pcall(fn) }
+  depth = depth - 1
+  local ok = table.remove(rets, 1)
+  if not ok then error(rets[1], 0) end
+  return (table.unpack or unpack)(rets)
+end
+ui.blocking = stub_blocking
+
+--- Wrap every db entry point that costs a round-trip, recording the ones that
+--- run with no spinner up. Returns the unspinnered call names.
+local function db_calls_outside_spinner(fn)
+  local db = require("dadbod-grip.db")
+  local watched = { "query", "get_primary_keys", "get_column_info", "get_foreign_keys" }
+  local real, naked = {}, {}
+  for _, name in ipairs(watched) do
+    real[name] = db[name]
+    db[name] = function(...)
+      if depth == 0 then table.insert(naked, name) end
+      return real[name](...)
+    end
+  end
+  local ok, err = pcall(fn)
+  for _, name in ipairs(watched) do db[name] = real[name] end
+  assert(ok, "call under test threw: " .. tostring(err))
+  return naked
+end
+
+local function cleanup_grids()
+  for bufnr, _ in pairs(view._sessions) do
+    view._sessions[bufnr] = nil
+    pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+  end
+  while #vim.api.nvim_tabpage_list_wins(0) > 1 do
+    local wins = vim.api.nvim_tabpage_list_wins(0)
+    pcall(vim.api.nvim_win_close, wins[#wins], true)
+  end
+end
+
+--- Open a real grid through the public entry point so the callbacks under test
+--- (on_requery / on_refresh) are the ones init.lua actually wires.
+local function open_grid(tbl)
+  cleanup_grids()
+  spins = {}
+  grip.open(tbl, url, {})
+  for bufnr, session in pairs(view._sessions) do
+    return bufnr, session
+  end
+  error("no grid session created for " .. tbl)
+end
+
+--- Spinner messages recorded since the last reset.
+local function take_spins()
+  local s = spins
+  spins = {}
+  return s
+end
+
+-- ── the opening query (the path that already worked) ──────────────────────
+
+test("open: opening query shows a spinner", function()
+  open_grid("users")
+  local s = take_spins()
+  truthy(#s >= 1, "expected a spinner during open")
+  contains(table.concat(s, "\n"), "users", "spinner names the table")
+end)
+
+-- ── pagination: H / L / [p / ]p ───────────────────────────────────────────
+
+test("on_requery: next page shows a spinner", function()
+  local bufnr, session = open_grid("users")
+  take_spins()
+  session.on_requery(bufnr, qmod.next_page(session.query_spec))
+  local s = take_spins()
+  truthy(#s >= 1, "expected a spinner while loading the next page")
+end)
+
+test("on_requery: page change still lands on the requested page", function()
+  local bufnr, session = open_grid("users")
+  session.on_requery(bufnr, qmod.set_page(session.query_spec, 1))
+  assert(view._sessions[bufnr].query_spec.page == 1, "page kept")
+end)
+
+-- ── sorting: s / S ────────────────────────────────────────────────────────
+
+test("on_requery: sort shows a spinner", function()
+  local bufnr, session = open_grid("users")
+  take_spins()
+  session.on_requery(bufnr, qmod.toggle_sort(session.query_spec, "id"))
+  local s = take_spins()
+  truthy(#s >= 1, "expected a spinner while sorting")
+end)
+
+test("on_requery: sort still reaches the grid", function()
+  local bufnr, session = open_grid("users")
+  session.on_requery(bufnr, qmod.toggle_sort(session.query_spec, "id"))
+  local spec = view._sessions[bufnr].query_spec
+  truthy(#spec.sorts == 1, "sort recorded on the session spec")
+end)
+
+-- ── refresh: R ────────────────────────────────────────────────────────────
+
+test("on_refresh: manual refresh shows a spinner", function()
+  local bufnr, session = open_grid("users")
+  take_spins()
+  session.on_refresh(bufnr)
+  local s = take_spins()
+  truthy(#s >= 1, "expected a spinner while refreshing")
+end)
+
+-- ── one spinner per reload, not a flicker of two ──────────────────────────
+
+test("on_requery: the count query and the page query share one spinner", function()
+  local bufnr, session = open_grid("users")
+  take_spins()
+  session.on_requery(bufnr, qmod.next_page(session.query_spec))
+  local s = take_spins()
+  assert(#s == 1, "expected exactly 1 spinner, got " .. #s .. ": " .. table.concat(s, " | "))
+end)
+
+-- ── the spinner has to stay up until the grid is ready ────────────────────
+
+-- The opening SELECT was inside the float, but the primary-key lookup and the
+-- pagination COUNT were not: on a remote connection the spinner vanished and
+-- the editor then sat frozen through two more round-trips before the grid
+-- appeared.
+test("open: every db round-trip happens inside the spinner", function()
+  cleanup_grids()
+  local naked = db_calls_outside_spinner(function() grip.open("users", url, {}) end)
+  assert(#naked == 0,
+    "these db calls ran with no spinner up: " .. table.concat(naked, ", "))
+end)
+
+test("open: the grid still knows the row count", function()
+  local bufnr = open_grid("users")
+  assert(view._sessions[bufnr].total_rows == 15,
+    "total_rows: expected 15, got " .. tostring(view._sessions[bufnr].total_rows))
+end)
+
+-- ── the spinner must not swallow the error ────────────────────────────────
+
+-- ui.blocking() forwards its fn's returns through table.unpack, which drops
+-- everything after a leading nil -- so a `return nil, err` from inside the
+-- float would reach the caller as no values at all and the real db error
+-- would be replaced by "unknown error". Run this one against the REAL
+-- ui.blocking: the stub above forwards returns faithfully and would hide it.
+test("on_requery: a failed query still reports the db error", function()
+  local bufnr, session = open_grid("users")
+  ui.blocking = real_blocking
+
+  local db = require("dadbod-grip.db")
+  local real_query  = db.query
+  local real_notify = vim.notify
+  local notified = {}
+  db.query = function() return nil, "boom: connection refused" end
+  vim.notify = function(msg) table.insert(notified, tostring(msg)) end
+
+  local ok, err = pcall(session.on_requery, bufnr, qmod.next_page(session.query_spec))
+
+  db.query   = real_query
+  vim.notify = real_notify
+  ui.blocking = stub_blocking
+
+  assert(ok, "on_requery threw: " .. tostring(err))
+  contains(table.concat(notified, "\n"), "boom: connection refused", "db error surfaced")
+end)
+
+cleanup_grids()
+ui.blocking = real_blocking
+
+print(string.format("requery_spinner_spec: %d passed, %d failed", pass, fail))
+if fail > 0 then os.exit(1) end

--- a/tests/spec/requery_spinner_spec.lua
+++ b/tests/spec/requery_spinner_spec.lua
@@ -53,7 +53,7 @@ local function stub_blocking(msg, fn)
   depth = depth - 1
   local ok = table.remove(rets, 1)
   if not ok then error(rets[1], 0) end
-  return (table.unpack or unpack)(rets)
+  return unpack(rets)
 end
 ui.blocking = stub_blocking
 
@@ -93,9 +93,8 @@ local function open_grid(tbl)
   cleanup_grids()
   spins = {}
   grip.open(tbl, url, {})
-  for bufnr, session in pairs(view._sessions) do
-    return bufnr, session
-  end
+  local bufnr, session = next(view._sessions)
+  if bufnr then return bufnr, session end
   error("no grid session created for " .. tbl)
 end
 


### PR DESCRIPTION
ui.blocking() covered exactly one query: the opening SELECT in init.open(). Every other db round-trip ran with no indicator at all, so on anything slower than a local SQLite file the editor simply froze and the grid looked hung.

Opening a table is three round-trips -- the SELECT, the primary-key lookup and the pagination COUNT -- and only the first was inside the float. The spinner vanished, the editor sat frozen through two more adapter invocations (each one spawns psql/mysql/sqlcmd), and only then did the grid appear.

Reloading an open grid had no spinner whatsoever: sorting (s, S), filtering (f, <C-f>, F, gn, gF, presets), pagination (H/L, [p/]p, [P/]P), reset (X), refresh (R) and the FK jumps (gf, gm).

do_refresh is split into fetch_refresh (the db round-trips) and apply_refresh (the render), so a caller with db work of its own can put the whole batch under one float instead of flashing two: on_requery's COUNT now shares a spinner with its page query, and the FK jumps put their three or four round-trips behind one. init.open() reuses fetch_refresh and pulls the COUNT ahead of view.open(), which also drops a render -- view.open() takes query_spec and total_rows in its opts, so the first paint already reads "Page 1/N (M rows)" and the follow-up _render_if_visible() re-render is gone. Opening a table renders once, not twice.

One trap for future callers, and the reason work run inside a float returns a single table rather than `nil, err`: ui.blocking() forwards its fn's returns through table.unpack, and `{ pcall(fn) }` with a leading nil is a table with a hole, so #rets is a border LuaJIT may report as 1. Everything after the nil is dropped, the caller sees no values at all, and a real db error is reported as "unknown error". requery_spinner_spec covers that case against the unstubbed ui.blocking; it fails on the `nil, err` shape and passes on the table shape.

The deferred get_column_info() for conditional formatting stays outside the spinner on purpose: it runs from vim.schedule once the grid is already visible, and folding it in would slow every open for a cosmetic feature.

## What does this PR do?

<!-- Brief description of the change -->

## How to test

<!-- Steps to verify the change works -->

## Checklist

- [x] `just test` passes (all specs green)
- [x] No new warnings or errors in `:messages`
- [x] Tested with at least one adapter (pg/sqlite/duckdb/mysql)
