### PR TITLE
security: add secret scanning and private reporting

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Enable per clone with: git config core.hooksPath .githooks
+set -eu
+
+if command -v mise >/dev/null 2>&1 && mise which gitleaks >/dev/null 2>&1; then
+  exec mise exec -- gitleaks git --pre-commit --redact --staged --verbose
+fi
+
+if command -v gitleaks >/dev/null 2>&1; then
+  exec gitleaks git --pre-commit --redact --staged --verbose
+fi
+
+printf '%s\n' "Gitleaks is required. Run 'mise install' or install Gitleaks 8.30.1." >&2
+exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - name: Scan committed history for secrets
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_COMMENTS: "false"
+          GITLEAKS_ENABLE_SUMMARY: "false"
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "false"
+          GITLEAKS_VERSION: "8.30.1"
       - uses: lunarmodules/luacheck@cc089e3f65acdd1ef8716cc73a3eca24a6b845e4 # v1
         with:
           args: lua/ plugin/ lazy.lua tests/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,15 @@
+title = "dadbod-grip.nvim"
+minVersion = "8.30.1"
+
+[extend]
+useDefault = true
+
+[[rules]]
+id = "generic-api-key"
+
+[[rules.allowlists]]
+description = "The DuckDB argv regression uses one synthetic password."
+condition = "AND"
+regexTarget = "line"
+paths = ['''^tests/spec/duckdb_argv_spec\.lua$''']
+regexes = ['''local password = "argv_secret_hunter2_7f3c"''']

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,2 +1,3 @@
 [tools]
+gitleaks = "8.30.1"
 just = "1.40.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Gitleaks now scans committed history inside the required lint job, and an optional native Git hook
+  scans staged changes locally. Both paths redact findings, and the repository allowlist covers only
+  the exact synthetic password used by the DuckDB process-boundary regression.
+- `SECURITY.md` directs vulnerability reports to GitHub's private advisory intake instead of the
+  public issue tracker.
+
 ## [3.10.2] - 2026-08-30
 
 ### Changed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security policy
+
+## Supported versions
+
+Dadbod Grip supports the latest published release and the current `main` branch.
+
+## Report a vulnerability
+
+Please use [GitHub's private vulnerability reporting](https://github.com/joryeugene/dadbod-grip.nvim/security/advisories/new) so the report stays private while it is investigated. Do not open a public issue for a suspected vulnerability.
+
+Include the affected version, reproduction steps, expected impact, and any mitigation you have already tested. Please omit real credentials and sensitive production data.

--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,6 @@ Shipped work belongs in `CHANGELOG.md`. Review this file after each release and 
 
 ## Deferred
 
-- Add `SECURITY.md` after the privacy release.
 - Add `CONTRIBUTING.md` when the contributor workflow has settled.
 - Revisit required checks and branch protection only after the workflows prove stable.
 


### PR DESCRIPTION
## Summary

Dadbod Grip now scans committed history for leaked credentials inside the protected lint job and provides an optional native staged-change hook. Private vulnerability reporting is enabled, and `SECURITY.md` directs sensitive reports away from public issues.

The repository pins Gitleaks 8.30.1 through Mise and pins the GitHub Action to its full commit SHA. Findings are redacted, comments and summaries are disabled, and the only allowlist targets one exact synthetic test assignment by rule, path, and line.

## Local hook

Maintainers can opt in per clone with `git config core.hooksPath .githooks`. The hook uses the repository-pinned binary when Mise is available, falls back to `gitleaks` on `PATH`, and fails with a setup instruction when neither exists.

## Verification

The full redacted history scan is clean. A staged copy of the synthetic fixture at a different path fails nonzero without printing its value, which proves the allowlist cannot cover moved fixtures or the wider test tree. The deterministic suite and LuaCheck also pass.