### PR TITLE
fix: restore the Dadbod Grip ASCII wordmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 <table><tr>
 <td valign="middle">
+<pre>
+D   ███████╗███████╗██╗███████╗
+A  ██╔═════╝██╔══██║██║██╔══██║
+D  ██║  ███╗██████╔╝██║███████║
+b  ██║   ██║██╔══██╗██║██╔════╝
+o  ╚██████╔╝██║  ██║██║██║
+d   ╚═════╝ ╚═╝  ╚═╝╚═╝╚═╝
+</pre>
 <p>
 <a href="https://jorypestorious.com/dadbod-grip-web/"><img src="https://img.shields.io/badge/docs-website-4ade80.svg" alt="Documentation"></a>&nbsp;
 <a href="https://github.com/joryeugene/dadbod-grip.nvim/blob/main/LICENSE"><img src="https://img.shields.io/github/license/joryeugene/dadbod-grip.nvim.svg" alt="MIT License"></a>&nbsp;

--- a/tests/spec/docs_contract_spec.lua
+++ b/tests/spec/docs_contract_spec.lua
@@ -59,6 +59,8 @@ test("public commands match lazy triggers and the help manual", function()
 end)
 
 test("README keeps the onboarding command path", function()
+  assert(readme:find("D   ███████╗███████╗██╗███████╗", 1, true),
+    "README Dadbod Grip wordmark missing")
   for _, name in ipairs({ "GripConnect", "GripStart", "Grip", "GripQuery" }) do
     assert(readme:find("`:" .. name, 1, true), "README onboarding missing :" .. name)
   end


### PR DESCRIPTION
The README restores the exact Dadbod Grip ASCII wordmark removed during onboarding cleanup. A documentation contract now fails if the wordmark disappears again.

`just spec docs_contract` passes.