### PR TITLE
docs: refresh README branding and contributor credit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,28 @@
 # dadbod-grip.nvim
 
-<table><tr>
-<td valign="middle">
-<pre>
-D   ███████╗███████╗██╗███████╗
-A  ██╔═════╝██╔══██║██║██╔══██║
-D  ██║  ███╗██████╔╝██║███████║
-b  ██║   ██║██╔══██╗██║██╔════╝
-o  ╚██████╔╝██║  ██║██║██║
-d   ╚═════╝ ╚═╝  ╚═╝╚═╝╚═╝
-</pre>
-<p>
+<p align="center">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="docs/brand/dadbod-grip-wordmark-dark.svg">
+<source media="(prefers-color-scheme: light)" srcset="docs/brand/dadbod-grip-wordmark-light.svg">
+<img src="docs/brand/dadbod-grip-wordmark-light.svg" width="620" alt="Dadbod Grip">
+</picture>
+</p>
+
+<p align="center">
 <a href="https://jorypestorious.com/dadbod-grip-web/"><img src="https://img.shields.io/badge/docs-website-4ade80.svg" alt="Documentation"></a>&nbsp;
 <a href="https://github.com/joryeugene/dadbod-grip.nvim/blob/main/LICENSE"><img src="https://img.shields.io/github/license/joryeugene/dadbod-grip.nvim.svg" alt="MIT License"></a>&nbsp;
 <img src="https://img.shields.io/badge/Neovim-0.10%2B-green.svg" alt="Neovim 0.10+">&nbsp;
 <a href="https://github.com/joryeugene/dadbod-grip.nvim/actions/workflows/test.yml"><img src="https://github.com/joryeugene/dadbod-grip.nvim/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
 </p>
+
+<p align="center">
 <b>Dadbod Grip turns database tables into editable Vim buffers, with schema browsing, staged mutations, generated SQL, relationship navigation, and cross-database federation inside Neovim.</b>
-</td>
-<td align="center" valign="middle" width="180">
+</p>
+
+<p align="center">
 <img src="https://jorypestorious.com/dadbod-grip-web/mascot.gif" width="160" alt="Chonk, the Dadbod Grip mascot"><br>
 <sub><b>Chonk</b></sub>
-</td>
-</tr></table>
+</p>
 
 **Workflow.** Browse a schema, edit rows with Vim motions, follow foreign keys, and run saved SQL without leaving the editor.
 
@@ -214,6 +214,10 @@ Lazy should show the local directory instead of a cached release. The developmen
 
 Dadbod Grip works by itself and can also read vim-dadbod and vim-dadbod-ui connection variables. It is listed in [awesome-neovim](https://github.com/rockerBOO/awesome-neovim).
 
-## License and credit
+## Contributors
 
-Dadbod Grip is available under the [MIT License](LICENSE). Jory Pestorious maintains the project, and external contributors receive credit through their commits and pull requests.
+Contributions are welcome. Read [CONTRIBUTING.md](CONTRIBUTING.md) and open a focused pull request when you see something Dadbod Grip can do better.
+
+A special thank-you to [Gleb Yavorski (@GlebYavorski)](https://github.com/GlebYavorski).
+
+Dadbod Grip is available under the [MIT License](LICENSE), and I maintain the project.

--- a/docs/brand/dadbod-grip-wordmark-dark.svg
+++ b/docs/brand/dadbod-grip-wordmark-dark.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 198" role="img" aria-labelledby="title desc">
+  <title id="title">Dadbod Grip</title>
+  <desc id="desc">A terminal-style Dadbod Grip wordmark.</desc>
+  <metadata id="dadbod-grip-ascii"><![CDATA[████▄  ▄████▄ ████▄  █████▄ ▄████▄ ████▄
+██  ██ ██▄▄██ ██  ██ ██▄▄██ ██  ██ ██  ██
+████▀  ██  ██ ████▀  ██▄▄█▀ ▀████▀ ████▀
+         ▄████  █████▄  ██ █████▄
+        ██  ▄▄▄ ██▄▄██▄ ██ ██▄▄█▀
+         ▀███▀  ██   ██ ██ ██]]></metadata>
+  <rect x="1" y="1" width="518" height="196" rx="12" fill="#010409" stroke="#30363d" stroke-width="2"/>
+  <circle cx="24" cy="24" r="5" fill="#ff5f57"/>
+  <circle cx="42" cy="24" r="5" fill="#febc2e"/>
+  <circle cx="60" cy="24" r="5" fill="#28c840"/>
+  <text x="260" y="28" text-anchor="middle" fill="#8b949e" font-family="ui-monospace, SFMono-Regular, Consolas, Liberation Mono, monospace" font-size="10">dadbod-grip.nvim</text>
+  <rect x="27" y="48" width="4" height="119" rx="2" fill="#4ade80"/>
+  <g fill="#f0f6fc" font-family="ui-monospace, SFMono-Regular, Consolas, Liberation Mono, monospace" font-size="15" font-weight="700" xml:space="preserve">
+    <text x="47" y="72">████▄  ▄████▄ ████▄  █████▄ ▄████▄ ████▄</text>
+    <text x="47" y="91">██  ██ ██▄▄██ ██  ██ ██▄▄██ ██  ██ ██  ██</text>
+    <text x="47" y="110">████▀  ██  ██ ████▀  ██▄▄█▀ ▀████▀ ████▀</text>
+  </g>
+  <g fill="#4ade80" font-family="ui-monospace, SFMono-Regular, Consolas, Liberation Mono, monospace" font-size="15" font-weight="700" xml:space="preserve">
+    <text x="128" y="130"> ▄████  █████▄  ██ █████▄</text>
+    <text x="128" y="149">██  ▄▄▄ ██▄▄██▄ ██ ██▄▄█▀</text>
+    <text x="128" y="168"> ▀███▀  ██   ██ ██ ██</text>
+  </g>
+  <rect x="47" y="184" width="333" height="3" rx="1.5" fill="#4ade80"/>
+</svg>

--- a/docs/brand/dadbod-grip-wordmark-light.svg
+++ b/docs/brand/dadbod-grip-wordmark-light.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 198" role="img" aria-labelledby="title desc">
+  <title id="title">Dadbod Grip</title>
+  <desc id="desc">A terminal-style Dadbod Grip wordmark.</desc>
+  <metadata id="dadbod-grip-ascii"><![CDATA[████▄  ▄████▄ ████▄  █████▄ ▄████▄ ████▄
+██  ██ ██▄▄██ ██  ██ ██▄▄██ ██  ██ ██  ██
+████▀  ██  ██ ████▀  ██▄▄█▀ ▀████▀ ████▀
+         ▄████  █████▄  ██ █████▄
+        ██  ▄▄▄ ██▄▄██▄ ██ ██▄▄█▀
+         ▀███▀  ██   ██ ██ ██]]></metadata>
+  <rect x="1" y="1" width="518" height="196" rx="12" fill="#f6f8fa" stroke="#d0d7de" stroke-width="2"/>
+  <circle cx="24" cy="24" r="5" fill="#ff5f57"/>
+  <circle cx="42" cy="24" r="5" fill="#febc2e"/>
+  <circle cx="60" cy="24" r="5" fill="#28c840"/>
+  <text x="260" y="28" text-anchor="middle" fill="#57606a" font-family="ui-monospace, SFMono-Regular, Consolas, Liberation Mono, monospace" font-size="10">dadbod-grip.nvim</text>
+  <rect x="27" y="48" width="4" height="119" rx="2" fill="#15803d"/>
+  <g fill="#1f2328" font-family="ui-monospace, SFMono-Regular, Consolas, Liberation Mono, monospace" font-size="15" font-weight="700" xml:space="preserve">
+    <text x="47" y="72">████▄  ▄████▄ ████▄  █████▄ ▄████▄ ████▄</text>
+    <text x="47" y="91">██  ██ ██▄▄██ ██  ██ ██▄▄██ ██  ██ ██  ██</text>
+    <text x="47" y="110">████▀  ██  ██ ████▀  ██▄▄█▀ ▀████▀ ████▀</text>
+  </g>
+  <g fill="#15803d" font-family="ui-monospace, SFMono-Regular, Consolas, Liberation Mono, monospace" font-size="15" font-weight="700" xml:space="preserve">
+    <text x="128" y="130"> ▄████  █████▄  ██ █████▄</text>
+    <text x="128" y="149">██  ▄▄▄ ██▄▄██▄ ██ ██▄▄█▀</text>
+    <text x="128" y="168"> ▀███▀  ██   ██ ██ ██</text>
+  </g>
+  <rect x="47" y="184" width="333" height="3" rx="1.5" fill="#15803d"/>
+</svg>

--- a/tests/spec/docs_contract_spec.lua
+++ b/tests/spec/docs_contract_spec.lua
@@ -42,6 +42,27 @@ local changelog = read("CHANGELOG.md")
 local grid_help = read("lua/dadbod-grip/view.lua")
 local contributing = read("CONTRIBUTING.md")
 local security = read("SECURITY.md")
+local wordmark_light = read("docs/brand/dadbod-grip-wordmark-light.svg")
+local wordmark_dark = read("docs/brand/dadbod-grip-wordmark-dark.svg")
+
+local wordmark = table.concat({
+  "████▄  ▄████▄ ████▄  █████▄ ▄████▄ ████▄",
+  "██  ██ ██▄▄██ ██  ██ ██▄▄██ ██  ██ ██  ██",
+  "████▀  ██  ██ ████▀  ██▄▄█▀ ▀████▀ ████▀",
+  "         ▄████  █████▄  ██ █████▄",
+  "        ██  ▄▄▄ ██▄▄██▄ ██ ██▄▄█▀",
+  "         ▀███▀  ██   ██ ██ ██",
+}, "\n")
+
+local contributors = table.concat({
+  "## Contributors",
+  "",
+  "Contributions are welcome. Read [CONTRIBUTING.md](CONTRIBUTING.md) and open a focused pull request when you see something Dadbod Grip can do better.",
+  "",
+  "A special thank-you to [Gleb Yavorski (@GlebYavorski)](https://github.com/GlebYavorski).",
+  "",
+  "Dadbod Grip is available under the [MIT License](LICENSE), and I maintain the project.",
+}, "\n")
 
 test("public commands match lazy triggers and the help manual", function()
   grip.setup({})
@@ -59,8 +80,16 @@ test("public commands match lazy triggers and the help manual", function()
 end)
 
 test("README keeps the onboarding command path", function()
-  assert(readme:find("D   ███████╗███████╗██╗███████╗", 1, true),
-    "README Dadbod Grip wordmark missing")
+  assert(readme:find("docs/brand/dadbod-grip-wordmark-light.svg", 1, true),
+    "README light wordmark missing")
+  assert(readme:find("docs/brand/dadbod-grip-wordmark-dark.svg", 1, true),
+    "README dark wordmark missing")
+  assert(wordmark_light:find(wordmark, 1, true), "light wordmark changed")
+  assert(wordmark_dark:find(wordmark, 1, true), "dark wordmark changed")
+  local hero = assert(readme:match("^(.-)\n%*%*Workflow%.%*%*"))
+  assert(not hero:find("<table", 1, true), "README hero must remain table-free")
+  assert(hero:find("mascot.gif", 1, true), "README hero lost Chonk")
+  assert(readme:find(contributors, 1, true), "README contributor block changed")
   for _, name in ipairs({ "GripConnect", "GripStart", "Grip", "GripQuery" }) do
     assert(readme:find("`:" .. name, 1, true), "README onboarding missing :" .. name)
   end


### PR DESCRIPTION
## Summary

- replace the table-based README hero with responsive light and dark ASCII wordmarks
- keep Chonk separate so the header stays readable on narrow GitHub views
- add the approved Gleb Yavorski contributor credit
- lock the branding and contributor copy with documentation contracts

## Verification

- 
- 
- Checking lua/dadbod-grip/adapters/duckdb.lua      OK
Checking lua/dadbod-grip/adapters/init.lua        OK
Checking lua/dadbod-grip/adapters/mysql.lua       OK
Checking lua/dadbod-grip/adapters/postgresql.lua  OK
Checking lua/dadbod-grip/adapters/sqlite.lua      OK
Checking lua/dadbod-grip/adapters/sqlserver.lua   OK
Checking lua/dadbod-grip/ai.lua                   OK
Checking lua/dadbod-grip/cell_buffer.lua          OK
Checking lua/dadbod-grip/completion.lua           OK
Checking lua/dadbod-grip/completion/blink.lua     OK
Checking lua/dadbod-grip/connections.lua          OK
Checking lua/dadbod-grip/data.lua                 OK
Checking lua/dadbod-grip/db.lua                   OK
Checking lua/dadbod-grip/ddl.lua                  OK
Checking lua/dadbod-grip/diff.lua                 OK
Checking lua/dadbod-grip/editor.lua               OK
Checking lua/dadbod-grip/er_diagram.lua           OK
Checking lua/dadbod-grip/explain.lua              OK
Checking lua/dadbod-grip/filetypes.lua            OK
Checking lua/dadbod-grip/filters.lua              OK
Checking lua/dadbod-grip/format.lua               OK
Checking lua/dadbod-grip/grip_picker.lua          OK
Checking lua/dadbod-grip/health.lua               OK
Checking lua/dadbod-grip/history.lua              OK
Checking lua/dadbod-grip/init.lua                 OK
Checking lua/dadbod-grip/json_tree.lua            OK
Checking lua/dadbod-grip/keymaps.lua              OK
Checking lua/dadbod-grip/palette.lua              OK
Checking lua/dadbod-grip/paths.lua                OK
Checking lua/dadbod-grip/picker.lua               OK
Checking lua/dadbod-grip/pickers/snacks.lua       OK
Checking lua/dadbod-grip/pickers/telescope.lua    OK
Checking lua/dadbod-grip/profile.lua              OK
Checking lua/dadbod-grip/properties.lua           OK
Checking lua/dadbod-grip/query.lua                OK
Checking lua/dadbod-grip/query_pad.lua            OK
Checking lua/dadbod-grip/saved.lua                OK
Checking lua/dadbod-grip/schema.lua               OK
Checking lua/dadbod-grip/secrets.lua              OK
Checking lua/dadbod-grip/sources/docker_localdb.lua OK
Checking lua/dadbod-grip/sql.lua                  OK
Checking lua/dadbod-grip/ui.lua                   OK
Checking lua/dadbod-grip/version.lua              OK
Checking lua/dadbod-grip/view.lua                 OK
Checking lua/dadbod-grip/view/column_highlight.lua OK
Checking lua/dadbod-grip/view/keymaps_aggregate.lua OK
Checking lua/dadbod-grip/view/keymaps_ai.lua      OK
Checking lua/dadbod-grip/view/keymaps_edit.lua    OK
Checking lua/dadbod-grip/view/keymaps_fk.lua      OK
Checking lua/dadbod-grip/view/keymaps_inspect.lua OK
Checking lua/dadbod-grip/view/keymaps_misc.lua    OK
Checking lua/dadbod-grip/view/keymaps_nav.lua     OK
Checking lua/dadbod-grip/view/keymaps_results.lua OK
Checking lua/dadbod-grip/view/keymaps_schema.lua  OK
Checking lua/dadbod-grip/view/keymaps_session.lua OK
Checking lua/dadbod-grip/view/keymaps_sort_filter.lua OK
Checking lua/dadbod-grip/view/keymaps_tab_view.lua OK
Checking lua/dadbod-grip/view/keymaps_visual_batch.lua OK
Checking lua/dadbod-grip/view/sticky_header.lua   OK
Checking plugin/dadbod-grip.lua                   OK
Checking lazy.lua                                 OK
Checking tests/fixtures/keymap_contract_integration.lua OK
Checking tests/fixtures/schedule_failure.lua      OK
Checking tests/fixtures/workspace_layout_integration.lua OK
Checking tests/fixtures/workspace_no_sidebar_integration.lua OK
Checking tests/fixtures/workspace_preload_integration.lua OK
Checking tests/helpers.lua                        OK
Checking tests/minimal_init.lua                   OK
Checking tests/run_specs.lua                      OK
Checking tests/spec/adapter_argv_spec.lua         OK
Checking tests/spec/adapter_env_spec.lua          OK
Checking tests/spec/adapter_spec.lua              OK
Checking tests/spec/ai_argv_spec.lua              OK
Checking tests/spec/ai_spec.lua                   OK
Checking tests/spec/batch_parser_spec.lua         OK
Checking tests/spec/blink_source_spec.lua         OK
Checking tests/spec/cell_buffer_spec.lua          OK
Checking tests/spec/cell_end_spec.lua             OK
Checking tests/spec/clipboard_isolation_spec.lua  OK
Checking tests/spec/col_reveal_spec.lua           OK
Checking tests/spec/column_resolve_spec.lua       OK
Checking tests/spec/column_set_spec.lua           OK
Checking tests/spec/completion_spec.lua           OK
Checking tests/spec/config_spec.lua               OK
Checking tests/spec/conn_color_spec.lua           OK
Checking tests/spec/connections_fields_spec.lua   OK
Checking tests/spec/connections_spec.lua          OK
Checking tests/spec/csv_parser_spec.lua           OK
Checking tests/spec/data_spec.lua                 OK
Checking tests/spec/ddl_spec.lua                  OK
Checking tests/spec/diff_spec.lua                 OK
Checking tests/spec/discovery_merge_spec.lua      OK
Checking tests/spec/discovery_spec.lua            OK
Checking tests/spec/docs_contract_spec.lua        OK
Checking tests/spec/duckdb_argv_spec.lua          OK
Checking tests/spec/duckdb_attach_spec.lua        OK
Checking tests/spec/duckdb_federated_schema_spec.lua OK
Checking tests/spec/duckdb_federation_spec.lua    OK
Checking tests/spec/duckdb_live_federation_spec.lua OK
Checking tests/spec/duckdb_native_schema_spec.lua OK
Checking tests/spec/duckdb_nested_json_spec.lua   OK
Checking tests/spec/edit_cursor_spec.lua          OK
Checking tests/spec/edit_nav_spec.lua             OK
Checking tests/spec/enum_hint_spec.lua            OK
Checking tests/spec/er_diagram_spec.lua           OK
Checking tests/spec/explain_spec.lua              OK
Checking tests/spec/export_spec.lua               OK
Checking tests/spec/filetypes_spec.lua            OK
Checking tests/spec/filter_spec.lua               OK
Checking tests/spec/filters_spec.lua              OK
Checking tests/spec/fk_pinned_spec.lua            OK
Checking tests/spec/fk_reverse_spec.lua           OK
Checking tests/spec/format_spec.lua               OK
Checking tests/spec/globals_spec.lua              OK
Checking tests/spec/grid_reuse_spec.lua           OK
Checking tests/spec/grip_picker_spec.lua          OK
Checking tests/spec/health_spec.lua               OK
Checking tests/spec/history_spec.lua              OK
Checking tests/spec/init_spec.lua                 OK
Checking tests/spec/json_nav_spec.lua             OK
Checking tests/spec/json_tree_spec.lua            OK
Checking tests/spec/keymaps_contract_spec.lua     OK
Checking tests/spec/lazy_spec.lua                 OK
Checking tests/spec/live_workflow_spec.lua        OK
Checking tests/spec/mutation_spec.lua             OK
Checking tests/spec/mysql_integration_spec.lua    OK
Checking tests/spec/null_resolve_spec.lua         OK
Checking tests/spec/palette_spec.lua              OK
Checking tests/spec/pg_integration_spec.lua       OK
Checking tests/spec/picker_dispatch_spec.lua      OK
Checking tests/spec/profile_spec.lua              OK
Checking tests/spec/properties_spec.lua           OK
Checking tests/spec/query_pad_spec.lua            OK
Checking tests/spec/query_spec.lua                OK
Checking tests/spec/readonly_mode_spec.lua        OK
Checking tests/spec/redact_spec.lua               OK
Checking tests/spec/requery_spinner_spec.lua      OK
Checking tests/spec/run_cmd_async_spec.lua        OK
Checking tests/spec/saved_spec.lua                OK
Checking tests/spec/schema_routines_spec.lua      OK
Checking tests/spec/schema_truncation_spec.lua    OK
Checking tests/spec/secrets_integration_spec.lua  OK
Checking tests/spec/secrets_spec.lua              OK
Checking tests/spec/slack_spec.lua                OK
Checking tests/spec/sql_spec.lua                  OK
Checking tests/spec/sqlserver_schema_spec.lua     OK
Checking tests/spec/sticky_header_spec.lua        OK
Checking tests/spec/test_harness_spec.lua         OK
Checking tests/spec/truncate_display_spec.lua     OK
Checking tests/spec/type_nav_spec.lua             OK
Checking tests/spec/ui_spec.lua                   OK
Checking tests/spec/undo_sql_spec.lua             OK
Checking tests/spec/view_snap_spec.lua            OK
Checking tests/spec/view_spec.lua                 OK
Checking tests/spec/visual_nav_spec.lua           OK
Checking tests/spec/workspace_preload_spec.lua    OK

Total: 0 warnings / 0 errors in 156 files
- GitHub Markdown API rendering in light and dark at 320, 375, 430, 768, and 1012 pixels