### PR TITLE
test: make asynchronous failures fail CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,12 +20,11 @@ jobs:
         neovim: ['v0.10.0', 'stable']
     steps:
       - uses: actions/checkout@v4
+      - uses: extractions/setup-just@v3
       - uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
           version: ${{ matrix.neovim }}
-      - name: Seed SQLite test database
-        run: sqlite3 tests/seed_sqlite.db < tests/seed_sqlite.sql
       # duckdb_federation, duckdb_native_schema and duckdb_federated_schema gate on
       # this binary — 66 assertions that print SKIPPED without it while the runner
       # still reports ALL TESTS PASSED. Pinned rather than floating: those specs
@@ -64,10 +63,9 @@ jobs:
             sleep 5
           done
           exit 1
-      - name: Run unit tests
+      - name: Run deterministic suite through the documented entry point
         # Turns a missing duckdb/sqlite3 into a failure instead of a silent skip,
         # so removing the step above can't quietly take those 66 assertions with it.
         env:
           GRIP_REQUIRE_DUCKDB: '1'
-        run: |
-          nvim --headless -u tests/minimal_init.lua -l tests/run_specs.lua
+        run: just test

--- a/justfile
+++ b/justfile
@@ -4,12 +4,12 @@
 # Default recipe: run tests
 default: test
 
-# Run all unit tests (328 specs across 14 modules)
-test:
+# Run all unit tests from a fresh deterministic SQLite fixture
+test: seed-sqlite
     nvim --headless -u tests/minimal_init.lua -l tests/run_specs.lua
 
 # Run a single spec file by name (e.g., just spec data)
-spec name:
+spec name: seed-sqlite
     nvim --headless -u tests/minimal_init.lua -l tests/spec/{{name}}_spec.lua
 
 # Lint with luacheck. Settings live in .luacheckrc; same args as CI.

--- a/tests/fixtures/schedule_failure.lua
+++ b/tests/fixtures/schedule_failure.lua
@@ -1,0 +1,6 @@
+vim.schedule(function()
+  error("intentional scheduled callback failure")
+end)
+
+vim.wait(1000, function() return false end, 10)
+vim.cmd("qall!")

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -1,10 +1,28 @@
 -- Minimal init for headless testing: loads plugin from repo root
 vim.opt.rtp:prepend(".")
+vim.g.grip_test_progpath = vim.v.progpath
 -- Shared spec assertions live in tests/helpers.lua and are pulled in with
 -- require("helpers"). The directory is resolved from this file's own path, so
 -- the name works no matter which cwd nvim was launched from.
 package.path = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h")
   .. "/?.lua;" .. package.path
+
+-- Neovim reports scheduled callback errors without making the headless process
+-- fail. That can turn a real async regression into "ALL TESTS PASSED". Install
+-- this once because a few focused specs source minimal_init.lua themselves.
+if not vim.g.grip_test_schedule_guard then
+  vim.g.grip_test_schedule_guard = true
+  local schedule = vim.schedule
+  vim.schedule = function(callback)
+    schedule(function()
+      local ok, err = xpcall(callback, debug.traceback)
+      if not ok then
+        vim.api.nvim_err_writeln(err)
+        vim.cmd("cquit 1")
+      end
+    end)
+  end
+end
 
 -- An in-memory clipboard, so a test run cannot touch the developer's real one.
 --

--- a/tests/spec/discovery_spec.lua
+++ b/tests/spec/discovery_spec.lua
@@ -27,6 +27,7 @@ end
 
 local _orig_systemlist = vim.fn.systemlist
 local _orig_executable = vim.fn.executable
+local _orig_v = vim.v
 local _orig_shell_error = vim.v.shell_error
 local _orig_hrtime_uv = vim.uv and vim.uv.hrtime or nil
 local _orig_hrtime_loop = vim.loop and vim.loop.hrtime or nil
@@ -57,6 +58,7 @@ end
 local function reset_stubs()
   vim.fn.systemlist = _orig_systemlist
   vim.fn.executable = _orig_executable
+  vim.v = _orig_v
   if _orig_hrtime_uv and vim.uv then vim.uv.hrtime = _orig_hrtime_uv end
   if _orig_hrtime_loop and vim.loop then vim.loop.hrtime = _orig_hrtime_loop end
   discovery._reset_cache()

--- a/tests/spec/mysql_integration_spec.lua
+++ b/tests/spec/mysql_integration_spec.lua
@@ -13,10 +13,18 @@
 -- prepend it when needed: PATH="/opt/homebrew/opt/mysql-client/bin:$PATH".
 
 local URL = vim.env.GRIP_TEST_MYSQL_URL
+local REQUIRED = vim.env.GRIP_REQUIRE_MYSQL == "1"
+
+local function unavailable(reason)
+  if REQUIRED then
+    error("mysql_integration_spec: " .. reason .. " while GRIP_REQUIRE_MYSQL=1")
+  end
+  print("SKIP: mysql_integration_spec (" .. reason .. ")")
+  print("\nmysql_integration_spec: 0 passed, 0 failed (skipped)")
+end
 
 if not URL or URL == "" then
-  print("SKIP: mysql_integration_spec (GRIP_TEST_MYSQL_URL not set)")
-  print("\nmysql_integration_spec: 0 passed, 0 failed (skipped)")
+  unavailable("GRIP_TEST_MYSQL_URL not set")
   return
 end
 
@@ -27,14 +35,12 @@ local sql = require("dadbod-grip.sql")
 local SENTINEL = "zzz_explained"
 
 if vim.fn.executable("mysql") == 0 then
-  print("SKIP: mysql_integration_spec (mysql CLI not found)")
-  print("\nmysql_integration_spec: 0 passed, 0 failed (skipped)")
+  unavailable("mysql CLI not found")
   return
 end
 
 if not my.ping(URL) then
-  print("SKIP: mysql_integration_spec (cannot reach " .. URL .. ")")
-  print("\nmysql_integration_spec: 0 passed, 0 failed (skipped)")
+  unavailable("database is unreachable")
   return
 end
 

--- a/tests/spec/pg_integration_spec.lua
+++ b/tests/spec/pg_integration_spec.lua
@@ -10,24 +10,30 @@
 --     nvim --headless -u tests/minimal_init.lua -l tests/run_specs.lua
 
 local URL = vim.env.GRIP_TEST_PG_URL
+local REQUIRED = vim.env.GRIP_REQUIRE_POSTGRES == "1"
+
+local function unavailable(reason)
+  if REQUIRED then
+    error("pg_integration_spec: " .. reason .. " while GRIP_REQUIRE_POSTGRES=1")
+  end
+  print("SKIP: pg_integration_spec (" .. reason .. ")")
+  print("\npg_integration_spec: 0 passed, 0 failed (skipped)")
+end
 
 if not URL or URL == "" then
-  print("SKIP: pg_integration_spec (GRIP_TEST_PG_URL not set)")
-  print("\npg_integration_spec: 0 passed, 0 failed (skipped)")
+  unavailable("GRIP_TEST_PG_URL not set")
   return
 end
 
 local pg = require("dadbod-grip.adapters.postgresql")
 
 if vim.fn.executable("psql") == 0 then
-  print("SKIP: pg_integration_spec (psql CLI not found)")
-  print("\npg_integration_spec: 0 passed, 0 failed (skipped)")
+  unavailable("psql CLI not found")
   return
 end
 
 if not pg.ping(URL) then
-  print("SKIP: pg_integration_spec (cannot reach " .. URL .. ")")
-  print("\npg_integration_spec: 0 passed, 0 failed (skipped)")
+  unavailable("database is unreachable")
   return
 end
 

--- a/tests/spec/test_harness_spec.lua
+++ b/tests/spec/test_harness_spec.lua
@@ -1,0 +1,16 @@
+local result = vim.system({
+  vim.g.grip_test_progpath,
+  "--headless",
+  "-u", "tests/minimal_init.lua",
+  "-l", "tests/fixtures/schedule_failure.lua",
+}, { text = true }):wait()
+
+assert(result.code ~= 0, "a scheduled callback failure must make Neovim exit nonzero")
+assert(
+  ((result.stdout or "") .. (result.stderr or "")):find(
+    "intentional scheduled callback failure", 1, true
+  ),
+  "the scheduled callback traceback must remain visible"
+)
+
+print("test_harness_spec: 2 passed, 0 failed")


### PR DESCRIPTION
Makes scheduled callback errors terminate the headless test process, adds a subprocess regression test, reseeds SQLite idempotently through just test, and makes CI use that documented entry point.

This is the test-foundation prerequisite for the v3.10 hardening series.