### PR TITLE
docs: define SQL Server temporary table scope

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -15,6 +15,5 @@ Shipped work belongs in `CHANGELOG.md`. Review this file after each release and 
 - Explain result sets and inherited queries with AI, and flag anomalies in profiling output.
 - Add pgvector rendering, similarity-query helpers, and vector index details.
 - Add Snowflake, BigQuery, Turso/libSQL, CockroachDB, ClickHouse, and Oracle adapters when a maintainer can test each against a real service.
-- Support SQL Server `##temp` tables across CLI invocations.
 - Add column reordering, bookmarked rows, saved grid views, and row pinning.
 - Explore Neon branches, cross-connection schema diff, data-lineage views, user scripting hooks, credential-free query bundles, and schema-change detection.

--- a/doc/dadbod-grip.txt
+++ b/doc/dadbod-grip.txt
@@ -377,8 +377,9 @@ All commands are global and available after the plugin loads.
 
                                                                 *:GripQuery*
 :GripQuery [sql]
-  Open a SQL query pad. Optionally pre-fill with a SQL string. Press
-  <C-CR> to execute the buffer contents into a grip grid.
+  Open a SQL query pad. Optionally pre-fill with a SQL string. In normal or
+  insert mode, press <C-CR> to execute the blank-line-delimited SQL block
+  under the cursor into a grip grid.
 
                                                                  *:GripSave*
 :GripSave [name]
@@ -910,8 +911,8 @@ below existing SQL with a blank separator. The pad is only pre-filled when
 it is empty (or contains only the hint comment). Your work is never lost.
 
 `<C-CR>` in visual mode runs only the selected lines. In normal or insert
-mode it runs the full buffer. `gA` reads existing pad content and modifies
-it rather than generating from scratch.
+mode it runs the blank-line-delimited SQL block under the cursor. `gA` reads
+existing pad content and modifies it rather than generating from scratch.
 
 SQL completion is built in: table names, column names, aliases, and SQL
 keywords complete automatically as you type. In DuckDB federated sessions,
@@ -920,7 +921,7 @@ columns from all attached databases appear with schema-qualified names
 Works with nvim-cmp, blink.cmp, or standalone via `<C-Space>`.
 
 Query pad keymaps:
-  <C-CR>          Execute buffer contents into a grip grid (normal/insert)
+  <C-CR>          Execute the SQL block under the cursor (normal/insert)
   <C-CR>          Execute visual selection into a grip grid (visual mode)
   <S-CR>      Execute and always open result in a new split (never reuses
                   an existing grid, even an unpinned one)
@@ -1292,6 +1293,11 @@ and mssql:// accept these URL query parameters:
 
 server_certificate cannot be combined with trust_server_certificate=true
 and requires mandatory or strict encryption.
+
+Each SQL Server submission starts a new sqlcmd session. Create and use #temp
+or ##temp tables in the same submitted block or visual selection. GO-separated
+batches in one submission share that session, but temporary tables do not
+persist into the next submission.
 
 DuckDB federation: attach external databases via :GripAttach. Supports
 PostgreSQL (postgres_scanner), MySQL/MariaDB (mysql_scanner), SQLite

--- a/tests/spec/adapter_spec.lua
+++ b/tests/spec/adapter_spec.lua
@@ -70,9 +70,10 @@ end
 --- called with, so a test can inspect opts.env (e.g. a password delivered
 --- via the environment instead of argv).
 local function capture_system_call(stdout, fn)
-  local captured_args, captured_opts
+  local captured_args, captured_opts, call_count = nil, nil, 0
   local orig = vim.system
   vim.system = function(args, opts, cb)
+    call_count = call_count + 1
     captured_args = args
     captured_opts = opts
     local r = { stdout = stdout or "", stderr = "", code = 0 }
@@ -81,7 +82,7 @@ local function capture_system_call(stdout, fn)
   local ok, err = pcall(fn)
   vim.system = orig
   if not ok then error(err) end
-  return captured_args, captured_opts
+  return captured_args, captured_opts, call_count
 end
 
 local function with_executable(fn)
@@ -500,6 +501,24 @@ test("sqlserver query: builds sqlcmd args for non-interactive use", function()
     end
     eq(opts.env.SQLCMDPASSWORD, "pw", "password delivered via env instead")
     contains(opts.stdin, "SELECT 1", "query delivered via stdin")
+  end)
+end)
+
+test("sqlserver query: sends one complete multi-batch block in one invocation", function()
+  with_executable(function()
+    local block = table.concat({
+      "CREATE TABLE #grip_scope (id INT NOT NULL);",
+      "GO",
+      "INSERT INTO #grip_scope VALUES (7);",
+      "GO",
+      "SELECT id FROM #grip_scope;",
+    }, "\n")
+    local _, opts, calls = capture_system_call("id\n--\n7\n", function()
+      local result, err = sqlserver.query(block, "sqlserver://sa:pw@localhost/grip_test")
+      assert(result, err)
+    end)
+    eq(calls, 1, "one sqlcmd process")
+    contains(opts.stdin, block, "complete block delivered through one stdin")
   end)
 end)
 

--- a/tests/spec/docs_contract_spec.lua
+++ b/tests/spec/docs_contract_spec.lua
@@ -172,8 +172,17 @@ test("TODO contains only active or unshipped work", function()
   assert(not todo:find("SECURITY.md", 1, true), "completed security policy retained")
   assert(not todo:find("CONTRIBUTING.md", 1, true), "completed contributor guide retained")
   assert(not todo:find("TOP N pagination", 1, true), "stale SQL Server pagination claim retained")
-  assert(todo:find("`##temp`", 1, true), "unresolved SQL Server temp-table limitation missing")
+  assert(not todo:find("`##temp`", 1, true), "stateless SQL Server temp-table scope retained as product work")
   assert(not todo:find("GripFill", 1, true), "shipped GripFill work retained")
+end)
+
+test("query-pad and SQL Server temp-table scope stay accurate", function()
+  assert(help:find("blank-line-delimited SQL block under the cursor", 1, true),
+    "query-pad block behavior missing")
+  assert(help:find("Create and use #temp\nor ##temp tables in the same submitted block or visual selection", 1, true),
+    "SQL Server temp-table session boundary missing")
+  assert(help:find("GO-separated\nbatches in one submission share that session", 1, true),
+    "SQL Server same-invocation GO behavior missing")
 end)
 
 test("contributor and vulnerability paths remain actionable", function()

--- a/tests/spec/live_workflow_spec.lua
+++ b/tests/spec/live_workflow_spec.lua
@@ -103,5 +103,24 @@ test("all-row export is complete and atomically written", function()
   vim.fn.delete(path)
 end)
 
+if URL:match("^sqlserver://") or URL:match("^mssql://") then
+  test("SQL Server temporary tables share one submission but not the next", function()
+    local name = "##grip_live_temp_scope"
+    local result, err = db.query(table.concat({
+      "CREATE TABLE " .. name .. " (id INT NOT NULL);",
+      "GO",
+      "INSERT INTO " .. name .. " VALUES (7);",
+      "GO",
+      "SELECT id FROM " .. name .. ";",
+    }, "\n"), URL)
+    assert(result, err)
+    eq(tonumber(result.rows[1][1]), 7, "GO batches share one sqlcmd session")
+
+    local next_result, next_err = db.query("SELECT id FROM " .. name, URL)
+    assert(not next_result, "temporary table survived a new sqlcmd invocation")
+    assert(next_err and next_err ~= "", "missing-object error was not reported")
+  end)
+end
+
 print(string.format("\nlive_workflow_spec: %d passed, %d failed", pass, fail))
 if fail > 0 then os.exit(1) end


### PR DESCRIPTION
## Summary

- correct query-pad help to describe the SQL block under the cursor
- document the stateless SQL Server temporary-table boundary
- remove the speculative cross-invocation global-temp backlog item
- prove one multi-batch block uses one stdin invocation and that SQL Server drops the global temporary table before the next invocation

## Verification

- just spec adapter
- just spec docs_contract
- just lint
- full deterministic suite against SQL Server 2025 with GRIP_REQUIRE_LIVE=1