### PR TITLE
fix(ui): build the workspace behind one preloader, not on screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Connecting assembled the workspace on screen, one empty pane at a time.** `schema.toggle()`
+  opened the sidebar split *before* `list_tables()`/`list_routines()`, and those block on a DB
+  round-trip that pumps the event loop — so the terminal repainted with an empty sidebar next to
+  an empty content area, held it for as long as the query took, then dropped the query pad in as
+  a third paint before anything had content. The "connected to …" toast fired first of all,
+  hanging alone over the blank layout. The schema is now fetched by the new `schema.prefetch(url)`
+  while no sidebar exists yet, and `connections.switch()` builds sidebar, welcome screen and query
+  pad inside a single `ui.blocking()` preloader with nothing blocking between them: the spinner
+  covers the old screen until the whole workspace is ready, and lifts on a finished layout. The
+  toast now follows it. `ui.blocking()` calls nest — an inner call relabels the float instead of
+  closing it, so the file-open path (which runs its own spinner for the grid query) no longer
+  flashes a half-built layout between the two.
+
 - **`F` and `X` dropped you out of an FK context without saying so.** An FK jump (`gf`, `gm`)
   scopes the grid with a WHERE clause of its own — `"categoryId" = 15` for "the CategoryVersion
   rows referencing Category 15". That clause lived in `query_spec.filters` indistinguishable from

--- a/lua/dadbod-grip/connections.lua
+++ b/lua/dadbod-grip/connections.lua
@@ -781,7 +781,6 @@ function M.switch(url, name, conn_type, opts)
   view.invalidate_mode_cache()
 
   if resolved_type == "file" then
-    vim.notify("Grip: opening " .. (name or url), vim.log.levels.INFO)
     M.set_health(url, "ok")
     -- Compute the DuckDB connection that will actually run queries against this file.
     -- Mirrors the logic in init.lua so the query pad is wired to the same connection.
@@ -791,22 +790,33 @@ function M.switch(url, name, conn_type, opts)
     local active_resolved = active and (M.expand_url(active) or active)
     local db_url = (active_resolved and active_resolved:match("^duckdb:")) and active
       or "duckdb::memory:"
+    local label = name or url
     vim.schedule(function()
       -- No reuse_win: let find_content_win() place the grid correctly.
       -- Passing cur_win risks putting the grid in the sidebar if that window was focused.
       local open_opts = {}
       if opts and opts.write    then open_opts.write    = true       end
       if opts and opts.watch_ms then open_opts.watch_ms = opts.watch_ms end
-      require("dadbod-grip").open(url, nil, open_opts)
-      -- Open sidebar and query pad after the grid is placed
+      local schema = require("dadbod-grip.schema")
+      -- Both round-trips under one preloader. open() runs a blocking() of its
+      -- own for the grid query; nested, that relabels this float instead of
+      -- closing it, so the screen stays covered until there is a grid to show.
+      -- prefetch() goes first so the sidebar opened in the next tick is
+      -- already populated rather than empty for a second beside a live grid.
+      ui.blocking("opening " .. label .. "...", function()
+        schema.prefetch(url)
+        require("dadbod-grip").open(url, nil, open_opts)
+      end)
+      -- Open sidebar and query pad after the grid is placed. Nothing here
+      -- blocks any more, so both land in a single repaint.
       vim.schedule(function()
-        local schema = require("dadbod-grip.schema")
         if not schema.is_open() then
           schema.toggle(url)
         else
           schema.refresh(url)
         end
         require("dadbod-grip.query_pad").open(db_url)
+        vim.notify("Grip: opening " .. label, vim.log.levels.INFO)
       end)
     end)
     return true
@@ -856,29 +866,44 @@ function M.switch(url, name, conn_type, opts)
     end
   end
 
-  vim.notify("Grip: connected to " .. (name or url), vim.log.levels.INFO)
   M.set_health(url, "ok")
   -- Invalidate completion cache so the new connection's schema is fetched fresh.
   require("dadbod-grip.completion").invalidate(url)
 
+  local label = name or url
+
   vim.schedule(function()
     local schema = require("dadbod-grip.schema")
-    if not schema.is_open() then
-      schema.toggle(url)
-    else
-      schema.refresh(url)
-    end
 
-    -- Show welcome screen in the main content area
-    require("dadbod-grip").open_welcome()
+    -- One preloader over the whole workspace. The table list is fetched here,
+    -- before any of these windows exist, and the three panes are then built
+    -- with nothing blocking between them -- so the float lifts on a finished
+    -- layout. Built the other way round, each pane appeared empty and filled
+    -- in a second later, which read as the plugin assembling itself on screen.
+    ui.blocking("connecting to " .. label .. "...", function()
+      schema.prefetch(url)
 
-    local query_pad = require("dadbod-grip.query_pad")
-    query_pad.open(url)
+      if not schema.is_open() then
+        schema.toggle(url)
+      else
+        schema.refresh(url)
+      end
 
-    -- Focus sidebar so user can immediately browse tables
-    if schema.is_open() and schema.get_winid() then
-      vim.api.nvim_set_current_win(schema.get_winid())
-    end
+      -- Show welcome screen in the main content area
+      require("dadbod-grip").open_welcome()
+
+      local query_pad = require("dadbod-grip.query_pad")
+      query_pad.open(url)
+
+      -- Focus sidebar so user can immediately browse tables
+      if schema.is_open() and schema.get_winid() then
+        vim.api.nvim_set_current_win(schema.get_winid())
+      end
+    end)
+
+    -- After the layout, not before it: fired first, this toast hung alone over
+    -- an empty screen for however long the schema took to arrive.
+    vim.notify("Grip: connected to " .. label, vim.log.levels.INFO)
 
     -- Pre-warm completion schema cache in background (avoids freeze on first keypress)
     vim.schedule(function()

--- a/lua/dadbod-grip/schema.lua
+++ b/lua/dadbod-grip/schema.lua
@@ -1147,6 +1147,26 @@ local function sidebar_width()
   return math.max(SIDEBAR_MIN_WIDTH, math.min(SIDEBAR_MAX_WIDTH, w))
 end
 
+--- Fetch the schema for `url` into state, touching no window.
+---
+--- Split out of toggle() so a caller assembling the workspace can pay for the
+--- DB round-trip while the preloader is still up and the old screen is still
+--- whole, instead of behind a sidebar that is already visible and empty.
+--- Cached: a second call for the same URL costs nothing.
+--- @param url string
+--- @return table state
+function M.prefetch(url)
+  local state = get_state(url)
+  if not state.items then
+    if is_file_url(url) then
+      fetch_file_schema(state)
+    else
+      fetch_tables(state)
+    end
+  end
+  return state
+end
+
 --- Open or toggle the schema sidebar.
 -- From outside the sidebar: focus it (open if needed).
 -- From inside the sidebar: close it.
@@ -1171,7 +1191,13 @@ function M.toggle(url)
     end
   end
 
-  local state = get_state(url)
+  -- Fetch first, window second. list_tables()/list_routines() block on a DB
+  -- round-trip that pumps the event loop, so a sidebar opened ahead of them
+  -- sat on screen empty for the whole query -- and, next to an equally empty
+  -- content area, made the workspace look like it was assembling itself in
+  -- front of the user. Nothing between here and render() below blocks, so the
+  -- split now appears already filled.
+  local state = M.prefetch(url)
 
   -- Create buffer if needed
   if not _sidebar_bufnr or not vim.api.nvim_buf_is_valid(_sidebar_bufnr) then
@@ -1197,15 +1223,6 @@ function M.toggle(url)
   vim.wo[_sidebar_winid].cursorline = true
   vim.wo[_sidebar_winid].winfixwidth = true
   vim.wo[_sidebar_winid].wrap = false
-
-  -- Fetch schema if not cached
-  if not state.items then
-    if is_file_url(url) then
-      fetch_file_schema(state)
-    else
-      fetch_tables(state)
-    end
-  end
 
   render(state)
 end
@@ -1246,6 +1263,11 @@ end
 M.get_state = get_state
 
 --- Exposed for testing only.
+--- Test hook: forget every cached schema so a spec can watch a fresh fetch.
+function M._reset_state()
+  _states = {}
+end
+
 M._truncate_name = truncate_name
 M._build_nodes = build_nodes
 

--- a/lua/dadbod-grip/ui.lua
+++ b/lua/dadbod-grip/ui.lua
@@ -300,6 +300,10 @@ function M.dismiss_float(opts)
   return close
 end
 
+--- The float owned by the outermost blocking() call, or nil when none is up.
+--- @type table|nil  { msg = string }
+local _spinner = nil
+
 --- Show an animated spinner float, run fn(), then clear the float.
 ---
 --- IMPORTANT: fn() must be synchronous OR use vim.wait() for async work.
@@ -315,10 +319,35 @@ end
 --- eventignore="all" suppresses plugin autocmds (WinNew/BufNew) that add
 --- 200-400ms overhead from noice/treesitter/nvim-cmp handlers.
 ---
+--- Calls nest: only the outermost one owns the float, and an inner call just
+--- relabels it for the duration of its own work. Closing the inner float would
+--- flush whatever the outer call has built so far to the terminal -- for the
+--- workspace that means a half-open sidebar over an empty content area, the
+--- exact flicker the spinner is there to cover.
+---
 --- @param msg string
 --- @param fn  function  must be synchronous or use vim.wait() internally
 --- @return    any       all return values from fn() forwarded
 function M.blocking(msg, fn)
+  -- table.pack/table.unpack are Lua 5.2+; LuaJIT is 5.1.
+  -- { pcall(fn) } => { ok, r1, r2, ... } or { false, errmsg }
+  -- table.unpack is nil on the LuaJIT Neovim embeds; probed so this keeps
+  -- working if Neovim ever moves to a 5.2+ VM, where bare `unpack` is gone.
+  -- luacheck: ignore 143
+  local unpack_ = table.unpack or unpack
+
+  -- Nested: borrow the float that is already up, restoring its message so the
+  -- outer call goes back to describing its own work when this one returns.
+  if _spinner then
+    local outer_msg = _spinner.msg
+    _spinner.msg = msg
+    local rets = { pcall(fn) }
+    local ok   = table.remove(rets, 1)
+    _spinner.msg = outer_msg
+    if not ok then error(rets[1], 2) end
+    return unpack_(rets)
+  end
+
   local frames = { "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏" }
   local fi = 1
 
@@ -338,6 +367,10 @@ function M.blocking(msg, fn)
   })
   vim.o.eventignore = ei
 
+  -- Claimed only now: a nested call reaching this far would have had no float
+  -- to borrow, and every one after it must find a live window to relabel.
+  _spinner = { msg = msg }
+
   -- Flush to terminal NOW, before fn() runs. nvim__redraw is private API on
   -- purpose: there is no public equivalent that flushes from inside a blocking
   -- call (:redraw is a no-op while we hold the loop).
@@ -346,23 +379,26 @@ function M.blocking(msg, fn)
   -- Animate: timer fires during vim.system():wait() and vim.wait() event loop pumps.
   -- libuv timer callbacks are "fast events" - nvim API calls are forbidden there.
   -- vim.schedule_wrap defers the API work into the main loop, which pumps during wait().
+  -- Reads _spinner.msg, not the upvalue, so a nested call's label shows while
+  -- it runs.
   local timer = vim.uv.new_timer()
   timer:start(80, 80, vim.schedule_wrap(function()
     fi = (fi % #frames) + 1
     if vim.api.nvim_buf_is_valid(buf) then
       pcall(vim.api.nvim_buf_set_lines, buf, 0, -1, false,
-        { "", "  " .. frames[fi] .. " " .. msg, "" })
+        { "", "  " .. frames[fi] .. " " .. ((_spinner and _spinner.msg) or msg), "" })
       vim.api.nvim__redraw({ flush = true })
     end
   end))
 
-  -- table.pack/table.unpack are Lua 5.2+; LuaJIT is 5.1.
-  -- { pcall(fn) } => { ok, r1, r2, ... } or { false, errmsg }
   local rets = { pcall(fn) }
   local ok   = table.remove(rets, 1)
 
   timer:stop()
   timer:close()
+  -- Released before the close below: anything the cleanup triggers must see
+  -- no spinner rather than one that is about to vanish.
+  _spinner = nil
 
   -- Close float, suppressing autocmds again.
   ei = vim.o.eventignore
@@ -375,10 +411,7 @@ function M.blocking(msg, fn)
   vim.api.nvim__redraw({ flush = true })
 
   if not ok then error(rets[1], 2) end
-  -- table.unpack is nil on the LuaJIT Neovim embeds; probed so this keeps working
-  -- if Neovim ever moves to a 5.2+ VM, where the bare `unpack` global is gone.
-  -- luacheck: ignore 143
-  return (table.unpack or unpack)(rets)
+  return unpack_(rets)
 end
 
 return M

--- a/tests/fixtures/workspace_preload_integration.lua
+++ b/tests/fixtures/workspace_preload_integration.lua
@@ -1,0 +1,23 @@
+local grip = require("dadbod-grip")
+local connections = require("dadbod-grip.connections")
+local query_pad = require("dadbod-grip.query_pad")
+local schema = require("dadbod-grip.schema")
+
+local url = "sqlite:tests/seed_sqlite.db"
+grip.setup({})
+assert(connections.switch(url, "seed", "sqlite"))
+
+assert(vim.wait(5000, function()
+  local state = schema.get_state(url)
+  local pad = query_pad.get_pad_bufnr()
+  return schema.is_open()
+    and state.items and #state.items > 0
+    and pad and vim.api.nvim_buf_is_valid(pad)
+    and vim.fn.bufnr("grip://welcome") ~= -1
+end, 10), "the complete workspace did not finish opening")
+
+local schema_buf = vim.fn.bufnr("grip://schema")
+local lines = vim.api.nvim_buf_get_lines(schema_buf, 0, -1, false)
+assert(table.concat(lines, "\n"):find("users", 1, true), "sidebar opened before it was populated")
+
+vim.cmd("qall!")

--- a/tests/spec/conn_color_spec.lua
+++ b/tests/spec/conn_color_spec.lua
@@ -246,6 +246,7 @@ local function with_real_file(fn)
     is_open = function() return true end,
     refresh = function() end,
     toggle = function() end,
+    prefetch = function() return {} end,
     get_winid = function() return nil end,
   }
   package.loaded["dadbod-grip.query_pad"] = { open = function() end }

--- a/tests/spec/connections_fields_spec.lua
+++ b/tests/spec/connections_fields_spec.lua
@@ -72,6 +72,7 @@ local function with_real_file(fn)
     is_open = function() return true end,
     refresh = function() end,
     toggle = function() end,
+    prefetch = function() return {} end,
     get_winid = function() return nil end,
   }
   package.loaded["dadbod-grip.query_pad"] = { open = function() end }

--- a/tests/spec/connections_spec.lua
+++ b/tests/spec/connections_spec.lua
@@ -83,6 +83,9 @@ local function with_real_file(fn)
     refresh = function() end,
     toggle = function() end,
     get_winid = function() return nil end,
+    -- switch() prefetches the schema under the preloader, before it opens
+    -- any window; the double has to answer that call too.
+    prefetch = function() return {} end,
   }
   package.loaded["dadbod-grip.query_pad"] = { open = function() end }
   package.loaded["dadbod-grip.completion"] = { invalidate = function() end, warm_schema = function() end }
@@ -112,6 +115,13 @@ local function with_real_file(fn)
   vim.fn.delete(project_dir, "rf")
   vim.fn.delete(fake_home, "rf")
   if not ok then error(err) end
+end
+
+--- switch() reports which branch it took from inside a scheduled callback --
+--- it notifies after the workspace is on screen, not before it is built -- so
+--- the queue has to be flushed before the message can be read.
+local function flush_schedules()
+  vim.wait(100)
 end
 
 local function read_connections_json(dir)
@@ -210,6 +220,7 @@ test("switch: global file is consulted when no local match and no configured pat
 
     connections.switch("customscheme://host/db", nil, nil, {})
 
+    flush_schedules()
     assert(#notified > 0 and notified[1]:find("opening", 1, true),
       "type resolved from global file, file-open branch should have run: " .. vim.inspect(notified))
   end)
@@ -229,6 +240,7 @@ test("switch: global file is not consulted when connections_path is configured",
 
     connections.switch("customscheme://host/db", nil, nil, {})
 
+    flush_schedules()
     assert(#notified > 0 and notified[1]:find("connected to", 1, true),
       "global type must be ignored when connections_path is configured: " .. vim.inspect(notified))
   end)
@@ -246,6 +258,7 @@ test("switch: global file is not consulted when conn_type is already given", fun
 
     connections.switch("customscheme://host/db", nil, "postgresql", {})
 
+    flush_schedules()
     assert(#notified > 0 and notified[1]:find("connected to", 1, true),
       "explicit conn_type param must win over global lookup: " .. vim.inspect(notified))
   end)
@@ -267,6 +280,7 @@ test("switch: global file is not consulted when the type is already known locall
 
     connections.switch("customscheme://host/db", nil, nil, {})
 
+    flush_schedules()
     assert(#notified > 0 and notified[1]:find("connected to", 1, true),
       "locally-known type must win over global lookup: " .. vim.inspect(notified))
   end)

--- a/tests/spec/readonly_mode_spec.lua
+++ b/tests/spec/readonly_mode_spec.lua
@@ -790,7 +790,8 @@ local function with_switchable(initial_url, fn)
     }
     package.loaded["dadbod-grip.schema"] = {
       is_open = function() return true end, refresh = function() end,
-      toggle = function() end, get_winid = function() return nil end,
+      toggle = function() end, prefetch = function() return {} end,
+      get_winid = function() return nil end,
     }
     package.loaded["dadbod-grip.query_pad"]  = { open = function() end }
     package.loaded["dadbod-grip.completion"] = {

--- a/tests/spec/secrets_integration_spec.lua
+++ b/tests/spec/secrets_integration_spec.lua
@@ -83,6 +83,7 @@ local function with_real_file(fn)
     is_open = function() return true end,
     refresh = function() end,
     toggle = function() end,
+    prefetch = function() return {} end,
     get_winid = function() return nil end,
     -- view.lua asks the sidebar where to place the grid.
     get_right_win = function() return nil end,
@@ -464,6 +465,31 @@ local function with_duckdb(label, fn)
   fn()
 end
 
+--- Drive the real process boundary without contacting a database service.
+--- The fake executable emits controlled stderr so redaction is tested after
+--- spawn, not against a string passed straight to the redactor.
+local function with_fake_duckdb(stderr, fn)
+  local dir = vim.fn.tempname() .. "_fake_duckdb"
+  local executable = dir .. "/duckdb"
+  vim.fn.mkdir(dir, "p")
+  vim.fn.writefile({
+    "#!/bin/sh",
+    "printf '%s\\n' \"$GRIP_FAKE_DUCKDB_STDERR\" >&2",
+    "exit 1",
+  }, executable)
+  assert(vim.fn.setfperm(executable, "rwx------") == 1, "could not create fake duckdb")
+
+  local path = vim.env.PATH
+  local fake_stderr = vim.env.GRIP_FAKE_DUCKDB_STDERR
+  vim.env.PATH = dir .. ":" .. (path or "")
+  vim.env.GRIP_FAKE_DUCKDB_STDERR = stderr
+  local ok, err = pcall(fn)
+  vim.env.PATH = path
+  vim.env.GRIP_FAKE_DUCKDB_STDERR = fake_stderr
+  vim.fn.delete(dir, "rf")
+  if not ok then error(err, 0) end
+end
+
 test("attach error: a password containing @ survives url_to_dsn and is fully masked", function()
   with_duckdb("@-in-password leak test", function()
     local duckdb = require("dadbod-grip.adapters.duckdb")
@@ -529,16 +555,11 @@ test("query error: an attachment that dies after attach cannot leak on the next 
 end)
 
 test("attach error: a motherduck token never reaches the message", function()
-  with_duckdb("motherduck token test", function()
-    local duckdb = require("dadbod-grip.adapters.duckdb")
-    -- Honest scope: DuckDB v1.5.5 rejects this before it echoes the DSN, so
-    -- this asserts the property (no token on screen) rather than proving the
-    -- mask fired. It is a forward guard against a binary that does echo -- and
-    -- unlike the composed-message test it replaces, it cannot pass by
-    -- construction.
-    local dsn = "md:analytics?motherduck_token=eyJhbGciOi_fake_token"
+  local duckdb = require("dadbod-grip.adapters.duckdb")
+  local dsn = "md:analytics?motherduck_token=eyJhbGciOi_fake_token"
+  with_fake_duckdb("Connection failed for " .. dsn, function()
     local err = duckdb.attach("duckdb::memory:", dsn, "mdtok")
-    duckdb.detach("duckdb::memory:", "mdtok")
+    assert(err, "the fake CLI failure must be returned")
     assert(not (err or ""):find("eyJhbGciOi_fake_token", 1, true),
       "no token in the message: " .. tostring(err))
   end)

--- a/tests/spec/ui_spec.lua
+++ b/tests/spec/ui_spec.lua
@@ -52,6 +52,59 @@ test("blocking: nil return values handled", function()
   eq(b, nil, "second nil")
 end)
 
+-- ── nested blocking() ───────────────────────────────────────────────────────
+-- A workspace is built from several steps that each want to say what they are
+-- doing. Only the outermost one owns the float: an inner call that closed it
+-- would flush the half-built layout to the terminal, which is the whole thing
+-- the preloader exists to hide.
+
+test("blocking: nested call keeps one float, not two", function()
+  local outer_wins, inner_wins
+  ui.blocking("outer", function()
+    outer_wins = win_count()
+    ui.blocking("inner", function()
+      inner_wins = win_count()
+    end)
+  end)
+  eq(inner_wins, outer_wins, "nested call adds no second float")
+end)
+
+test("blocking: float survives the nested call", function()
+  local after_nested
+  ui.blocking("outer", function()
+    ui.blocking("inner", function() end)
+    after_nested = win_count()
+  end)
+  assert(after_nested, "outer body ran")
+  eq(after_nested, win_count() + 1, "outer float still up after the nested call")
+end)
+
+test("blocking: nested call forwards return values", function()
+  local a, b = ui.blocking("outer", function()
+    return ui.blocking("inner", function() return 7, 8 end)
+  end)
+  eq(a, 7, "first"); eq(b, 8, "second")
+end)
+
+test("blocking: nested error propagates and still cleans up", function()
+  local before = win_count()
+  local ok, err = pcall(ui.blocking, "outer", function()
+    ui.blocking("inner", function() error("nested boom") end)
+  end)
+  eq(ok, false, "should error")
+  assert(tostring(err):find("nested boom"), "error msg should contain 'nested boom'")
+  eq(win_count(), before, "no float left behind")
+end)
+
+test("blocking: a later top-level call still opens its own float", function()
+  ui.blocking("outer", function()
+    ui.blocking("inner", function() end)
+  end)
+  local during
+  ui.blocking("after", function() during = win_count() end)
+  eq(during, win_count() + 1, "spinner state was released")
+end)
+
 -- ── input / confirm ─────────────────────────────────────────────────────────
 
 --- Answer the next prompt with `keys`, then run fn().

--- a/tests/spec/workspace_preload_spec.lua
+++ b/tests/spec/workspace_preload_spec.lua
@@ -93,5 +93,15 @@ test("prefetch: a second call does not re-query", function()
   eq(calls, 1, "cached schema is reused")
 end)
 
+test("switch: a real connection opens the complete prefetched workspace", function()
+  local result = vim.system({
+    vim.g.grip_test_progpath,
+    "--headless",
+    "-u", "tests/minimal_init.lua",
+    "-l", "tests/fixtures/workspace_preload_integration.lua",
+  }, { text = true }):wait()
+  assert(result.code == 0, (result.stdout or "") .. (result.stderr or ""))
+end)
+
 print(string.format("workspace_preload_spec: %d passed, %d failed", pass, fail))
 if fail > 0 then os.exit(1) end

--- a/tests/spec/workspace_preload_spec.lua
+++ b/tests/spec/workspace_preload_spec.lua
@@ -1,0 +1,97 @@
+-- workspace_preload_spec.lua: the workspace must not be assembled on screen.
+--
+-- Opening a connection used to paint three times: an empty sidebar while the
+-- table list was still being fetched, then an empty content area, then the
+-- query pad dropping in. Every step here exists to keep that from coming back.
+dofile("tests/minimal_init.lua")
+
+local schema = require("dadbod-grip.schema")
+local db     = require("dadbod-grip.db")
+
+local pass, fail = 0, 0
+
+local function test(name, fn)
+  local ok, err = pcall(fn)
+  if ok then
+    pass = pass + 1
+  else
+    fail = fail + 1
+    print("FAIL: " .. name .. ": " .. tostring(err))
+  end
+end
+
+local function eq(a, b, msg)
+  assert(a == b, (msg or "") .. ": expected " .. tostring(b) .. ", got " .. tostring(a))
+end
+
+--- Is a schema sidebar window on screen right now?
+local function sidebar_on_screen()
+  for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+    local buf = vim.api.nvim_win_get_buf(win)
+    if vim.api.nvim_buf_is_valid(buf) and vim.bo[buf].filetype == "grip_schema" then
+      return true
+    end
+  end
+  return false
+end
+
+--- Run fn() with db.list_tables/list_routines stubbed out, then restore.
+--- `on_fetch` is called at the moment the table list is asked for -- the
+--- point where a real connection blocks on a round-trip.
+local function with_stubbed_db(on_fetch, fn)
+  local real_tables, real_routines = db.list_tables, db.list_routines
+  db.list_tables = function()
+    if on_fetch then on_fetch() end
+    return { { type = "table", name = "users" }, { type = "table", name = "orders" } }
+  end
+  db.list_routines = function() return {} end
+  local ok, err = pcall(fn)
+  db.list_tables, db.list_routines = real_tables, real_routines
+  if not ok then error(err, 0) end
+end
+
+test("toggle: schema is fetched before the sidebar window exists", function()
+  schema.close()
+  schema._reset_state()
+  local sidebar_during_fetch
+  with_stubbed_db(
+    function() sidebar_during_fetch = sidebar_on_screen() end,
+    function() schema.toggle("sqlite:tests/seed_sqlite.db") end)
+  schema.close()
+  eq(sidebar_during_fetch, false, "no empty sidebar on screen while fetching")
+end)
+
+test("toggle: the sidebar is populated the moment it opens", function()
+  schema.close()
+  schema._reset_state()
+  with_stubbed_db(nil, function() schema.toggle("sqlite:tests/seed_sqlite.db") end)
+  local buf = vim.fn.bufnr("grip://schema")
+  assert(buf ~= -1, "sidebar buffer exists")
+  local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+  local joined = table.concat(lines, "\n")
+  schema.close()
+  assert(joined:find("users", 1, true), "table list rendered on open, not after")
+end)
+
+test("prefetch: fills state without opening any window", function()
+  schema.close()
+  schema._reset_state()
+  local before = #vim.api.nvim_list_wins()
+  with_stubbed_db(nil, function() schema.prefetch("sqlite:tests/seed_sqlite.db") end)
+  eq(#vim.api.nvim_list_wins(), before, "prefetch opened no window")
+  eq(sidebar_on_screen(), false, "prefetch showed no sidebar")
+end)
+
+test("prefetch: a second call does not re-query", function()
+  schema.close()
+  schema._reset_state()
+  local calls = 0
+  with_stubbed_db(function() calls = calls + 1 end, function()
+    schema.prefetch("sqlite:tests/seed_sqlite.db")
+    schema.prefetch("sqlite:tests/seed_sqlite.db")
+  end)
+  eq(calls, 1, "cached schema is reused")
+end)
+
+print(string.format("workspace_preload_spec: %d passed, %d failed", pass, fail))
+if fail > 0 then os.exit(1) end


### PR DESCRIPTION
Connecting painted the layout three times. schema.toggle() opened the sidebar split before list_tables()/list_routines(), and those block on a DB round-trip that pumps the event loop, so the terminal repainted with an empty sidebar beside an empty content area and held it for the length of the query; the query pad then arrived as a third paint, still with nothing in it. The "connected to ..." toast fired ahead of all of it.

schema.prefetch(url) does the fetch with no window in existence, and connections.switch() builds sidebar, welcome screen and query pad inside a single ui.blocking() with nothing blocking in between -- so the float lifts on a finished workspace instead of the user watching it assemble.

ui.blocking() now nests: an inner call relabels the float rather than closing it. Closing it would flush the outer call's half-built layout to the terminal, which is what the file-open path did between its schema fetch and the grid query.

The four connections_spec cases that read the notify as a proxy for which branch switch() took now flush the schedule queue first: the message is deferred along with the layout it describes.

## What does this PR do?

<!-- Brief description of the change -->

## How to test

<!-- Steps to verify the change works -->

## Checklist

- [x] `just test` passes (all specs green)
- [x] No new warnings or errors in `:messages`
- [x] Tested with at least one adapter (pg/sqlite/duckdb/mysql)
