### PR TITLE
ci: run one test matrix per pull request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,10 @@ name: Tests
 
 on:
   push:
+    branches:
+      - main
+    tags:
+      - "v*"
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary

- run the full test workflow for pull requests, main pushes, version tags, and manual dispatches
- stop running the same matrix again for feature-branch pushes
- preserve all job names and the separate SQL Server release workflow

## Verification

- confirmed the workflow event filters retain main, v* tags, pull requests, and manual dispatches
- confirmed the SQL Server workflow is unchanged