### PR TITLE
fix(ai): keep provider requests out of process arguments

### DIFF
--- a/lua/dadbod-grip/ai.lua
+++ b/lua/dadbod-grip/ai.lua
@@ -160,11 +160,13 @@ function M.resolve_api_key(provider_name)
       return nil, "Environment variable " .. var .. " is not set"
     elseif key:match("^cmd:") then
       local cmd = key:sub(5)
-      local result = vim.system({"sh", "-c", cmd}, { text = true }):wait()
+      local ok, process = pcall(vim.system, { "sh", "-s" }, { text = true, stdin = cmd .. "\n" })
+      if not ok then return nil, "API key command failed" end
+      local result = process:wait()
       if result.code == 0 and result.stdout ~= "" then
         return vim.trim(result.stdout)
       end
-      return nil, "Command failed: " .. cmd
+      return nil, "API key command failed"
     else
       return key
     end
@@ -383,6 +385,33 @@ end
 
 -- ── generation ────────────────────────────────────────────────────────────────
 
+--- Quote one value for curl's double-quoted config-file syntax.
+--- @param value any
+--- @return string
+local function curl_config_quote(value)
+  local escaped = tostring(value)
+  escaped = escaped:gsub("\\", "\\\\")
+  escaped = escaped:gsub('"', '\\"')
+  escaped = escaped:gsub("\t", "\\t")
+  escaped = escaped:gsub("\n", "\\n")
+  escaped = escaped:gsub("\r", "\\r")
+  escaped = escaped:gsub("\v", "\\v")
+  return '"' .. escaped .. '"'
+end
+M._curl_config_quote = curl_config_quote
+
+local function curl_config(req)
+  local lines = {
+    "request = \"POST\"",
+    "url = " .. curl_config_quote(req.url),
+  }
+  for _, header in ipairs(req.headers) do
+    lines[#lines + 1] = "header = " .. curl_config_quote(header)
+  end
+  lines[#lines + 1] = "data-binary = " .. curl_config_quote(vim.fn.json_encode(req.body))
+  return table.concat(lines, "\n") .. "\n"
+end
+
 --- POST a provider request with curl and hand the extracted text back.
 --- Every failure mode (transport, malformed JSON, API error payload, empty
 --- extraction) arrives as callback(nil, err); success as callback(text).
@@ -392,19 +421,11 @@ end
 --- @param empty_err string  message when the provider extracts nothing
 --- @param callback fun(text: string|nil, err: string|nil)
 local function post_json(req, provider, empty_err, callback)
-  local curl_args = { "curl", "-s", "-X", "POST" }
-  for _, h in ipairs(req.headers) do
-    table.insert(curl_args, "-H")
-    table.insert(curl_args, h)
-  end
-  table.insert(curl_args, "-d")
-  table.insert(curl_args, vim.fn.json_encode(req.body))
-  table.insert(curl_args, req.url)
-
-  vim.system(curl_args, { text = true }, function(result)
+  local curl_args = { "curl", "--disable", "--silent", "--show-error", "--config", "-" }
+  local ok = pcall(vim.system, curl_args, { text = true, stdin = curl_config(req) }, function(result)
     vim.schedule(function()
       if result.code ~= 0 then
-        callback(nil, "curl failed: " .. (result.stderr or "unknown error"))
+        callback(nil, "curl failed (exit " .. tostring(result.code or "unknown") .. ")")
         return
       end
 
@@ -416,8 +437,12 @@ local function post_json(req, provider, empty_err, callback)
 
       -- Check for API error
       if body.error then
-        local err_msg = type(body.error) == "table" and (body.error.message or "API error") or tostring(body.error)
-        callback(nil, err_msg)
+        local kind = type(body.error) == "table" and (body.error.type or body.error.code) or nil
+        if type(kind) == "string" and kind:match("^[%w_.-]+$") then
+          callback(nil, "API error: " .. kind)
+        else
+          callback(nil, "API error")
+        end
         return
       end
 
@@ -430,6 +455,9 @@ local function post_json(req, provider, empty_err, callback)
       callback(text)
     end)
   end)
+  if not ok then
+    vim.schedule(function() callback(nil, "Could not start curl") end)
+  end
 end
 
 --- Generate SQL from natural language. Async via curl.

--- a/tests/spec/ai_argv_spec.lua
+++ b/tests/spec/ai_argv_spec.lua
@@ -1,0 +1,139 @@
+-- ai_argv_spec.lua: provider credentials and request content must never enter argv.
+local ai = require("dadbod-grip.ai")
+local db = require("dadbod-grip.db")
+
+if vim.uv.os_uname().sysname ~= "Linux" then
+  print("SKIP: ai_argv_spec (/proc cmdline inspection requires Linux)")
+  return
+end
+
+local dir = vim.fn.tempname() .. "_ai_argv"
+local executable = dir .. "/curl"
+vim.fn.mkdir(dir, "p")
+vim.fn.writefile({
+  "#!/bin/sh",
+  "printf '%s' \"$$\" > \"$GRIP_AI_PID_FILE\"",
+  "cat > \"$GRIP_AI_STDIN_FILE\"",
+  ": > \"$GRIP_AI_READY_FILE\"",
+  "while [ ! -f \"$GRIP_AI_RELEASE_FILE\" ]; do sleep 0.02; done",
+  "if grep -q '/v1/messages' \"$GRIP_AI_STDIN_FILE\"; then",
+  "  printf '%s\\n' '{\"content\":[{\"text\":\"SELECT 1\"}]}'",
+  "elif grep -q '/v1/chat/completions' \"$GRIP_AI_STDIN_FILE\"; then",
+  "  printf '%s\\n' '{\"choices\":[{\"message\":{\"content\":\"SELECT 1\"}}]}'",
+  "elif grep -q ':generateContent' \"$GRIP_AI_STDIN_FILE\"; then",
+  "  printf '%s\\n' '{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"SELECT 1\"}]}}]}'",
+  "else",
+  "  printf '%s\\n' '{\"message\":{\"content\":\"SELECT 1\"}}'",
+  "fi",
+}, executable)
+assert(vim.fn.setfperm(executable, "rwx------") == 1, "could not create fake curl")
+
+local old_env = {
+  path = vim.env.PATH,
+  pid = vim.env.GRIP_AI_PID_FILE,
+  stdin = vim.env.GRIP_AI_STDIN_FILE,
+  ready = vim.env.GRIP_AI_READY_FILE,
+  release = vim.env.GRIP_AI_RELEASE_FILE,
+}
+local old_path = old_env.path
+vim.env.PATH = dir .. ":" .. (old_path or "")
+
+local real = {
+  list_tables = db.list_tables,
+  get_schema_batch = db.get_schema_batch,
+  get_primary_keys = db.get_primary_keys,
+  get_foreign_keys = db.get_foreign_keys,
+  notify = vim.notify,
+}
+local provider
+db.list_tables = function() return { { name = "private_table" } } end
+db.get_schema_batch = function()
+  return {
+    private_table = {
+      { column_name = "schema_secret_" .. provider, data_type = "text", is_nullable = "NO" },
+    },
+  }
+end
+db.get_primary_keys = function() return {} end
+db.get_foreign_keys = function() return {} end
+vim.notify = function() end
+
+local release_files, pids = {}, {}
+local ok, err = xpcall(function()
+  for _, name in ipairs({ "anthropic", "openai", "gemini", "ollama" }) do
+    provider = name
+    local prefix = dir .. "/" .. name
+    local pid_file = prefix .. ".pid"
+    local stdin_file = prefix .. ".stdin"
+    local ready_file = prefix .. ".ready"
+    local release_file = prefix .. ".release"
+    release_files[#release_files + 1] = release_file
+    vim.env.GRIP_AI_PID_FILE = pid_file
+    vim.env.GRIP_AI_STDIN_FILE = stdin_file
+    vim.env.GRIP_AI_READY_FILE = ready_file
+    vim.env.GRIP_AI_RELEASE_FILE = release_file
+
+    local key = name == "ollama" and "" or ("api_key_secret_" .. name)
+    local question = "prompt_secret_" .. name
+    local existing_sql = "SELECT 'existing_sql_secret_" .. name .. "'"
+    local callback_done, callback_err = false, nil
+    ai.setup({ provider = name, api_key = key, model = "model-" .. name })
+    ai.generate_sql(question, "test://argv-" .. name, function(_, cb_err)
+      callback_done, callback_err = true, cb_err
+    end, existing_sql)
+
+    assert(vim.wait(3000, function() return vim.fn.filereadable(ready_file) == 1 end, 1),
+      "fake curl did not reach the process-inspection barrier for " .. name)
+    local pid = assert(vim.fn.readfile(pid_file)[1], "fake curl did not record its pid")
+    pids[#pids + 1] = pid
+    local cmdline_file = assert(io.open("/proc/" .. pid .. "/cmdline", "rb"))
+    local cmdline = cmdline_file:read("*a")
+    cmdline_file:close()
+
+    for _, forbidden in ipairs({
+      key, question, "schema_secret_" .. name, existing_sql,
+      "api.anthropic.com", "api.openai.com", "generativelanguage.googleapis.com",
+      "localhost:11434", "Content-Type: application/json",
+    }) do
+      if forbidden ~= "" then
+        assert(not cmdline:find(forbidden, 1, true),
+          string.format("curl argv exposed %q for %s: %s", forbidden, name, cmdline:gsub("%z", " ")))
+      end
+    end
+
+    local stdin = table.concat(vim.fn.readfile(stdin_file), "\n")
+    assert(stdin:find(question, 1, true), "prompt missing from curl stdin for " .. name)
+    assert(stdin:find("schema_secret_" .. name, 1, true), "schema missing from curl stdin for " .. name)
+    assert(stdin:find("existing_sql_secret_" .. name, 1, true), "existing SQL missing from curl stdin for " .. name)
+    if key ~= "" then assert(stdin:find(key, 1, true), "API key missing from curl stdin for " .. name) end
+
+    vim.fn.writefile({ "release" }, release_file)
+    assert(vim.wait(3000, function() return callback_done end, 1), "AI callback never fired for " .. name)
+    assert(callback_err == nil, tostring(callback_err))
+  end
+end, debug.traceback)
+
+for _, release_file in ipairs(release_files) do
+  if vim.fn.filereadable(release_file) == 0 then vim.fn.writefile({ "release" }, release_file) end
+end
+vim.wait(3000, function()
+  for _, pid in ipairs(pids) do
+    if vim.fn.filereadable("/proc/" .. pid .. "/cmdline") == 1 then return false end
+  end
+  return true
+end, 1)
+ai.setup({})
+db.list_tables = real.list_tables
+db.get_schema_batch = real.get_schema_batch
+db.get_primary_keys = real.get_primary_keys
+db.get_foreign_keys = real.get_foreign_keys
+vim.notify = real.notify
+vim.env.PATH = old_env.path
+vim.env.GRIP_AI_PID_FILE = old_env.pid
+vim.env.GRIP_AI_STDIN_FILE = old_env.stdin
+vim.env.GRIP_AI_READY_FILE = old_env.ready
+vim.env.GRIP_AI_RELEASE_FILE = old_env.release
+vim.fn.delete(dir, "rf")
+
+if not ok then error(err, 0) end
+print("ai_argv_spec: 4 passed, 0 failed")

--- a/tests/spec/ai_spec.lua
+++ b/tests/spec/ai_spec.lua
@@ -54,6 +54,55 @@ test("resolve_api_key: ollama returns empty string (no key needed)", function()
   eq(key, "", "ollama needs no key")
 end)
 
+test("resolve_api_key: cmd script is delivered through stdin", function()
+  local orig_system = vim.system
+  local captured_args, captured_opts
+  vim.system = function(args, opts)
+    captured_args, captured_opts = args, opts
+    return { wait = function() return { code = 0, stdout = "from-command\n" } end }
+  end
+  ai.setup({ api_key = "cmd:printf from-command" })
+  local ok, key = pcall(ai.resolve_api_key, "openai")
+  ai.setup({})
+  vim.system = orig_system
+
+  assert(ok, key)
+  eq(key, "from-command", "command output")
+  eq(vim.inspect(captured_args), vim.inspect({ "sh", "-s" }), "constant shell argv")
+  eq(captured_opts.stdin, "printf from-command\n", "script on stdin")
+end)
+
+test("resolve_api_key: failed cmd does not reproduce the command", function()
+  local orig_system = vim.system
+  vim.system = function()
+    return { wait = function() return { code = 1, stdout = "", stderr = "failed" } end }
+  end
+  local secret_command = "printf command_secret_7f3c"
+  ai.setup({ api_key = "cmd:" .. secret_command })
+  local key, err = ai.resolve_api_key("openai")
+  ai.setup({})
+  vim.system = orig_system
+
+  eq(key, nil, "no key")
+  contains(err, "API key command failed", "actionable error")
+  assert(not err:find(secret_command, 1, true), "failed key command leaked into its error")
+end)
+
+test("resolve_api_key: cmd spawn failure is returned without reproducing the command", function()
+  local orig_system = vim.system
+  local secret_command = "printf spawn_secret_7f3c"
+  vim.system = function() error("ENOENT " .. secret_command) end
+  ai.setup({ api_key = "cmd:" .. secret_command })
+  local ok, key, err = pcall(ai.resolve_api_key, "openai")
+  ai.setup({})
+  vim.system = orig_system
+
+  assert(ok, key)
+  eq(key, nil, "no key")
+  eq(err, "API key command failed", "safe spawn failure")
+  assert(not err:find(secret_command, 1, true), "spawn failure leaked the key command")
+end)
+
 -- ── resolve_provider ─────────────────────────────────────────────────────────
 
 test("resolve_provider: explicit config wins", function()
@@ -99,9 +148,13 @@ test("_format_ddl_line: basic columns", function()
     { column_name = "name", data_type = "text", is_nullable = "YES" },
   }
   local result = ai._format_ddl_line("users", cols, {"id"}, {})
-  contains(result, "CREATE TABLE users", "table name")
-  contains(result, "id integer PK", "PK marker")
-  contains(result, "name text", "column type")
+  eq(result, "CREATE TABLE users (id integer PK, name text);",
+    "complete DDL has one PK marker")
+end)
+
+test("curl config quoting: escapes only curl's documented quoted-string controls", function()
+  eq(ai._curl_config_quote('a\\b"c\t\n\r\v'), '"a\\\\b\\"c\\t\\n\\r\\v"',
+    "curl config quoted string")
 end)
 
 test("_format_ddl_line: FK markers (test-style field names)", function()
@@ -276,7 +329,7 @@ end)
 -- refactoring around it, so any edit to its wording -- a doubled space, a
 -- reordered rule, a lost blank line -- could ship silently and quietly change
 -- every generated query. generate_sql is driven all the way down to the curl
--- argv here and the prompt is read back out of the JSON body that would have
+-- stdin here and the prompt is read back out of the JSON body that would have
 -- been POSTed: those are the exact bytes the provider receives.
 --
 -- Fixture notes: the provider is pinned to anthropic (its build_request puts
@@ -295,10 +348,13 @@ local function captured_prompt(question, url, existing_sql)
   })
   local orig_system = vim.system
   local orig_notify = vim.notify
-  local captured
+  local captured_args, captured_opts
   -- post_json passes its own completion callback, which is simply never
   -- invoked: the request is inspected, not answered.
-  vim.system = function(args) captured = args; return { wait = function() return {} end } end
+  vim.system = function(args, opts)
+    captured_args, captured_opts = args, opts
+    return { wait = function() return {} end }
+  end
   vim.notify = function() end
   ai.setup({ provider = "anthropic", api_key = "test-key", model = "pinned-model" })
 
@@ -312,12 +368,15 @@ local function captured_prompt(question, url, existing_sql)
 
   if not ok then error(err, 0) end
   assert(cb_err == nil, "generate_sql failed before building a request: " .. tostring(cb_err))
-  assert(captured, "curl was invoked")
-  local payload
-  for i, a in ipairs(captured) do
-    if a == "-d" then payload = captured[i + 1] end
-  end
-  assert(payload, "request body found in the curl argv")
+  assert(captured_args, "curl was invoked")
+  eq(vim.inspect(captured_args),
+    vim.inspect({ "curl", "--disable", "--silent", "--show-error", "--config", "-" }),
+    "curl argv")
+  local config = assert(captured_opts and captured_opts.stdin, "curl config delivered on stdin")
+  local quoted = assert(config:match("data%-binary%s*=%s*([^\n]+)"), "request body in curl config")
+  local payload = quoted:sub(2, -2):gsub("\\(.)", {
+    ['\\'] = '\\', ['"'] = '"', t = "\t", n = "\n", r = "\r", v = "\v",
+  })
   local body = vim.fn.json_decode(payload)
   return body.system, body.messages[1].content
 end
@@ -358,6 +417,99 @@ end)
 test("generate_sql: an empty editor query adds nothing to the prompt", function()
   local prompt = captured_prompt("oldest user", "test://prompt-snapshot-empty", "")
   eq(prompt, EXPECTED_PROMPT, "empty existing_sql must not open the existing-query block")
+end)
+
+test("generate_sql: transport errors never reproduce request secrets", function()
+  local restore = mock_ai_db({ { name = "users" } }, {
+    users = { { column_name = "private_schema_value", data_type = "text", is_nullable = "NO" } },
+  })
+  local orig_system = vim.system
+  local orig_notify = vim.notify
+  local key = "transport_key_secret_7f3c"
+  local question = "transport_prompt_secret_7f3c"
+  vim.notify = function() end
+  vim.system = function(_, _, callback)
+    callback({
+      code = 7,
+      stdout = "",
+      stderr = table.concat({ key, question, "private_schema_value" }, " "),
+    })
+    return {}
+  end
+  ai.setup({ provider = "anthropic", api_key = key })
+  local callback_done, callback_err = false, nil
+  ai.generate_sql(question, "test://safe-transport-error", function(_, err)
+    callback_done, callback_err = true, err
+  end)
+  assert(vim.wait(1000, function() return callback_done end, 1), "transport callback never fired")
+
+  ai.setup({})
+  vim.system = orig_system
+  vim.notify = orig_notify
+  restore()
+
+  contains(callback_err, "curl failed", "transport category retained")
+  for _, secret in ipairs({ key, question, "private_schema_value" }) do
+    assert(not callback_err:find(secret, 1, true), "transport error leaked " .. secret)
+  end
+end)
+
+test("generate_sql: curl spawn failures are delivered safely through the callback", function()
+  local restore = mock_ai_db({}, nil)
+  local orig_system = vim.system
+  local orig_notify = vim.notify
+  local spawn_secret = "spawn_error_request_secret_7f3c"
+  vim.notify = function() end
+  vim.system = function()
+    error("ENOENT " .. spawn_secret)
+  end
+  ai.setup({ provider = "anthropic", api_key = "test-key" })
+  local callback_done, callback_err = false, nil
+  local ok, thrown = pcall(ai.generate_sql, "question", "test://safe-spawn-error", function(_, err)
+    callback_done, callback_err = true, err
+  end)
+  assert(vim.wait(1000, function() return callback_done end, 1), "spawn-failure callback never fired")
+
+  ai.setup({})
+  vim.system = orig_system
+  vim.notify = orig_notify
+  restore()
+
+  assert(ok, thrown)
+  eq(callback_err, "Could not start curl", "safe spawn failure")
+  assert(not callback_err:find(spawn_secret, 1, true), "spawn failure leaked process error")
+end)
+
+test("generate_sql: API errors retain a safe type without reproducing the remote message", function()
+  local restore = mock_ai_db({}, nil)
+  local orig_system = vim.system
+  local orig_notify = vim.notify
+  local remote_secret = "remote_error_echoed_request_secret_7f3c"
+  vim.notify = function() end
+  vim.system = function(_, _, callback)
+    callback({
+      code = 0,
+      stdout = vim.fn.json_encode({
+        error = { type = "invalid_request_error", message = remote_secret },
+      }),
+      stderr = "",
+    })
+    return {}
+  end
+  ai.setup({ provider = "anthropic", api_key = "test-key" })
+  local callback_done, callback_err = false, nil
+  ai.generate_sql("question", "test://safe-api-error", function(_, err)
+    callback_done, callback_err = true, err
+  end)
+  assert(vim.wait(1000, function() return callback_done end, 1), "API error callback never fired")
+
+  ai.setup({})
+  vim.system = orig_system
+  vim.notify = orig_notify
+  restore()
+
+  eq(callback_err, "API error: invalid_request_error", "safe error type")
+  assert(not callback_err:find(remote_secret, 1, true), "remote error message leaked request content")
 end)
 
 -- ── _strip_fences ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Send provider URLs, authentication headers, and request bodies through curl-config stdin instead of process arguments.
- Resolve command-based API keys through shell stdin and keep provider failures useful without reproducing sensitive data.
- Render primary-key schema markers exactly once.

## Verification

- just lint
- just test
- Process-level regressions confirm that API keys, prompts, schema text, existing SQL, and request bodies stay out of argv.