### PR TITLE
feat: add staged imports and harden the demo walkthrough

### DIFF
--- a/.github/workflows/sqlserver.yml
+++ b/.github/workflows/sqlserver.yml
@@ -47,11 +47,10 @@ jobs:
       - name: Run required SQL Server release scenarios
         env:
           GRIP_TEST_LIVE_URL: "sqlserver://sa:Grip-ci-2025!@localhost/grip_test?encrypt=optional&trust_server_certificate=true"
-          GRIP_REQUIRE_LIVE: "1"
         run: |
           sudo apt-get update
           sudo apt-get install -y sqlite3
-          just test
+          just test-live sqlserver-2025
       - name: Show SQL Server logs on failure
         if: failure()
         run: docker logs grip-sqlserver

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,10 +111,7 @@ jobs:
                 -d grip_test -c "SELECT 1" >/dev/null 2>&1; do sleep 2; done
               PGPASSWORD=grip psql -h 127.0.0.1 -p "$host_port" -U postgres \
                 -d grip_test -f tests/seed_pg.sql
-              echo "GRIP_TEST_PG_URL=postgresql://postgres:grip@127.0.0.1:$host_port/grip_test" >> "$GITHUB_ENV"
-              echo "GRIP_REQUIRE_POSTGRES=1" >> "$GITHUB_ENV"
               echo "GRIP_TEST_LIVE_URL=postgresql://postgres:grip@127.0.0.1:$host_port/grip_test" >> "$GITHUB_ENV"
-              echo "GRIP_TEST_DUCKDB_FEDERATION_URL=postgresql://postgres:grip@127.0.0.1:$host_port/grip_test" >> "$GITHUB_ENV"
               ;;
             mysql-8.4)
               scanner=mysql_scanner
@@ -124,11 +121,7 @@ jobs:
               until mysql -h 127.0.0.1 -P "$host_port" -u root -pgrip \
                 -e "SELECT 1" >/dev/null 2>&1; do sleep 2; done
               mysql -h 127.0.0.1 -P "$host_port" -u root -pgrip grip_test < tests/seed_mysql.sql
-              echo "GRIP_TEST_MYSQL_URL=mysql://root:grip@127.0.0.1:$host_port/grip_test" >> "$GITHUB_ENV"
-              echo "GRIP_EXPECT_MYSQL_FLAVOR=mysql-8.4" >> "$GITHUB_ENV"
-              echo "GRIP_REQUIRE_MYSQL=1" >> "$GITHUB_ENV"
               echo "GRIP_TEST_LIVE_URL=mysql://root:grip@127.0.0.1:$host_port/grip_test" >> "$GITHUB_ENV"
-              echo "GRIP_TEST_DUCKDB_FEDERATION_URL=mysql://root:grip@127.0.0.1:$host_port/grip_test" >> "$GITHUB_ENV"
               ;;
             mariadb-11.8)
               scanner=mysql_scanner
@@ -138,19 +131,12 @@ jobs:
               until mysql -h 127.0.0.1 -P "$host_port" -u root -pgrip \
                 -e "SELECT 1" >/dev/null 2>&1; do sleep 2; done
               mysql -h 127.0.0.1 -P "$host_port" -u root -pgrip grip_test < tests/seed_mysql.sql
-              echo "GRIP_TEST_MYSQL_URL=mariadb://root:grip@127.0.0.1:$host_port/grip_test" >> "$GITHUB_ENV"
-              echo "GRIP_EXPECT_MYSQL_FLAVOR=mariadb-11.8" >> "$GITHUB_ENV"
-              echo "GRIP_REQUIRE_MYSQL=1" >> "$GITHUB_ENV"
               echo "GRIP_TEST_LIVE_URL=mariadb://root:grip@127.0.0.1:$host_port/grip_test" >> "$GITHUB_ENV"
-              echo "GRIP_TEST_DUCKDB_FEDERATION_URL=mariadb://root:grip@127.0.0.1:$host_port/grip_test" >> "$GITHUB_ENV"
               ;;
           esac
           duckdb -c "INSTALL sqlite_scanner; INSTALL $scanner;"
-          echo "GRIP_REQUIRE_LIVE=1" >> "$GITHUB_ENV"
-          echo "GRIP_REQUIRE_DUCKDB=1" >> "$GITHUB_ENV"
-          echo "GRIP_REQUIRE_DUCKDB_FEDERATION=1" >> "$GITHUB_ENV"
       - name: Run full suite with assigned live database required
-        run: just test
+        run: just test-live "${{ matrix.database }}"
       - name: Show database logs on failure
         if: failure()
         run: docker logs grip-live-db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Staged apply and committed-transaction undo now use SQL Server's `BEGIN TRANSACTION` and
   `COMMIT TRANSACTION` syntax instead of sending the unsupported shared `BEGIN` form. SQL Server
-  sessions also enable `XACT_ABORT`, so a failed statement cannot commit an earlier batch prefix.
+  managed transactions also enable `XACT_ABORT`, so a failed statement cannot commit an earlier
+  batch prefix.
 - SQLite invocations now use `-bail` and a real null-device init file, so startup stays quiet and a
   failed statement stops before `COMMIT` instead of leaving an earlier staged insert applied.
+- The Softrear walkthrough now seeds fail-closed, keeps every disposable database under Neovim's
+  data directory, attaches supplier data without touching the current project, and exercises the
+  staged import workflow with current keymaps and dataset counts.
+- DuckDB invocations now use `-bail`, so a failed statement stops a multi-statement submission
+  instead of continuing into later statements.
 
 ## [3.10.2] - 2026-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `:GripImport` previews CSV, TSV, or JSON from the clipboard or an explicit `!command`, maps
+  columns by name, and stages the rows as one undoable insert batch without writing until the
+  existing apply confirmation. The parent shell receives the producer script through stdin and
+  imported content stays out of argv; child commands retain normal shell argument visibility.
+
 ### Security
 
 - Gitleaks now scans committed history inside the required lint job, and an optional native Git hook
@@ -21,6 +28,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   model, while the in-editor help and documentation website remain the exhaustive references.
 - `CONTRIBUTING.md` now records the pinned tool setup, local gates, visual-test boundary, changelog
   policy, purpose-based branch naming, and optional secret-scanning hook.
+- `just test` and `just spec` now honor `NVIM`, while `just check` and `just test-live <database>`
+  provide shared deterministic and required live-dialect entry points for local CI parity.
+
+### Fixed
+
+- Staged apply and committed-transaction undo now use SQL Server's `BEGIN TRANSACTION` and
+  `COMMIT TRANSACTION` syntax instead of sending the unsupported shared `BEGIN` form. SQL Server
+  sessions also enable `XACT_ABORT`, so a failed statement cannot commit an earlier batch prefix.
+- SQLite invocations now use `-bail` and a real null-device init file, so startup stays quiet and a
+  failed statement stops before `COMMIT` instead of leaving an earlier staged insert applied.
 
 ## [3.10.2] - 2026-08-30
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,17 +22,20 @@ Use a short, purpose-based branch name such as `fix/mysql-null-values` or `docs/
 
 ## Run the local gates
 
-Run the focused spec while developing, then run the complete deterministic suite and LuaCheck:
+Run the focused spec while developing, then run the local CI gates:
 
 ```sh
 just spec data
-just test
-just lint
+just check
 ```
+
+Use `NVIM=/path/to/nvim just test` for a specific supported Neovim. For an
+already-running database, set `GRIP_TEST_LIVE_URL` and run `just test-live
+postgresql-16`, `mysql-8.4`, `mariadb-11.8`, `sqlserver-2025`, or `sqlite`.
 
 Run `just e2e-visual` when a change can affect window creation, sidebar sizing, the query pad, grid rendering, or resize behavior. It opens a real tmux-backed Neovim UI at 100, 80, and 160 columns.
 
-Live PostgreSQL, MySQL, MariaDB, and SQL Server jobs run in GitHub Actions. If you run them locally, set the corresponding `GRIP_REQUIRE_*` flag so a missing database fails instead of silently skipping its assigned test.
+Live PostgreSQL, MySQL, MariaDB, and SQL Server jobs run in GitHub Actions.
 
 ## Scan for secrets
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Dadbod Grip requires Neovim 0.10 or newer and the command-line client for each d
 | DuckDB, local files, HTTP, or S3 | `duckdb` |
 | SQL Server | `sqlcmd` |
 
-The built-in demo requires either `duckdb` or `sqlite3`, but it requires no database server or manual setup. Dadbod Grip has no required Lua dependencies. vim-dadbod-ui, completion plugins, SQL formatters, and AI providers are optional integrations.
+The built-in demo requires either `duckdb` or `sqlite3`, but it requires no database server or manual setup. DuckDB loads the full dataset; SQLite provides a compact fallback. Install both CLIs to include the automatically attached supplier-federation chapter. Dadbod Grip has no required Lua dependencies. vim-dadbod-ui, completion plugins, SQL formatters, and AI providers are optional integrations.
 
 ### Install with lazy.nvim
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ These commands cover the normal path:
 | `:GripQuery` | Opens the query pad. |
 | `:GripAsk` | Generates SQL from a natural-language request. |
 | `:GripExport` | Exports the current page or every matching row. |
+| `:GripImport` | Previews and stages CSV, TSV, or JSON rows from the clipboard or `!command`. |
 | `:GripHome` | Returns to the welcome screen. |
 
 In the query pad, `<C-CR>` runs SQL and `gA` generates SQL. In the grid, `f` filters by the current cell, `s` sorts the current column, `gf` follows a foreign key, and `gE` exports to the clipboard.
@@ -176,6 +177,8 @@ All default values, picker integrations, connection fields, remappable actions, 
 Dadbod Grip stages cell edits, inserted rows, and deletions in memory. Nothing reaches the database until you inspect the generated SQL and confirm the apply action. A connection with `"mode": "ro"` disables editing and asks the database client for a read-only session, but database permissions remain the real security boundary.
 
 Dadbod Grip sends all database SQL and AI request content through stdin. Statements, mutation values, prompts, schema context, existing SQL, and request bodies stay out of process arguments. API-key lookup commands also enter the shell through stdin.
+
+For `:GripImport !command`, the parent shell receives the script through stdin, but child commands retain normal shell argument visibility. Pass credentials through environment variables, stdin, or configuration files instead of command arguments.
 
 Passwords and connection parameters use client environment variables or invocation-scoped files instead of command arguments. Processes running as your user may still read those environment variables, so this prevents casual process-list exposure rather than replacing operating-system isolation.
 

--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,6 @@ Shipped work belongs in `CHANGELOG.md`. Review this file after each release and 
 
 ## Product ideas
 
-- Import CSV, TSV, or JSON from the clipboard or a pipe, preview the inferred columns, and stage the rows as inserts.
 - Generate migration SQL that makes one table match another from the existing diff view.
 - Add client-side virtual columns defined by project configuration without writing them to the database.
 - Support DuckDB Iceberg/Delta Lake tables, spatial values, full-text search, and MotherDuck branches.

--- a/demo/softrear-internal.md
+++ b/demo/softrear-internal.md
@@ -12,7 +12,11 @@ Three questions:
 3. What decisions drove the company here, and how were they made?
 
 This notebook answers all three. Place your cursor inside any SQL block and press
-`C-CR` to run it. Results appear in the grid below. Navigate blocks with `j`/`k`.
+`<C-CR>` to run it. Results appear in the grid below. Move through the notebook
+with `j`/`k`.
+
+DuckDB loads the full 505-roll investigation. The SQLite fallback keeps the same
+named evidence in a compact 35-roll fixture, so exact background-row counts differ.
 
 ---
 
@@ -160,8 +164,10 @@ under embargo.
 
 > **Grid:** this result is wide. Press `K` on any row for a vertical key-value view.
 > Visual-select two rows with `V`, then press `K` to stack both in one float.
-> Press `gE` to inspect the query plan and confirm the join indexes are used.
-> Press `gf` on any FK column to follow it interactively to its referenced table.
+> Press `gQ` to inspect the query plan and confirm the join indexes are used.
+> Press `gf` on any FK column to follow it interactively to its referenced table,
+> or `gm` on a referenced row to open the rows that point back to it. Press `gE`
+> to export the current page or every matching row.
 
 ---
 
@@ -185,8 +191,9 @@ Sample of the unreviewed set:
 - "Has anyone else noticed the sheets are thinner than they used to be?"
 - "Why is this product 15% smaller than it was in 2018?"
 
-190 comments are in the unreviewed queue. The threat landscape is expanding faster
-than the Threat Assessment team can process it.
+The full DuckDB fixture has 193 comments in the unreviewed queue; the compact
+SQLite fallback keeps two representative rows. The threat landscape is expanding
+faster than the Threat Assessment team can process it.
 
 ---
 
@@ -345,18 +352,15 @@ problem internally, build policy to prevent naming it externally.
 
 ---
 
-## 13. Cross-database: attach the supplier intelligence file
+## 13. Cross-database: supplier intelligence
 
 The internal investigation terminates at the embargo on Bamboo Don. A leaked
 supplier logistics database covers what happened on the other side of that
-relationship. Attach it:
-
-```vim
-:GripAttach sqlite:.grip/supplier_intel.db  supplier
-```
-
-The schema sidebar updates. A `supplier` section appears with three tables:
-`shipments`, `ingredient_tests`, `pricing`.
+relationship. When both DuckDB and SQLite are installed, `:GripStart` creates the
+disposable supplier database under Neovim's data directory and attaches it as
+`supplier`. The schema sidebar shows its three tables: `shipments`,
+`ingredient_tests`, and `pricing`. Skip sections 14-16 when the demo is using the
+compact SQLite fallback.
 
 ---
 
@@ -427,6 +431,24 @@ relabeling preserved the margin. Detach when done:
 
 ---
 
+## 17. Stage a new lead from a pipe
+
+The investigation produced one more lead. Open the editable table and import it
+without writing to the database yet:
+
+```vim
+:Grip people_on_to_us
+:GripImport !printf 'id,name,platform,evidence_strength,what_they_know,our_response,investigation_id\n1001,Import Auditor,Forum,6,Knows the import path,ignored,\n1002,Pipe Witness,Chat,7,Saw the staged batch,coupon_sent,\n'
+```
+
+Answer `y` to the preview. Both rows appear with staged markers, but the database
+is unchanged. Press `gs` to inspect both `INSERT` statements, then press `u` once
+to remove the whole imported batch. To try the commit path, run the import again
+and press `a`; the normal transaction confirmation still applies. `:GripStart`
+restores the disposable database on the next run.
+
+---
+
 ## What this found
 
 The three questions from the opening now have answers.
@@ -452,7 +474,7 @@ The data was here the whole time.
 ## Going further
 
 Every result set is a live grid. Press `?` from any surface for the full
-keymap reference. Navigate between SQL blocks with `gn` without leaving
-the notebook.
+keymap reference. Press `gn` from the query pad to open another SQL or Markdown
+notebook.
 
-Full feature reference: https://joryeugene.github.io/dadbod-grip-web/
+Full feature reference: https://jorypestorious.com/dadbod-grip-web/

--- a/demo/softrear.sql
+++ b/demo/softrear.sql
@@ -482,7 +482,8 @@ SELECT
        ELSE 'Substack' END,
   100 + ((n * 347) % 50000),
   (n % 7 = 0),
-  CASE WHEN n % 5 = 0 THEN ((n * 3) % 100) + 1 ELSE NULL END
+  CASE WHEN n % 5 = 0 THEN ((n * 3) % 100) + 1 ELSE NULL END,
+  NULL
 FROM range(11, 201) t(n);
 
 

--- a/demo/softrear_supplier.sql
+++ b/demo/softrear_supplier.sql
@@ -1,6 +1,6 @@
 -- softrear_supplier.sql: Leaked supplier logistics database (SQLite)
 -- Seeded by :GripStart alongside the main Softrear database.
--- Attach with: :GripAttach sqlite:.grip/supplier_intel.db  supplier
+-- :GripStart attaches this disposable database automatically when both CLIs are available.
 
 CREATE TABLE shipments (
   id INTEGER PRIMARY KEY,

--- a/doc/dadbod-grip.txt
+++ b/doc/dadbod-grip.txt
@@ -515,6 +515,29 @@ All commands are global and available after the plugin loads.
     :GripFill 5      stage 5 rows
     :GripFill 50     maximum
 
+                                                             *:GripImport*
+:GripImport [!command]
+  Preview CSV, TSV, or JSON rows and stage them as pending INSERTs in the
+  current editable table grid. With no argument, reads the system clipboard.
+  With !command, runs the producer through the shell and reads its standard
+  output. The parent shell receives the script through stdin, but child
+  commands retain normal shell argument visibility. Pass credentials through
+  environment variables, stdin, or configuration files instead of command
+  arguments. The first CSV or TSV row supplies column names; JSON accepts one
+  object or an array of objects. Input columns map by exact name to the table.
+  Empty delimited fields and JSON null values stage SQL NULL. Unknown or
+  duplicate columns are rejected before the grid changes.
+
+  The preview shows the detected format, row count, and mapped columns. Answer
+  y to stage the whole batch as one undoable edit, then press a separately to
+  apply it. Cancelling, malformed input, or a failed producer stages nothing.
+
+  Examples: >
+    :GripImport
+    :GripImport !cat /tmp/new-users.csv
+    :GripImport !jq '.users' response.json
+<
+
                                                                *:GripStart*
 :GripStart
   Open the built-in demo database (Softrear Inc. Analyst Portal). Recreates

--- a/doc/dadbod-grip.txt
+++ b/doc/dadbod-grip.txt
@@ -541,10 +541,13 @@ All commands are global and available after the plugin loads.
                                                                *:GripStart*
 :GripStart
   Open the built-in demo database (Softrear Inc. Analyst Portal). Recreates
-  its SQLite database from the bundled seed on every run, then opens the
-  schema browser. It requires either the duckdb or sqlite3 CLI, but no
-  database server or manual setup. The demo is disposable and is never
-  treated as user data.
+  its database from the bundled seed on every run, then opens the schema
+  browser and investigation notebook. It requires either the duckdb or
+  sqlite3 CLI, but no database server or manual setup. DuckDB loads the full
+  fixture; SQLite provides a compact fallback. When both CLIs are installed,
+  the disposable supplier database is attached automatically as `supplier`.
+  Demo files live under stdpath("data") and never overwrite the current
+  project's .grip directory.
 
                                                                 *:GripHome*
 :GripHome

--- a/justfile
+++ b/justfile
@@ -148,20 +148,77 @@ e2e-visual: seed-sqlite
       fi
     }
     snapshot() {
-      printf '\n=== Neovim attached UI: %s columns ===\n' "$1"
+      printf '\n=== %s ===\n' "$1"
       tmux capture-pane -p -t "$session"
+    }
+    wait_text() {
+      local text="$1"
+      for _ in {1..160}; do
+        tmux capture-pane -p -t "$session" | grep -Fq "$text" && return 0
+        sleep 0.05
+      done
+      echo "e2e-visual timed out waiting for text: $text" >&2
+      tmux capture-pane -p -t "$session" >&2 || true
+      exit 1
+    }
+    send_import() {
+      local command=":GripImport !printf 'name,email,age\\nE2E Import One,e2e-one@example.test,41\\nE2E Import Two,e2e-two@example.test,42\\n'"
+      tmux send-keys -t "$session" -l "$command"
+      tmux send-keys -t "$session" Enter
     }
 
     wait_for ready
-    snapshot 100
+    snapshot "Neovim attached UI: 100 columns"
     tmux resize-window -t "$session" -x 80 -y 30
     wait_for 80
-    snapshot 80
+    snapshot "Neovim attached UI: 80 columns"
     tmux resize-window -t "$session" -x 160 -y 40
     wait_for 160
-    snapshot 160
+    snapshot "Neovim attached UI: 160 columns"
     tmux resize-window -t "$session" -x 100 -y 36
     wait_for 100
+
+    wait_for import-ready
+    tmux resize-window -t "$session" -x 100 -y 50
+    send_import
+    wait_text "Import 2 CSV rows"
+    snapshot "GripImport preview prompt"
+    tmux send-keys -t "$session" y Enter
+    wait_text "Press ENTER or type command to continue"
+    tmux send-keys -t "$session" Enter
+    wait_for import-staged
+    tmux send-keys -t "$session" '$'
+    wait_text "2 staged"
+    snapshot "GripImport staged indicator"
+    tmux send-keys -t "$session" 0
+    tmux send-keys -t "$session" G
+    wait_text "E2E Import One"
+    snapshot "GripImport staged rows"
+
+    tmux send-keys -t "$session" g s
+    wait_for import-sql
+    snapshot "GripImport staged SQL"
+    tmux send-keys -t "$session" q
+    tmux send-keys -t "$session" u
+    wait_for import-undone
+
+    send_import
+    wait_text "Import 2 CSV rows"
+    tmux send-keys -t "$session" y Enter
+    wait_text "Press ENTER or type command to continue"
+    tmux send-keys -t "$session" Enter
+    wait_for import-restaged
+    tmux send-keys -t "$session" a
+    wait_text "Apply 2 staged change"
+    snapshot "GripImport apply confirmation"
+    tmux send-keys -t "$session" a
+    wait_text "Press ENTER or type command to continue"
+    tmux send-keys -t "$session" Enter
+    wait_for import-applied
+    tmux send-keys -t "$session" G
+    wait_text "E2E Import One"
+    snapshot "GripImport committed rows"
+    tmux send-keys -t "$session" :qa! Enter
 
     for _ in {1..100}; do
       [[ "$(tmux display-message -p -t "$session" '#{pane_dead}')" == 1 ]] && break
@@ -179,7 +236,7 @@ e2e-visual: seed-sqlite
       tmux capture-pane -p -t "$session" >&2
       exit "$status"
     fi
-    echo "e2e-visual: attached UI passed at 100, 80, and 160 columns"
+    echo "e2e-visual: layout and staged import passed at 100, 80, and 160 columns"
 
 # Open Neovim connected to DuckDB for httpfs testing
 dev-httpfs: seed-httpfs

--- a/justfile
+++ b/justfile
@@ -6,11 +6,45 @@ default: test
 
 # Run all unit tests from a fresh deterministic SQLite fixture
 test: seed-sqlite
-    nvim --headless -u tests/minimal_init.lua -l tests/run_specs.lua
+    "${NVIM:-nvim}" --headless -u tests/minimal_init.lua -l tests/run_specs.lua
 
 # Run a single spec file by name (e.g., just spec data)
 spec name: seed-sqlite
-    nvim --headless -u tests/minimal_init.lua -l tests/spec/{{name}}_spec.lua
+    "${NVIM:-nvim}" --headless -u tests/minimal_init.lua -l tests/spec/{{ name }}_spec.lua
+
+# Run the local CI gates that do not require external databases
+check:
+    just lint
+    just test
+
+# Run the required live suite for one already-running database
+test-live database:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    : "${GRIP_TEST_LIVE_URL:?Set GRIP_TEST_LIVE_URL to the assigned database URL}"
+    export GRIP_REQUIRE_LIVE=1
+    case "{{ database }}" in
+      postgresql-16)
+        export GRIP_TEST_PG_URL="$GRIP_TEST_LIVE_URL" GRIP_REQUIRE_POSTGRES=1
+        export GRIP_TEST_DUCKDB_FEDERATION_URL="$GRIP_TEST_LIVE_URL"
+        export GRIP_REQUIRE_DUCKDB_FEDERATION=1 GRIP_REQUIRE_DUCKDB=1
+        ;;
+      mysql-8.4)
+        export GRIP_TEST_MYSQL_URL="$GRIP_TEST_LIVE_URL" GRIP_REQUIRE_MYSQL=1
+        export GRIP_EXPECT_MYSQL_FLAVOR=mysql-8.4
+        export GRIP_TEST_DUCKDB_FEDERATION_URL="$GRIP_TEST_LIVE_URL"
+        export GRIP_REQUIRE_DUCKDB_FEDERATION=1 GRIP_REQUIRE_DUCKDB=1
+        ;;
+      mariadb-11.8)
+        export GRIP_TEST_MYSQL_URL="$GRIP_TEST_LIVE_URL" GRIP_REQUIRE_MYSQL=1
+        export GRIP_EXPECT_MYSQL_FLAVOR=mariadb-11.8
+        export GRIP_TEST_DUCKDB_FEDERATION_URL="$GRIP_TEST_LIVE_URL"
+        export GRIP_REQUIRE_DUCKDB_FEDERATION=1 GRIP_REQUIRE_DUCKDB=1
+        ;;
+      sqlite|sqlserver-2025) ;;
+      *) echo "Unknown live database: {{ database }}" >&2; exit 2 ;;
+    esac
+    just test
 
 # Lint with luacheck. Settings live in .luacheckrc; same args as CI.
 # Install: luarocks --lua-version=5.1 --local install luacheck

--- a/lazy.lua
+++ b/lazy.lua
@@ -28,6 +28,7 @@ return {
       "GripRename",
       "GripProperties",
       "GripExport",
+      "GripImport",
       "GripAttach",
       "GripDetach",
       "GripOpen",

--- a/lua/dadbod-grip/adapters/duckdb.lua
+++ b/lua/dadbod-grip/adapters/duckdb.lua
@@ -482,7 +482,7 @@ end
 --- @param flags string[]|nil  output flags for this call site
 local function duckdb_args(db, opts, flags)
   local db_path = (type(db) == "string" and db:match("^duckdb:")) and extract_path(db) or db
-  local args = { "duckdb" }
+  local args = { "duckdb", "-bail" }
   for _, f in ipairs(flags or {}) do
     args[#args + 1] = f
   end
@@ -1339,7 +1339,7 @@ function M.attach(url, dsn, alias, template)
   -- Validate in-memory: avoids acquiring a write lock on the main db file.
   -- If we opened db_path here, we'd race with list_tables / get_schema_batch_async
   -- (both also open the same file), causing "Failed to lock file" on connection switch.
-  local args = { "duckdb" }
+  local args = duckdb_args(":memory:", nil)
 
   local _, stderr_attach, code_attach = adapters.run_cmd(args, timeout, { stdin = test_sql })
   if code_attach ~= 0 then

--- a/lua/dadbod-grip/adapters/sqlite.lua
+++ b/lua/dadbod-grip/adapters/sqlite.lua
@@ -49,7 +49,8 @@ end
 --- rw mode -- there is nothing to protect in a database that does not exist.
 --- @param opts table|nil  { readonly = boolean }
 local function sqlite3_args(db_path, opts)
-  local args = { "sqlite3", "-init", "", "-csv", "-header" }
+  local null_device = vim.fn.has("win32") == 1 and "NUL" or "/dev/null"
+  local args = { "sqlite3", "-init", null_device, "-bail", "-csv", "-header" }
   if opts and opts.readonly and vim.fn.filereadable(db_path) == 1 then
     args[#args + 1] = "-readonly"
   end

--- a/lua/dadbod-grip/connections.lua
+++ b/lua/dadbod-grip/connections.lua
@@ -643,20 +643,14 @@ function M.list()
   -- Softrear Inc. Analyst Portal™: built-in demo, shown until dismissed or
   -- until the user switches to it (after which it's persisted as a regular
   -- file connection and `seen[demo_url]` suppresses this entry).
-  local hidden = vim.fn.stdpath("data") .. "/grip/softrear.hidden"
-  local sql_files = vim.api.nvim_get_runtime_file("demo/softrear.sql", false)
-  if #sql_files > 0 and vim.fn.filereadable(hidden) == 0 then
-    local ext      = has_duck and ".duckdb" or ".db"
-    local db_path  = vim.fn.stdpath("data") .. "/grip/softrear" .. ext
-    local demo_url = (has_duck and "duckdb:" or "sqlite:") .. db_path
-    if not seen[demo_url] then  -- suppress once persisted as a real connection
-      local seed = has_duck and sql_files[1]
-        or (vim.api.nvim_get_runtime_file("demo/softrear_sqlite.sql", false)[1] or "")
+  local hidden = data_dir .. "/softrear.hidden"
+  local demo_spec = require("dadbod-grip.demo").spec()
+  if demo_spec and vim.fn.filereadable(hidden) == 0 then
+    if not seen[demo_spec.url] then  -- suppress once persisted as a real connection
       table.insert(all, {
-        name      = "Softrear Inc. Analyst Portal\xe2\x84\xa2",
-        url       = demo_url,
+        name      = require("dadbod-grip.demo").label,
+        url       = demo_spec.url,
         _is_demo  = true,
-        _demo_sql = seed,
       })
     end
   end
@@ -1252,16 +1246,18 @@ function M.pick(opts)
         M.switch(c.url, nil, "file")
       else
         -- Lazy-seed the portal DB on first selection
-        if c._is_demo and c._demo_sql and c._demo_sql ~= "" then
-          local db_path = c.url:gsub("^duckdb:", ""):gsub("^sqlite:", "")
-          if vim.fn.filereadable(db_path) == 0 then
-            vim.fn.mkdir(vim.fn.fnamemodify(db_path, ":h"), "p")
-            local bin = db_path:match("%.duckdb$") and "duckdb" or "sqlite3"
-            vim.fn.system(bin .. " " .. vim.fn.shellescape(db_path)
-              .. " < " .. vim.fn.shellescape(c._demo_sql))
+        if c._is_demo then
+          local demo, err = require("dadbod-grip.demo").prepare(false)
+          if not demo then
+            vim.notify("Grip: " .. err, vim.log.levels.ERROR)
+            return
           end
-          -- Persist with name so MRU tracking works on every future selection
-          M.switch(c.url, c.name)
+          -- Persist with name so MRU tracking works on every future selection.
+          M.switch(demo.url, c.name)
+          local ok
+          ok, err = require("dadbod-grip.demo").attach_supplier(demo)
+          if not ok then vim.notify("Grip: " .. err, vim.log.levels.WARN) end
+          if demo.supplier_error then vim.notify("Grip: " .. demo.supplier_error, vim.log.levels.WARN) end
         else
           M.switch(c.url, c.name, c.type)
         end

--- a/lua/dadbod-grip/data.lua
+++ b/lua/dadbod-grip/data.lua
@@ -62,6 +62,13 @@ local function deep_copy(t)
   return copy
 end
 
+local function sorted_numeric_keys(t)
+  local keys = {}
+  for key in pairs(t) do keys[#keys + 1] = key end
+  table.sort(keys)
+  return keys
+end
+
 --- Shallow-copy a state, deep-copying only the mutable subtrees
 --- (changes, deleted, inserted). Rows, columns, and pks are shared
 --- since they are never mutated after creation.
@@ -135,15 +142,23 @@ function M.toggle_delete(state, row_idx)
   return s
 end
 
+-- M.insert_rows_with_values(state, after_idx, rows) → State
+-- Adds pre-populated rows as one state transform, preserving source order.
+function M.insert_rows_with_values(state, after_idx, rows)
+  local s = edit_copy(state)
+  for _, values in ipairs(rows) do
+    local new_idx = s._next_insert_idx
+    s._next_insert_idx = s._next_insert_idx + 1
+    s.inserted[new_idx] = { _after = after_idx, values = values }
+  end
+  return s
+end
+
 -- M.insert_row_with_values(state, after_idx, values) → State
 -- Adds a row with pre-populated values as a staged insert.
 -- Used by mutation preview to show INSERT VALUES rows highlighted green.
 function M.insert_row_with_values(state, after_idx, values)
-  local s = edit_copy(state)
-  local new_idx = s._next_insert_idx
-  s._next_insert_idx = s._next_insert_idx + 1
-  s.inserted[new_idx] = { _after = after_idx, values = values or {} }
-  return s
+  return M.insert_rows_with_values(state, after_idx, { values or {} })
 end
 
 -- M.insert_row(state, after_idx) → State
@@ -230,7 +245,8 @@ end
 -- M.get_inserts(state) → list of {values, columns}
 function M.get_inserts(state)
   local inserts = {}
-  for _, ins in pairs(state.inserted) do
+  for _, idx in ipairs(sorted_numeric_keys(state.inserted)) do
+    local ins = state.inserted[idx]
     local clean_values = {}
     for col, val in pairs(ins.values) do
       clean_values[col] = val  -- keep NULL_SENTINEL; sql.lua emits NULL for it
@@ -322,17 +338,20 @@ end
 -- Inserts are spliced after their _after idx.
 function M.get_ordered_rows(state)
   local order = {}
+  local inserted = sorted_numeric_keys(state.inserted)
   for i = 1, #state.rows do
     table.insert(order, i)
     -- Splice in any inserted rows that follow this one
-    for ins_idx, ins in pairs(state.inserted) do
+    for _, ins_idx in ipairs(inserted) do
+      local ins = state.inserted[ins_idx]
       if ins._after == i then
         table.insert(order, ins_idx)
       end
     end
   end
   -- Rows inserted after the last row (after_idx = #rows or 0)
-  for ins_idx, ins in pairs(state.inserted) do
+  for _, ins_idx in ipairs(inserted) do
+    local ins = state.inserted[ins_idx]
     if ins._after == 0 or ins._after >= #state.rows then
       -- Only add if not already spliced
       local found = false

--- a/lua/dadbod-grip/db.lua
+++ b/lua/dadbod-grip/db.lua
@@ -64,15 +64,16 @@ function M.group_referencing_fks(entries)
   return refs
 end
 
---- Parse CSV output into rows + columns.
+--- Parse delimited output into rows + columns.
 --- Handles multiline quoted fields (RFC 4180).
---- Shared by all adapters that use CSV CLI output.
-function M.parse_csv(raw)
+--- Shared by all adapters that use CSV CLI output; imports also pass a tab
+--- delimiter and strict=true for user-supplied TSV.
+function M.parse_csv(raw, delimiter, strict)
   if not raw or raw == "" then
     return { columns = {}, rows = {} }
   end
 
-  local DQUOTE, COMMA, LF, CR = 34, 44, 10, 13
+  local DQUOTE, DELIM, LF, CR = 34, (delimiter or ","):byte(), 10, 13
 
   -- Parse entire raw string respecting quoted fields that span newlines.
   local all_rows = {}
@@ -93,6 +94,7 @@ function M.parse_csv(raw)
       while true do
         local qpos = raw:find('"', i, true)
         if not qpos then
+          if strict then return nil, "unterminated quoted field" end
           -- Unterminated quote: the rest of the input is the field.
           parts[#parts + 1] = raw:sub(start, len)
           i = len + 1
@@ -113,18 +115,26 @@ function M.parse_csv(raw)
       -- After closing quote: expect comma, newline, or end
       if i <= len then
         b = raw:byte(i)
-        if b == COMMA then
+        if b == DELIM then
           i = i + 1
+          if i > len or raw:byte(i) == LF or raw:byte(i) == CR then
+            table.insert(fields, "")
+          end
         elseif b == LF or b == CR then
           if b == CR and raw:byte(i + 1) == LF then i = i + 1 end
           i = i + 1
           table.insert(all_rows, fields)
           fields = {}
+        elseif strict then
+          return nil, "unexpected text after quoted field"
         end
       end
-    elseif b == COMMA then
+    elseif b == DELIM then
       table.insert(fields, "")
       i = i + 1
+      if i > len or raw:byte(i) == LF or raw:byte(i) == CR then
+        table.insert(fields, "")
+      end
     elseif b == LF or b == CR then
       if b == CR and raw:byte(i + 1) == LF then i = i + 1 end
       i = i + 1
@@ -135,14 +145,17 @@ function M.parse_csv(raw)
       local start = i
       while i <= len do
         local ub = raw:byte(i)
-        if ub == COMMA or ub == LF or ub == CR then break end
+        if ub == DELIM or ub == LF or ub == CR then break end
         i = i + 1
       end
       table.insert(fields, raw:sub(start, i - 1))
       if i <= len then
         b = raw:byte(i)
-        if b == COMMA then
+        if b == DELIM then
           i = i + 1
+          if i > len or raw:byte(i) == LF or raw:byte(i) == CR then
+            table.insert(fields, "")
+          end
         elseif b == LF or b == CR then
           if b == CR and raw:byte(i + 1) == LF then i = i + 1 end
           i = i + 1
@@ -173,6 +186,9 @@ function M.parse_csv(raw)
   local rows = {}
   for ri = 2, #filtered do
     local row = filtered[ri]
+    if strict and #row ~= #columns then
+      return nil, string.format("row %d has %d fields; expected %d", ri - 1, #row, #columns)
+    end
     while #row < #columns do table.insert(row, "") end
     table.insert(rows, row)
   end

--- a/lua/dadbod-grip/demo.lua
+++ b/lua/dadbod-grip/demo.lua
@@ -1,0 +1,85 @@
+-- demo.lua: prepare the disposable Softrear databases without touching the project.
+
+local M = {}
+
+M.label = "Softrear Inc. Analyst Portal\xe2\x84\xa2"
+
+function M.spec()
+  local has_duck = vim.fn.executable("duckdb") == 1
+  local has_sqlite = vim.fn.executable("sqlite3") == 1
+  if not has_duck and not has_sqlite then
+    return nil, "GripStart requires duckdb or sqlite3 for the demo database."
+  end
+
+  local seed_name = has_duck and "demo/softrear.sql" or "demo/softrear_sqlite.sql"
+  local seed = vim.api.nvim_get_runtime_file(seed_name, false)[1]
+  if not seed then return nil, "Softrear Portal not found. Is the plugin in your runtimepath?" end
+
+  local dir = vim.fn.stdpath("data") .. "/grip"
+  local path = dir .. (has_duck and "/softrear.duckdb" or "/softrear.db")
+  local supplier_seed = vim.api.nvim_get_runtime_file("demo/softrear_supplier.sql", false)[1]
+  return {
+    kind = has_duck and "duckdb" or "sqlite",
+    path = path,
+    url = (has_duck and "duckdb:" or "sqlite:") .. path,
+    seed = seed,
+    supplier_path = dir .. "/softrear-supplier.db",
+    supplier_seed = has_duck and has_sqlite and supplier_seed or nil,
+  }
+end
+
+local function seed_database(url, path, seed)
+  local read_ok, lines = pcall(vim.fn.readfile, seed)
+  if not read_ok then return nil, "could not read the bundled demo seed" end
+
+  local existing = vim.fn.getftype(path)
+  if existing ~= "" and (existing ~= "file" or vim.fn.delete(path) ~= 0) then
+    return nil, "could not replace " .. vim.fn.fnamemodify(path, ":t")
+  end
+  vim.fn.mkdir(vim.fn.fnamemodify(path, ":h"), "p")
+  local result, err = require("dadbod-grip.db").execute(table.concat(lines, "\n") .. "\n", url)
+  if not result then
+    local message = err or "database client returned no result"
+    if vim.fn.getftype(path) ~= "" and vim.fn.delete(path) ~= 0 then
+      message = message .. "; the partial demo database could not be removed"
+    end
+    return nil, message
+  end
+  return true
+end
+
+function M.prepare(reseed)
+  local spec, err = M.spec()
+  if not spec then return nil, err end
+
+  if spec.kind == "duckdb" then
+    require("dadbod-grip.adapters.duckdb").load_attachments(spec.url, nil)
+  end
+  if reseed or vim.fn.filereadable(spec.path) == 0 then
+    local ok
+    ok, err = seed_database(spec.url, spec.path, spec.seed)
+    if not ok then return nil, "Softrear seed failed: " .. err end
+  end
+
+  if spec.supplier_seed and (reseed or vim.fn.filereadable(spec.supplier_path) == 0) then
+    local ok
+    ok, err = seed_database("sqlite:" .. spec.supplier_path, spec.supplier_path, spec.supplier_seed)
+    if not ok then
+      spec.supplier_seed = nil
+      spec.supplier_error = "Supplier demo seed failed: " .. err
+    end
+  end
+  return spec
+end
+
+function M.attach_supplier(spec)
+  if spec.kind ~= "duckdb" then return true end
+  local duckdb = require("dadbod-grip.adapters.duckdb")
+  duckdb.load_attachments(spec.url, nil)
+  if not spec.supplier_seed then return true end
+  local err = duckdb.attach(spec.url, "sqlite:" .. spec.supplier_path, "supplier")
+  if err then return nil, "Supplier demo attachment failed: " .. err end
+  return true
+end
+
+return M

--- a/lua/dadbod-grip/importer.lua
+++ b/lua/dadbod-grip/importer.lua
@@ -1,0 +1,116 @@
+-- importer.lua: parse clipboard/pipe rows into staged-insert value maps.
+
+local data = require("dadbod-grip.data")
+local db = require("dadbod-grip.db")
+
+local M = {}
+
+local function is_list(value)
+  if vim.islist then return vim.islist(value) end
+  return vim.tbl_islist(value)
+end
+
+local function target_index(columns)
+  local index = {}
+  for _, column in ipairs(columns) do index[column] = true end
+  return index
+end
+
+local function normalize_json(value)
+  if value == vim.NIL then return data.NULL_SENTINEL end
+  if type(value) == "table" then return vim.json.encode(value) end
+  return tostring(value)
+end
+
+local function parse_json(raw, columns, first)
+  local ok, decoded = pcall(vim.json.decode, raw)
+  if not ok then return nil, "invalid JSON" end
+
+  local rows
+  if first == "[" then
+    if type(decoded) ~= "table" or not is_list(decoded) then
+      return nil, "JSON input must be an array of objects"
+    end
+    rows = decoded
+  else
+    if type(decoded) ~= "table" then return nil, "JSON input must be an object" end
+    rows = { decoded }
+  end
+  if #rows == 0 then return nil, "no rows to import" end
+
+  local allowed = target_index(columns)
+  local present, unknown, values = {}, {}, {}
+  for row_number, row in ipairs(rows) do
+    if type(row) ~= "table" or is_list(row) then
+      return nil, "JSON row " .. row_number .. " must be an object"
+    end
+    local mapped = {}
+    for column, value in pairs(row) do
+      if not allowed[column] then
+        unknown[column] = true
+      else
+        present[column] = true
+        mapped[column] = normalize_json(value)
+      end
+    end
+    values[#values + 1] = mapped
+  end
+
+  local unknown_list = {}
+  for column in pairs(unknown) do unknown_list[#unknown_list + 1] = tostring(column) end
+  table.sort(unknown_list)
+  if #unknown_list > 0 then
+    return nil, "unknown column(s): " .. table.concat(unknown_list, ", ")
+  end
+
+  local mapped_columns = {}
+  for _, column in ipairs(columns) do
+    if present[column] then mapped_columns[#mapped_columns + 1] = column end
+  end
+  if #mapped_columns == 0 then return nil, "no table columns found in JSON input" end
+
+  return { format = "JSON", columns = mapped_columns, rows = values }
+end
+
+local function parse_delimited(raw, columns)
+  local header = raw:match("^[^\r\n]*") or ""
+  local delimiter = header:find("\t", 1, true) and "\t" or ","
+  local parsed, err = db.parse_csv(raw, delimiter, true)
+  if not parsed then return nil, err end
+  if #parsed.columns == 0 or #parsed.rows == 0 then return nil, "no rows to import" end
+
+  local allowed = target_index(columns)
+  local seen = {}
+  for _, column in ipairs(parsed.columns) do
+    if column == "" then return nil, "empty column name" end
+    if seen[column] then return nil, "duplicate column: " .. column end
+    if not allowed[column] then return nil, "unknown column: " .. column end
+    seen[column] = true
+  end
+
+  local values = {}
+  for _, row in ipairs(parsed.rows) do
+    local mapped = {}
+    for index, column in ipairs(parsed.columns) do
+      mapped[column] = data.from_csv_raw(row[index])
+    end
+    values[#values + 1] = mapped
+  end
+
+  return {
+    format = delimiter == "\t" and "TSV" or "CSV",
+    columns = parsed.columns,
+    rows = values,
+  }
+end
+
+--- Parse CSV, TSV, or JSON rows and map them to the target table columns.
+function M.parse(raw, columns)
+  if type(raw) ~= "string" or vim.trim(raw) == "" then return nil, "no rows to import" end
+  raw = raw:gsub("^\239\187\191", "")
+  local first = raw:match("^%s*(.)")
+  if first == "[" or first == "{" then return parse_json(raw, columns, first) end
+  return parse_delimited(raw, columns)
+end
+
+return M

--- a/lua/dadbod-grip/init.lua
+++ b/lua/dadbod-grip/init.lua
@@ -2163,50 +2163,18 @@ function M.setup(opts)
 
   -- :GripStart: open the Softrear Analyst Portal directly
   vim.api.nvim_create_user_command("GripStart", function()
-    -- Build the demo URL directly: same logic as connections.list() demo entry.
-    -- Do NOT depend on _is_demo flag — once a user selects softrear it's
-    -- persisted as a regular file connection and _is_demo is no longer set.
-    local sql_files = vim.api.nvim_get_runtime_file("demo/softrear.sql", false)
-    if #sql_files == 0 then
-      vim.notify("Softrear Portal not found. Is the plugin in your runtimepath?", vim.log.levels.WARN)
+    local demo_module = require("dadbod-grip.demo")
+    local demo, err = demo_module.prepare(true)
+    if not demo then
+      vim.notify("Grip: " .. err, vim.log.levels.ERROR)
       return
     end
-    local has_duck = vim.fn.executable("duckdb") == 1
-    local ext      = has_duck and ".duckdb" or ".db"
-    local db_path  = vim.fn.stdpath("data") .. "/grip/softrear" .. ext
-    local demo_url = (has_duck and "duckdb:" or "sqlite:") .. db_path
-    local seed     = has_duck and sql_files[1]
-      or (vim.api.nvim_get_runtime_file("demo/softrear_sqlite.sql", false)[1] or "")
-
-    -- Always reseed: demo db is not user data; fresh state picks up schema updates
-    if seed ~= "" then
-      if vim.fn.filereadable(db_path) == 1 then vim.fn.delete(db_path) end
-      vim.fn.mkdir(vim.fn.fnamemodify(db_path, ":h"), "p")
-      local bin = db_path:match("%.duckdb$") and "duckdb" or "sqlite3"
-      if vim.fn.executable(bin) == 0 then
-        vim.notify(
-          "GripStart requires duckdb or sqlite3 for the demo database.\n"
-            .. "Install one, or use :GripConnect for your own DB.",
-          vim.log.levels.ERROR)
-        return
-      end
-      vim.fn.system(bin .. " " .. vim.fn.shellescape(db_path)
-        .. " < " .. vim.fn.shellescape(seed))
-    end
-
-    -- Seed supplier intel database for federation demo (requires sqlite3)
-    local supplier_sql_files = vim.api.nvim_get_runtime_file("demo/softrear_supplier.sql", false)
-    if #supplier_sql_files > 0 and vim.fn.executable("sqlite3") == 1 then
-      local grip_dir = vim.fn.getcwd() .. "/.grip"
-      vim.fn.mkdir(grip_dir, "p")
-      local supplier_db = grip_dir .. "/supplier_intel.db"
-      if vim.fn.filereadable(supplier_db) == 1 then vim.fn.delete(supplier_db) end
-      vim.fn.system("sqlite3 " .. vim.fn.shellescape(supplier_db)
-        .. " < " .. vim.fn.shellescape(supplier_sql_files[1]))
-    end
-
     local connections = require("dadbod-grip.connections")
-    connections.switch(demo_url, "Softrear Inc. Analyst Portal\xe2\x84\xa2")
+    connections.switch(demo.url, demo_module.label)
+    local attached
+    attached, err = demo_module.attach_supplier(demo)
+    if not attached then vim.notify("Grip: " .. err, vim.log.levels.WARN) end
+    if demo.supplier_error then vim.notify("Grip: " .. demo.supplier_error, vim.log.levels.WARN) end
 
     -- Load the demo notebook into the query pad.
     -- Double-schedule: connections.switch opens the pad in its own vim.schedule;
@@ -2216,7 +2184,7 @@ function M.setup(opts)
         local md_files = vim.api.nvim_get_runtime_file("demo/softrear-internal.md", false)
         if #md_files == 0 then return end
         local qpad = require("dadbod-grip.query_pad")
-        qpad.open(demo_url)  -- idempotent: ensures _pad_bufnr exists regardless of timing
+        qpad.open(demo.url)  -- idempotent: ensures _pad_bufnr exists regardless of timing
         local pad = qpad.get_pad_bufnr()
         if not pad or not vim.api.nvim_buf_is_valid(pad) then return end
         local lines = vim.fn.readfile(md_files[1])

--- a/lua/dadbod-grip/init.lua
+++ b/lua/dadbod-grip/init.lua
@@ -11,6 +11,7 @@ local query  = require("dadbod-grip.query")
 local ui     = require("dadbod-grip.ui")
 local explain = require("dadbod-grip.explain")
 local filetypes = require("dadbod-grip.filetypes")
+local importer = require("dadbod-grip.importer")
 
 local M = {}
 M._version = require("dadbod-grip.version")
@@ -346,7 +347,7 @@ local function do_apply(bufnr, url)
   end
 
   -- Wrap in transaction for atomicity (all or nothing)
-  local txn_sql = "BEGIN;\n" .. table.concat(stmts, ";\n") .. ";\nCOMMIT;"
+  local txn_sql = sql.wrap_transaction(stmts, require("dadbod-grip.adapters").kind(url))
   local t_apply = vim.uv.hrtime()
   local _, err = db.execute(txn_sql, url)
   local apply_ms = math.floor((vim.uv.hrtime() - t_apply) / 1e6)
@@ -2271,6 +2272,15 @@ function M.setup(opts)
     view.do_export(bufnr)
   end, { desc = "Export grip result to file (csv/json/sql)" })
 
+  -- :GripImport: parse clipboard rows, or stdout from an explicit !command,
+  -- then stage them as inserts in the current editable grid.
+  vim.api.nvim_create_user_command("GripImport", function(cmd_opts)
+    M.do_import(cmd_opts.args)
+  end, {
+    nargs = "*",
+    desc = "Preview and stage CSV, TSV, or JSON rows from clipboard or !command",
+  })
+
   -- :GripFill [N]: stage N AI-generated realistic rows (default 1, max 50)
   vim.api.nvim_create_user_command("GripFill", function(cmd_opts)
     -- do_fill_rows works on the session's connection, so guard on that one and
@@ -2306,6 +2316,67 @@ function M._next_edit_cursor(r, edited_row_idx, edited_col)
   local col_bp = bp and bp[edited_col]
   if not col_bp then return nil end
   return { line = next_line, col = col_bp.start }
+end
+
+--- Preview and stage CSV, TSV, or JSON rows in the current editable grid.
+--- An empty source reads the + register; !command captures stdout while the
+--- producer script is delivered to a constant parent shell argv over stdin.
+function M.do_import(source)
+  local bufnr = vim.api.nvim_get_current_buf()
+  local session = view._sessions[bufnr]
+  if not session then
+    vim.notify("GripImport: no grip session on this buffer", vim.log.levels.WARN)
+    return
+  end
+  if not session.state.table_name or session.state.readonly then
+    vim.notify("GripImport: requires an editable table grid", vim.log.levels.WARN)
+    return
+  end
+  if deny_if_readonly("GripImport", session.url) then return end
+  if db.is_readonly(session.url) then
+    vim.notify("GripImport: this adapter is read-only", vim.log.levels.WARN)
+    return
+  end
+
+  source = vim.trim(source or "")
+  local raw, source_name
+  if source == "" then
+    raw = vim.fn.getreg("+")
+    source_name = "clipboard"
+  elseif source:sub(1, 1) == "!" then
+    local command = vim.trim(source:sub(2))
+    if command == "" then
+      vim.notify("GripImport: provide a command after !", vim.log.levels.WARN)
+      return
+    end
+    local stdout, _, code = require("dadbod-grip.adapters").run_cmd(
+      { "sh", "-s" }, OPTS.timeout, { stdin = command .. "\n" })
+    if code ~= 0 then
+      vim.notify("GripImport: pipe command failed (exit " .. tostring(code) .. ")", vim.log.levels.ERROR)
+      return
+    end
+    raw = stdout
+    source_name = "pipe"
+  else
+    vim.notify("GripImport: use no argument for the clipboard or !command for a pipe",
+      vim.log.levels.WARN)
+    return
+  end
+
+  local parsed, err = importer.parse(raw, session.state.columns)
+  if not parsed then
+    vim.notify("GripImport: " .. err, vim.log.levels.ERROR)
+    return
+  end
+
+  local prompt = string.format("Import %d %s rows into %s?\nColumns: %s (y/N): ",
+    #parsed.rows, parsed.format, session.state.table_name, table.concat(parsed.columns, ", "))
+  if not ui.confirm(prompt) then return end
+
+  local state = data.insert_rows_with_values(session.state, #session.state.rows, parsed.rows)
+  view.apply_edit(bufnr, state)
+  vim.notify(string.format("GripImport: staged %d rows from %s; press a to apply",
+    #parsed.rows, source_name), vim.log.levels.INFO)
 end
 
 --- Stage N AI-generated realistic rows into the current grip grid.

--- a/lua/dadbod-grip/sql.lua
+++ b/lua/dadbod-grip/sql.lua
@@ -30,6 +30,14 @@ function M.quote_value(v)
   end
 end
 
+--- Wrap statements in the transaction syntax accepted by the target adapter.
+function M.wrap_transaction(statements, adapter_kind)
+  local begin_stmt = adapter_kind == "sqlserver"
+      and "SET XACT_ABORT ON;\nBEGIN TRANSACTION;" or "BEGIN;"
+  local commit_stmt = adapter_kind == "sqlserver" and "COMMIT TRANSACTION;" or "COMMIT;"
+  return begin_stmt .. "\n" .. table.concat(statements, ";\n") .. ";\n" .. commit_stmt
+end
+
 -- Quote a column or table identifier with double-quotes.
 function M.quote_ident(name)
   -- Split on . and quote each part: schema.table → "schema"."table"

--- a/lua/dadbod-grip/view/keymaps_edit.lua
+++ b/lua/dadbod-grip/view/keymaps_edit.lua
@@ -6,6 +6,7 @@
 local data   = require("dadbod-grip.data")
 local db     = require("dadbod-grip.db")
 local qmod   = require("dadbod-grip.query")
+local sql    = require("dadbod-grip.sql")
 
 local M = {}
 
@@ -193,7 +194,8 @@ function M.setup(bufnr, ctx)
         "Undo last committed transaction? (" .. count .. " statement(s))",
         "&Yes\n&No", 2)
       if choice ~= 1 then return end
-      local txn = "BEGIN;\n" .. table.concat(reverse, ";\n") .. ";\nCOMMIT;"
+      local txn = sql.wrap_transaction(reverse,
+        require("dadbod-grip.adapters").kind(session.url))
       local _, err = db.execute(txn, session.url)
       if err then
         vim.notify("Undo failed: " .. err, vim.log.levels.ERROR)

--- a/tests/fixtures/demo_failure_integration.lua
+++ b/tests/fixtures/demo_failure_integration.lua
@@ -1,0 +1,21 @@
+local demo = require("dadbod-grip.demo")
+local grip = require("dadbod-grip")
+local query_pad = require("dadbod-grip.query_pad")
+local schema = require("dadbod-grip.schema")
+
+local notices = {}
+vim.notify = function(message) notices[#notices + 1] = tostring(message) end
+
+local spec = assert(demo.spec())
+assert(spec.kind == "sqlite", "fake SQLite client was not selected")
+grip.setup({})
+vim.cmd("GripStart")
+
+assert(not vim.g.db, "failed seed switched connections")
+assert(not schema.is_open(), "failed seed opened the workspace")
+assert(not query_pad.get_pad_bufnr(), "failed seed opened the walkthrough")
+assert(vim.fn.getftype(spec.path) == "", "failed seed left a partial demo database")
+assert(table.concat(notices, "\n"):find("fake seed failure", 1, true),
+  "database client error was not shown")
+
+vim.cmd("qall!")

--- a/tests/fixtures/demo_start_integration.lua
+++ b/tests/fixtures/demo_start_integration.lua
@@ -1,0 +1,63 @@
+local root = assert(vim.env.GRIP_REPO_ROOT, "GRIP_REPO_ROOT is required")
+local db = require("dadbod-grip.db")
+local grip = require("dadbod-grip")
+local query_pad = require("dadbod-grip.query_pad")
+local schema = require("dadbod-grip.schema")
+
+local project_supplier = vim.fn.getcwd() .. "/.grip/supplier_intel.db"
+vim.fn.mkdir(vim.fn.fnamemodify(project_supplier, ":h"), "p")
+vim.fn.writefile({ "user-owned sentinel" }, project_supplier)
+
+grip.setup({})
+vim.cmd("GripStart")
+assert(vim.wait(10000, function()
+  return schema.is_open() and query_pad.get_pad_bufnr() and vim.g.db
+end, 10), "GripStart did not open the complete workspace")
+
+local url = vim.g.db
+local full = url:match("^duckdb:") ~= nil
+if vim.env.GRIP_REQUIRE_DUCKDB == "1" then assert(full, "GripStart did not prefer DuckDB") end
+
+local counts = assert(db.query(table.concat({
+  "SELECT",
+  "(SELECT COUNT(*) FROM rolls) AS rolls,",
+  "(SELECT COUNT(*) FROM suspicious_persons) AS people,",
+  "(SELECT COUNT(*) FROM youtube_comments) AS comments,",
+  "(SELECT COUNT(*) FROM youtube_comments WHERE conspiracy_adjacent IS NULL) AS unreviewed",
+}, " "), url))
+local expected = full and { 505, 200, 500, 193 } or { 35, 10, 15, 2 }
+for index, value in ipairs(expected) do
+  assert(tonumber(counts.rows[1][index]) == value, vim.inspect(counts.rows))
+end
+
+local pad = assert(query_pad.get_pad_bufnr())
+local notebook = table.concat(vim.api.nvim_buf_get_lines(pad, 0, -1, false), "\n")
+assert(notebook:find("Softrear Inc. Internal Operations Analysis", 1, true),
+  "GripStart did not load the investigation notebook")
+
+local blocks, current = {}, nil
+for _, line in ipairs(vim.fn.readfile(root .. "/demo/softrear-internal.md")) do
+  if line == "```sql" then
+    current = {}
+  elseif line == "```" and current then
+    blocks[#blocks + 1] = table.concat(current, "\n")
+    current = nil
+  elseif current then
+    current[#current + 1] = line
+  end
+end
+
+local limit = full and #blocks or 12
+for index = 1, limit do
+  local result, err = db.query(blocks[index], url)
+  assert(result and #result.rows > 0, string.format("notebook SQL block %d failed: %s", index, err or "empty"))
+end
+
+if full and vim.fn.executable("sqlite3") == 1 then
+  local attachments = require("dadbod-grip.adapters.duckdb").get_attachments(url)
+  assert(#attachments == 1 and attachments[1].alias == "supplier", vim.inspect(attachments))
+end
+
+assert(vim.deep_equal(vim.fn.readfile(project_supplier), { "user-owned sentinel" }),
+  "GripStart changed the current project's supplier database")
+vim.cmd("qall!")

--- a/tests/fixtures/workspace_layout_integration.lua
+++ b/tests/fixtures/workspace_layout_integration.lua
@@ -2,6 +2,9 @@ local grip = require("dadbod-grip")
 local connections = require("dadbod-grip.connections")
 local query_pad = require("dadbod-grip.query_pad")
 local schema = require("dadbod-grip.schema")
+local data = require("dadbod-grip.data")
+local db = require("dadbod-grip.db")
+local view = require("dadbod-grip.view")
 
 local url = "sqlite:tests/seed_sqlite.db"
 grip.setup({ open_sidebar = true })
@@ -84,6 +87,82 @@ if tmux_sync and tmux_sync ~= "" then
   assert(vim.api.nvim_win_get_width(sidebar.id) == 24,
     "deliberately narrow sidebar changed on a second resize")
   signal("100")
+
+  local grid_buf = vim.fn.bufnr("grip://users")
+  local function session() return view._sessions[grid_buf] end
+  local function imported_count()
+    local result = assert(db.query(
+      "SELECT COUNT(*) FROM users WHERE email IN "
+        .. "('e2e-one@example.test', 'e2e-two@example.test')", url))
+    return tonumber(result.rows[1][1])
+  end
+
+  local function fail(message)
+    vim.api.nvim_err_writeln("workspace layout integration: " .. tostring(message))
+    vim.cmd("cquit")
+  end
+
+  local function wait_until(label, predicate, on_ready, attempt)
+    attempt = (attempt or 0) + 1
+    local ok, ready = pcall(predicate)
+    if not ok then fail(ready); return end
+    if ready then
+      ok, ready = pcall(on_ready)
+      if not ok then fail(ready) end
+      return
+    end
+    if attempt >= 800 then fail(label); return end
+    vim.defer_fn(function() wait_until(label, predicate, on_ready, attempt) end, 10)
+  end
+
+  signal("import-ready")
+  wait_until("real :GripImport did not stage two rows", function()
+    local current = session()
+    return current and data.count_staged(current.state) == 2
+  end, function()
+    assert(imported_count() == 0, "import wrote before the apply confirmation")
+    local staged = table.concat(vim.api.nvim_buf_get_lines(grid_buf, 0, -1, false), "\n")
+    assert(staged:find("E2E Import One", 1, true), "first staged row did not render")
+    assert(staged:find("E2E Import Two", 1, true), "second staged row did not render")
+    assert(staged:find("2 staged", 1, true), "staged-count badge did not render")
+    signal("import-staged")
+
+    wait_until("gs did not show both imported INSERT statements", function()
+      local buf = vim.api.nvim_get_current_buf()
+      if vim.bo[buf].filetype ~= "sql" then return false end
+      local sql = table.concat(vim.api.nvim_buf_get_lines(buf, 0, -1, false), "\n")
+      return sql:find("E2E Import One", 1, true) and sql:find("E2E Import Two", 1, true)
+    end, function()
+      local sql = table.concat(vim.api.nvim_buf_get_lines(0, 0, -1, false), "\n")
+      local _, inserts = sql:gsub("INSERT INTO", "")
+      assert(inserts == 2, "staged SQL preview did not contain exactly two INSERTs")
+      signal("import-sql")
+
+      wait_until("one u did not remove the complete imported batch", function()
+        local current = session()
+        return current and data.count_staged(current.state) == 0
+      end, function()
+        assert(imported_count() == 0, "undo wrote imported rows to the database")
+        signal("import-undone")
+
+        wait_until("second :GripImport did not restage the batch", function()
+          local current = session()
+          return current and data.count_staged(current.state) == 2
+        end, function()
+          signal("import-restaged")
+
+          wait_until("confirmed apply did not clear the staged batch", function()
+            local current = session()
+            return current and data.count_staged(current.state) == 0
+          end, function()
+            assert(imported_count() == 2, "confirmed apply did not commit exactly two imported rows")
+            signal("import-applied")
+          end)
+        end)
+      end)
+    end)
+  end)
+  return
 end
 
 vim.cmd("qall!")

--- a/tests/spec/adapter_argv_spec.lua
+++ b/tests/spec/adapter_argv_spec.lua
@@ -127,6 +127,7 @@ local ok, err = xpcall(function()
       assert(stdin:find("ANSI_QUOTES", 1, true), "MySQL sql_mode missing from stdin")
     elseif case.name == "sqlserver" then
       assert(stdin:find("SET QUOTED_IDENTIFIER ON", 1, true), "SQL Server session setup missing from stdin")
+      assert(not stdin:find("SET XACT_ABORT ON", 1, true), "ordinary SQL Server execute forces XACT_ABORT")
       assert(not stdin:find("SET NOCOUNT ON", 1, true), "SQL Server execute must preserve row-count output")
     end
   end

--- a/tests/spec/adapter_spec.lua
+++ b/tests/spec/adapter_spec.lua
@@ -914,6 +914,15 @@ test("duckdb attach: a DSN with no scanner keeps the default validation timeout"
   duckdb.detach(url, "plain")
 end)
 
+test("duckdb attach: validation fails fast without opening the main database", function()
+  duckdb._forget_installed_extensions()
+  local args = capture_system_call("42\n", function()
+    duckdb.attach("duckdb:attach_flags.db", "/tmp/plain.duckdb", "plain")
+  end)
+  eq(table.concat(args, " "), "duckdb -bail", "in-memory validation argv")
+  duckdb.detach("duckdb:attach_flags.db", "plain")
+end)
+
 test("duckdb attach: plain validation honors the configured timeout", function()
   local grip = require("dadbod-grip")
   grip.setup({ timeout = 4321 })

--- a/tests/spec/adapter_spec.lua
+++ b/tests/spec/adapter_spec.lua
@@ -388,12 +388,27 @@ end)
 
 -- ── SQLite .sqliterc bypass ─────────────────────────────────────────────
 
-test("sqlite query: passes -init '' to skip .sqliterc", function()
+test("sqlite query: uses the null device to skip .sqliterc", function()
   with_executable(function()
     local args = capture_system_args("col\nval\n", function()
       sqlite.query("SELECT 1", "sqlite:test.db")
     end)
-    has_arg(args, "-init", "query should pass -init")
+    for i, arg in ipairs(args) do
+      if arg == "-init" then
+        eq(args[i + 1], vim.fn.has("win32") == 1 and "NUL" or "/dev/null", "empty init file")
+        return
+      end
+    end
+    error("query should pass -init")
+  end)
+end)
+
+test("sqlite stops at the first failed statement so transactions roll back", function()
+  with_executable(function()
+    local args = capture_system_args("", function()
+      sqlite.execute("BEGIN; SELECT 1; COMMIT;", "sqlite:test.db")
+    end)
+    has_arg(args, "-bail", "sqlite should stop before COMMIT after an error")
   end)
 end)
 
@@ -583,6 +598,22 @@ test("sqlserver enables double-quoted identifiers for every command", function()
         "sqlserver://sa:pw@localhost/grip_test")
     end)
     contains(last_arg(exec_args), "SET QUOTED_IDENTIFIER ON", "execute session")
+  end)
+end)
+
+test("sqlserver leaves ordinary user transaction semantics unchanged", function()
+  with_executable(function()
+    local query_args = capture_system_args("id\n--\n1\n", function()
+      sqlserver.query("SELECT 1", "sqlserver://sa:pw@localhost/grip_test")
+    end)
+    assert(not last_arg(query_args):find("SET XACT_ABORT ON", 1, true),
+      "query session must not force XACT_ABORT")
+
+    local exec_args = capture_system_args("\n(1 rows affected)\n", function()
+      sqlserver.execute("UPDATE users SET id = id", "sqlserver://sa:pw@localhost/grip_test")
+    end)
+    assert(not last_arg(exec_args):find("SET XACT_ABORT ON", 1, true),
+      "execute session must not force XACT_ABORT")
   end)
 end)
 

--- a/tests/spec/data_spec.lua
+++ b/tests/spec/data_spec.lua
@@ -288,6 +288,17 @@ test("get_inserts: returns inserted rows", function()
   eq(inserts[1].values.name, "carol")
 end)
 
+test("get_inserts: preserves batch insertion order", function()
+  local st = make_state({})
+  st = data.insert_rows_with_values(st, #st.rows, {
+    { name = "first" }, { name = "second" }, { name = "third" },
+  })
+  local inserts = data.get_inserts(st)
+  eq(inserts[1].values.name, "first")
+  eq(inserts[2].values.name, "second")
+  eq(inserts[3].values.name, "third")
+end)
+
 -- ── get_ordered_rows() ──────────────────────────────────────────────────────
 
 test("get_ordered_rows: returns original indices when no inserts", function()
@@ -307,6 +318,17 @@ test("get_ordered_rows: inserts are spliced after their _after idx", function()
   eq(ordered[3], 2)
   -- The inserted row should be between 1 and 2
   assert(ordered[2] >= 1000, "insert idx should be >= 1000")
+end)
+
+test("get_ordered_rows: preserves batch insertion order", function()
+  local st = make_state({})
+  st = data.insert_rows_with_values(st, #st.rows, {
+    { name = "first" }, { name = "second" }, { name = "third" },
+  })
+  local ordered = data.get_ordered_rows(st)
+  eq(data.effective_value(st, ordered[3], "name"), "first")
+  eq(data.effective_value(st, ordered[4], "name"), "second")
+  eq(data.effective_value(st, ordered[5], "name"), "third")
 end)
 
 -- ── clone_row() ─────────────────────────────────────────────────────────────

--- a/tests/spec/demo_spec.lua
+++ b/tests/spec/demo_spec.lua
@@ -1,0 +1,125 @@
+local db = require("dadbod-grip.db")
+local demo = require("dadbod-grip.demo")
+
+local pass, fail = 0, 0
+local function test(name, fn)
+  local ok, err = pcall(fn)
+  if ok then pass = pass + 1 else fail = fail + 1; print("FAIL: " .. name .. ": " .. tostring(err)) end
+end
+
+local function eq(actual, expected, message)
+  assert(actual == expected,
+    (message or "") .. ": expected " .. vim.inspect(expected) .. ", got " .. vim.inspect(actual))
+end
+
+local root = vim.fn.getcwd()
+local function with_spec(spec, fn)
+  local real = demo.spec
+  demo.spec = function() return spec end
+  local ok, err = pcall(fn)
+  demo.spec = real
+  if not ok then error(err) end
+end
+
+local function sql_blocks()
+  local blocks, current = {}, nil
+  for _, line in ipairs(vim.fn.readfile(root .. "/demo/softrear-internal.md")) do
+    if line == "```sql" then
+      current = {}
+    elseif line == "```" and current then
+      blocks[#blocks + 1] = table.concat(current, "\n")
+      current = nil
+    elseif current then
+      current[#current + 1] = line
+    end
+  end
+  return blocks
+end
+
+test("SQLite fallback seeds cleanly and runs every non-federated notebook query", function()
+  local dir = vim.fn.tempname()
+  vim.fn.mkdir(dir, "p")
+  local spec = {
+    kind = "sqlite",
+    path = dir .. "/softrear.db",
+    url = "sqlite:" .. dir .. "/softrear.db",
+    seed = root .. "/demo/softrear_sqlite.sql",
+    supplier_path = dir .. "/supplier.db",
+  }
+  local blocks = sql_blocks()
+  with_spec(spec, function()
+    local prepared, err = demo.prepare(true)
+    assert(prepared, err)
+    local counts = assert(db.query(
+      "SELECT COUNT(*) AS rolls, (SELECT COUNT(*) FROM youtube_comments "
+        .. "WHERE conspiracy_adjacent IS NULL) AS unreviewed FROM rolls", spec.url))
+    eq(tonumber(counts.rows[1][1]), 35, "compact roll count")
+    eq(tonumber(counts.rows[1][2]), 2, "compact unreviewed count")
+    for index = 1, 12 do
+      local result, query_err = db.query(blocks[index], spec.url)
+      assert(result and #result.rows > 0,
+        string.format("SQLite notebook block %d failed: %s", index, query_err or "empty"))
+    end
+  end)
+  vim.fn.delete(dir, "rf")
+end)
+
+test("a failing database client leaves no partial demo or workspace", function()
+  local dir = vim.fn.tempname()
+  local bin = dir .. "/bin"
+  vim.fn.mkdir(bin, "p")
+  local client = bin .. "/sqlite3"
+  vim.fn.writefile({
+    "#!/bin/sh",
+    "for last do :; done",
+    "printf partial > \"$last\"",
+    "/bin/cat >/dev/null",
+    "echo 'fake seed failure' >&2",
+    "exit 7",
+  }, client)
+  vim.fn.setfperm(client, "rwx------")
+
+  local result = vim.system({
+    vim.g.grip_test_progpath,
+    "--headless", "-u", "NONE",
+    "--cmd", "set rtp^=" .. vim.fn.fnameescape(root),
+    "-l", root .. "/tests/fixtures/demo_failure_integration.lua",
+  }, {
+    cwd = dir,
+    text = true,
+    env = {
+      PATH = bin,
+      XDG_DATA_HOME = dir .. "/data",
+      XDG_CONFIG_HOME = dir .. "/config",
+    },
+  }):wait()
+  local output = (result.stdout or "") .. (result.stderr or "")
+  vim.fn.delete(dir, "rf")
+  assert(result.code == 0, output)
+end)
+
+test("real GripStart is isolated, complete, and executes the walkthrough", function()
+  local dir = vim.fn.tempname()
+  vim.fn.mkdir(dir, "p")
+  local result = vim.system({
+    vim.g.grip_test_progpath,
+    "--headless", "-u", "NONE",
+    "--cmd", "set rtp^=" .. vim.fn.fnameescape(root),
+    "-l", root .. "/tests/fixtures/demo_start_integration.lua",
+  }, {
+    cwd = dir,
+    text = true,
+    env = {
+      XDG_DATA_HOME = dir .. "/data",
+      XDG_CONFIG_HOME = dir .. "/config",
+      GRIP_REPO_ROOT = root,
+      GRIP_REQUIRE_DUCKDB = vim.env.GRIP_REQUIRE_DUCKDB or "",
+    },
+  }):wait()
+  local output = (result.stdout or "") .. (result.stderr or "")
+  vim.fn.delete(dir, "rf")
+  assert(result.code == 0, output)
+end)
+
+print(string.format("\ndemo_spec: %d passed, %d failed", pass, fail))
+if fail > 0 then os.exit(1) end

--- a/tests/spec/docs_contract_spec.lua
+++ b/tests/spec/docs_contract_spec.lua
@@ -39,6 +39,7 @@ local readme = read("README.md")
 local help = read("doc/dadbod-grip.txt")
 local todo = read("TODO.md")
 local changelog = read("CHANGELOG.md")
+local walkthrough = read("demo/softrear-internal.md")
 local grid_help = read("lua/dadbod-grip/view.lua")
 local contributing = read("CONTRIBUTING.md")
 local security = read("SECURITY.md")
@@ -179,6 +180,52 @@ test("clipboard import documentation keeps its staging boundary", function()
       "child commands retain normal shell argument visibility", 1, true),
       "import child-process boundary missing")
   end
+end)
+
+test("demo walkthrough uses cataloged keys and current data-source behavior", function()
+  local claims = {
+    qpad_execute = "`%s` to run it",
+    grid_profile = "`%s` to see the full",
+    grid_sort = "`%s` on any column",
+    grid_sort_stack = "`%s` to stack",
+    grid_col_stats = "`%s` shows severity statistics",
+    grid_filter_cell = "Press `%s` on a",
+    grid_edit = "with `%s`, navigate",
+    grid_row_view = "Press `%s` on any row",
+    grid_explain = "Press `%s` to inspect the query plan",
+    grid_fk_follow = "Press `%s` on any FK column",
+    grid_fk_referencing = "or `%s` on a referenced row",
+    grid_export_clip = "Press `%s`\n> to export",
+    ai = "press `%s` from the grid",
+    editor_open_url = "press `%s`.",
+    grid_preview_sql = "Press `%s` to inspect both",
+    grid_undo = "press `%s` once",
+    grid_apply = "press `%s`;",
+    open_notebook = "Press `%s` from the query pad",
+    help = "Press `%s` from any surface",
+  }
+  for action, claim in pairs(claims) do
+    local key = assert(keymaps.defaults[action], "missing keymap action " .. action)
+    claim = claim:format(key)
+    assert(walkthrough:find(claim, 1, true),
+      "demo walkthrough missing current " .. action .. " claim " .. claim)
+  end
+
+  assert(walkthrough:find("full 505-roll investigation", 1, true), "DuckDB dataset size missing")
+  assert(walkthrough:find("compact 35-roll fixture", 1, true), "SQLite fallback size missing")
+  assert(walkthrough:find("193 comments in the unreviewed queue", 1, true),
+    "full unreviewed count drifted")
+  assert(walkthrough:find(":GripImport !printf", 1, true), "demo import exercise missing")
+  assert(walkthrough:find("Both rows appear with staged markers", 1, true),
+    "demo import exercise does not prove batch staging")
+  assert(walkthrough:find("https://jorypestorious.com/dadbod-grip-web/", 1, true),
+    "demo canonical documentation URL missing")
+  assert(not walkthrough:find("joryeugene.github.io/dadbod-grip-web", 1, true),
+    "demo retained obsolete documentation URL")
+  assert(not walkthrough:find(".grip/supplier_intel.db", 1, true),
+    "demo retained project-local supplier database")
+  assert(not walkthrough:find("Navigate between SQL blocks with `gn`", 1, true),
+    "demo retained false notebook navigation claim")
 end)
 
 test("query-pad and SQL Server temp-table scope stay accurate", function()

--- a/tests/spec/docs_contract_spec.lua
+++ b/tests/spec/docs_contract_spec.lua
@@ -42,6 +42,9 @@ local changelog = read("CHANGELOG.md")
 local grid_help = read("lua/dadbod-grip/view.lua")
 local contributing = read("CONTRIBUTING.md")
 local security = read("SECURITY.md")
+local justfile = read("justfile")
+local test_workflow = read(".github/workflows/test.yml")
+local sqlserver_workflow = read(".github/workflows/sqlserver.yml")
 local wordmark_path = "docs/brand/dadbod-grip-wordmark.png"
 
 local contributors = table.concat({
@@ -161,6 +164,21 @@ test("TODO contains only active or unshipped work", function()
   assert(not todo:find("TOP N pagination", 1, true), "stale SQL Server pagination claim retained")
   assert(not todo:find("`##temp`", 1, true), "stateless SQL Server temp-table scope retained as product work")
   assert(not todo:find("GripFill", 1, true), "shipped GripFill work retained")
+  assert(not todo:find("Import CSV", 1, true), "shipped clipboard import retained")
+end)
+
+test("clipboard import documentation keeps its staging boundary", function()
+  assert(readme:find("`:GripImport`", 1, true), "README import entry missing")
+  assert(help:find(":GripImport [!command]", 1, true), "help import command missing")
+  assert(help:find("stage the whole batch as one undoable edit", 1, true),
+    "help import staging boundary missing")
+  assert(help:find("press a separately to\n  apply it", 1, true),
+    "help import apply boundary missing")
+  for _, text in ipairs({ readme, help }) do
+    assert(text:gsub("%s+", " "):find(
+      "child commands retain normal shell argument visibility", 1, true),
+      "import child-process boundary missing")
+  end
 end)
 
 test("query-pad and SQL Server temp-table scope stay accurate", function()
@@ -173,12 +191,36 @@ test("query-pad and SQL Server temp-table scope stay accurate", function()
 end)
 
 test("contributor and vulnerability paths remain actionable", function()
-  for _, command in ipairs({ "mise install", "just test", "just lint", "just e2e-visual",
+  for _, command in ipairs({ "mise install", "just check", "just test-live", "just e2e-visual",
       "git config core.hooksPath .githooks", "gitleaks git --redact --verbose" }) do
     assert(contributing:find(command, 1, true), "CONTRIBUTING missing: " .. command)
   end
   assert(security:find("security/advisories/new", 1, true), "private report link missing")
   assert(security:find("Do not open a public issue", 1, true), "public disclosure warning missing")
+end)
+
+test("live dialect workflows use the shared required Just entry point", function()
+  local live_images = {
+    ["postgresql-16"] = "postgres:16-alpine",
+    ["mysql-8.4"] = "mysql:8.4",
+    ["mariadb-11.8"] = "mariadb:11.8",
+  }
+  for database, image in pairs(live_images) do
+    assert(test_workflow:find(database, 1, true), "CI matrix missing " .. database)
+    assert(justfile:find(database .. ")", 1, true), "test-live missing " .. database)
+    assert(test_workflow:find(image, 1, true), "CI image drifted from " .. database)
+  end
+  assert(test_workflow:find('just test-live "${{ matrix.database }}"', 1, true),
+    "live CI bypasses just test-live")
+  assert(justfile:find("sqlserver-2025", 1, true), "test-live missing sqlserver-2025")
+  assert(sqlserver_workflow:find("just test-live sqlserver-2025", 1, true),
+    "SQL Server gate bypasses just test-live")
+  assert(sqlserver_workflow:find("mcr.microsoft.com/mssql/server:2025-latest", 1, true),
+    "SQL Server gate drifted from SQL Server 2025")
+  assert(not sqlserver_workflow:find("GRIP_REQUIRE_LIVE", 1, true),
+    "SQL Server CI duplicates Justfile required flags")
+  assert(not test_workflow:find('echo "GRIP_REQUIRE_', 1, true),
+    "live CI duplicates Justfile required flags")
 end)
 
 test("release version has matching changelog notes", function()

--- a/tests/spec/import_spec.lua
+++ b/tests/spec/import_spec.lua
@@ -1,0 +1,224 @@
+-- import_spec.lua: clipboard/pipe parsing and staged-insert command contract.
+
+local data = require("dadbod-grip.data")
+local db = require("dadbod-grip.db")
+local grip = require("dadbod-grip")
+local importer = require("dadbod-grip.importer")
+local ui = require("dadbod-grip.ui")
+local view = require("dadbod-grip.view")
+local adapters = require("dadbod-grip.adapters")
+
+local pass, fail = 0, 0
+
+local function test(name, fn)
+  local ok, err = pcall(fn)
+  if ok then
+    pass = pass + 1
+  else
+    fail = fail + 1
+    print("FAIL: " .. name .. ": " .. tostring(err))
+  end
+end
+
+local function eq(actual, expected, message)
+  assert(vim.deep_equal(actual, expected),
+    (message or "") .. ": expected " .. vim.inspect(expected) .. ", got " .. vim.inspect(actual))
+end
+
+local columns = { "id", "name", "email", "active", "profile" }
+
+test("CSV headers map by name and empty cells become explicit NULL", function()
+  local parsed = assert(importer.parse("name,email\nAlice,alice@example.com\nBob,\n", columns))
+  eq(parsed.format, "CSV")
+  eq(parsed.columns, { "name", "email" })
+  eq(parsed.rows[1], { name = "Alice", email = "alice@example.com" })
+  eq(parsed.rows[2], { name = "Bob", email = data.NULL_SENTINEL })
+end)
+
+test("TSV and quoted fields reuse the delimited parser", function()
+  local parsed = assert(importer.parse('name\temail\n"Doe, Jane"\tjane@example.com\n', columns))
+  eq(parsed.format, "TSV")
+  eq(parsed.rows[1], { name = "Doe, Jane", email = "jane@example.com" })
+end)
+
+test("JSON objects map in table-column order and preserve null", function()
+  local parsed = assert(importer.parse(
+    ' [{"email":"a@example.com","name":"Alice","active":true,"profile":{"role":"admin"}},'
+      .. '{"name":"Bob","email":null}] ', columns))
+  eq(parsed.format, "JSON")
+  eq(parsed.columns, { "name", "email", "active", "profile" })
+  eq(parsed.rows[1].name, "Alice")
+  eq(parsed.rows[1].active, "true")
+  eq(vim.json.decode(parsed.rows[1].profile), { role = "admin" })
+  eq(parsed.rows[2].email, data.NULL_SENTINEL)
+end)
+
+test("a single JSON object imports as one row", function()
+  local parsed = assert(importer.parse('\239\187\191{"name":"Alice"}', columns))
+  eq(#parsed.rows, 1)
+  eq(parsed.rows[1].name, "Alice")
+end)
+
+test("unknown, duplicate, oversized, and malformed input is rejected", function()
+  local cases = {
+    { "unknown CSV column", "wat\nvalue\n", "unknown column" },
+    { "duplicate CSV column", "name,name\nA,B\n", "duplicate column" },
+    { "too many CSV cells", "name\nA,B\n", "2 fields" },
+    { "too few CSV cells", "name,email\nA\n", "1 fields" },
+    { "unterminated CSV quote", 'name\n"Alice\n', "unterminated quoted field" },
+    { "invalid JSON", '[{"name":]', "invalid JSON" },
+    { "non-object JSON row", '["Alice"]', "row 1 must be an object" },
+    { "empty input", "  \n", "no rows" },
+  }
+  for _, case in ipairs(cases) do
+    local parsed, err = importer.parse(case[2], columns)
+    eq(parsed, nil, case[1])
+    assert(tostring(err):find(case[3], 1, true), case[1] .. ": " .. tostring(err))
+  end
+end)
+
+grip.setup({})
+
+local function with_grid(opts, fn)
+  opts = opts or {}
+  local previous = vim.api.nvim_get_current_buf()
+  local bufnr = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_set_current_buf(bufnr)
+  local state = data.new({
+    rows = { { "1", "Existing", "old@example.com", "1", "" } },
+    columns = columns,
+    primary_keys = { "id" },
+    table_name = "users",
+    url = "sqlite:tests/seed_sqlite.db",
+  })
+  if opts.readonly then state.readonly = true end
+  view._sessions[bufnr] = { state = state, url = state.url }
+
+  local real = {
+    apply_edit = view.apply_edit,
+    confirm = ui.confirm,
+    notify = vim.notify,
+    run_cmd = adapters.run_cmd,
+    execute = db.execute,
+  }
+  local notices, prompt, applied, executed = {}, nil, nil, false
+  view.apply_edit = function(got_buf, new_state)
+    eq(got_buf, bufnr, "target buffer")
+    applied = new_state
+    view._sessions[bufnr].state = new_state
+  end
+  ui.confirm = function(message)
+    prompt = message
+    return opts.confirm ~= false
+  end
+  vim.notify = function(message) notices[#notices + 1] = tostring(message) end
+  db.execute = function() executed = true; return nil, "must not execute" end
+
+  local ok, err = pcall(fn, {
+    bufnr = bufnr,
+    state = state,
+    notices = notices,
+    prompt = function() return prompt end,
+    applied = function() return applied end,
+    executed = function() return executed end,
+    set_run_cmd = function(replacement) adapters.run_cmd = replacement end,
+  })
+
+  view.apply_edit = real.apply_edit
+  ui.confirm = real.confirm
+  vim.notify = real.notify
+  adapters.run_cmd = real.run_cmd
+  db.execute = real.execute
+  view._sessions[bufnr] = nil
+  vim.api.nvim_set_current_buf(previous)
+  vim.api.nvim_buf_delete(bufnr, { force = true })
+  if not ok then error(err) end
+end
+
+test(":GripImport previews clipboard columns and stages rows without writing", function()
+  with_grid({}, function(ctx)
+    vim.fn.setreg("+", "name,email\nAlice,a@example.com\nBob,b@example.com\n")
+    vim.cmd("GripImport")
+
+    local staged = assert(ctx.applied(), "state was not applied")
+    eq(data.count_staged(staged), 2, "two inserts staged")
+    eq(data.get_inserts(staged)[1].values.name, "Alice", "source order preserved")
+    eq(data.get_inserts(staged)[2].values.name, "Bob", "source order preserved")
+    assert(ctx.prompt():find("2 CSV rows", 1, true), "row-count preview missing: " .. ctx.prompt())
+    assert(ctx.prompt():find("name, email", 1, true), "column preview missing: " .. ctx.prompt())
+    eq(ctx.executed(), false, "import must not write to the database")
+    assert(ctx.notices[#ctx.notices]:find("staged 2 rows", 1, true), "success notice missing")
+  end)
+end)
+
+test(":GripImport !command sends producer text through stdin with constant argv", function()
+  with_grid({}, function(ctx)
+    local captured
+    ctx.set_run_cmd(function(args, timeout, opts)
+      captured = { args = args, timeout = timeout, stdin = opts.stdin }
+      return "name\nPiped\n", "", 0
+    end)
+    vim.cmd("GripImport !printf pipe_secret_42")
+    eq(captured.args, { "sh", "-s" }, "pipe argv")
+    eq(captured.stdin, "printf pipe_secret_42\n", "producer command stdin")
+    assert(captured.timeout > 0, "configured timeout forwarded")
+    eq(data.get_inserts(ctx.applied())[1].values.name, "Piped")
+  end)
+end)
+
+test("parent shell argv exposes neither producer script nor imported values", function()
+  if vim.fn.has("linux") ~= 1 then return end
+  with_grid({}, function(ctx)
+    local path = vim.fn.tempname()
+    local sensitive = "imported_argv_secret_6d92"
+    local command = "tr '\\000' '\\n' < /proc/$$/cmdline > " .. vim.fn.shellescape(path)
+      .. "; printf 'name\\n" .. sensitive .. "\\n'"
+    vim.cmd("GripImport !" .. command)
+
+    local cmdline = table.concat(vim.fn.readfile(path), " ")
+    vim.fn.delete(path)
+    assert(not cmdline:find(sensitive, 1, true), "imported value leaked into argv: " .. cmdline)
+    assert(not cmdline:find("printf", 1, true), "producer command leaked into argv: " .. cmdline)
+    eq(data.get_inserts(ctx.applied())[1].values.name, sensitive, "stdout reached the importer")
+  end)
+end)
+
+test("cancel, malformed input, and read-only grids leave state unchanged", function()
+  with_grid({ confirm = false }, function(ctx)
+    vim.fn.setreg("+", "name\nCancelled\n")
+    vim.cmd("GripImport")
+    eq(ctx.applied(), nil, "cancel must not apply")
+    eq(data.count_staged(ctx.state), 0, "cancel must not stage")
+  end)
+
+  with_grid({}, function(ctx)
+    vim.fn.setreg("+", "unknown\nvalue\n")
+    vim.cmd("GripImport")
+    eq(ctx.applied(), nil, "malformed input must not apply")
+    assert(ctx.notices[1]:find("unknown column", 1, true), "parse error missing")
+  end)
+
+  with_grid({ readonly = true }, function(ctx)
+    vim.fn.setreg("+", "name\nBlocked\n")
+    vim.cmd("GripImport")
+    eq(ctx.applied(), nil, "read-only import must not apply")
+    assert(ctx.notices[1]:find("editable table", 1, true), "read-only reason missing")
+  end)
+end)
+
+test("pipe failures reveal neither producer text nor stderr", function()
+  with_grid({}, function(ctx)
+    ctx.set_run_cmd(function()
+      return "", "remote_stderr_secret_91", 7
+    end)
+    vim.cmd("GripImport !printf producer_secret_73")
+    eq(ctx.applied(), nil, "failed pipe must not apply")
+    local notice = table.concat(ctx.notices, "\n")
+    assert(not notice:find("producer_secret_73", 1, true), "producer leaked: " .. notice)
+    assert(not notice:find("remote_stderr_secret_91", 1, true), "stderr leaked: " .. notice)
+    assert(notice:find("exit 7", 1, true), "exit status missing: " .. notice)
+  end)
+end)
+
+print(string.format("\nimport_spec: %d passed, %d failed", pass, fail))
+if fail > 0 then os.exit(1) end

--- a/tests/spec/import_spec.lua
+++ b/tests/spec/import_spec.lua
@@ -100,12 +100,16 @@ local function with_grid(opts, fn)
     notify = vim.notify,
     run_cmd = adapters.run_cmd,
     execute = db.execute,
+    is_readonly = db.is_readonly,
   }
   local notices, prompt, applied, executed = {}, nil, nil, false
   view.apply_edit = function(got_buf, new_state)
     eq(got_buf, bufnr, "target buffer")
+    local session = view._sessions[bufnr]
+    session._undo_stack = session._undo_stack or {}
+    table.insert(session._undo_stack, session.state)
     applied = new_state
-    view._sessions[bufnr].state = new_state
+    session.state = new_state
   end
   ui.confirm = function(message)
     prompt = message
@@ -122,6 +126,8 @@ local function with_grid(opts, fn)
     applied = function() return applied end,
     executed = function() return executed end,
     set_run_cmd = function(replacement) adapters.run_cmd = replacement end,
+    set_adapter_readonly = function(value) db.is_readonly = function() return value end end,
+    undo_depth = function() return #(view._sessions[bufnr]._undo_stack or {}) end,
   })
 
   view.apply_edit = real.apply_edit
@@ -129,6 +135,7 @@ local function with_grid(opts, fn)
   vim.notify = real.notify
   adapters.run_cmd = real.run_cmd
   db.execute = real.execute
+  db.is_readonly = real.is_readonly
   view._sessions[bufnr] = nil
   vim.api.nvim_set_current_buf(previous)
   vim.api.nvim_buf_delete(bufnr, { force = true })
@@ -147,7 +154,35 @@ test(":GripImport previews clipboard columns and stages rows without writing", f
     assert(ctx.prompt():find("2 CSV rows", 1, true), "row-count preview missing: " .. ctx.prompt())
     assert(ctx.prompt():find("name, email", 1, true), "column preview missing: " .. ctx.prompt())
     eq(ctx.executed(), false, "import must not write to the database")
+    eq(ctx.undo_depth(), 1, "the whole batch must create one undo state")
     assert(ctx.notices[#ctx.notices]:find("staged 2 rows", 1, true), "success notice missing")
+  end)
+end)
+
+test("invalid sources and adapter read-only mode stage nothing", function()
+  with_grid({}, function(ctx)
+    vim.cmd("GripImport rows.csv")
+    vim.cmd("GripImport !")
+    eq(ctx.applied(), nil, "invalid source must not apply")
+    local notices = table.concat(ctx.notices, "\n")
+    assert(notices:find("use no argument", 1, true), "non-pipe source reason missing")
+    assert(notices:find("provide a command", 1, true), "empty pipe reason missing")
+  end)
+
+  with_grid({}, function(ctx)
+    ctx.set_adapter_readonly(true)
+    vim.fn.setreg("+", "name\nBlocked\n")
+    vim.cmd("GripImport")
+    eq(ctx.applied(), nil, "read-only adapter must not apply")
+    assert(ctx.notices[1]:find("adapter is read-only", 1, true), "adapter reason missing")
+  end)
+
+  with_grid({}, function(ctx)
+    ctx.state.table_name = nil
+    vim.fn.setreg("+", "name\nBlocked\n")
+    vim.cmd("GripImport")
+    eq(ctx.applied(), nil, "non-table grid must not apply")
+    assert(ctx.notices[1]:find("editable table grid", 1, true), "non-table reason missing")
   end)
 end)
 

--- a/tests/spec/lazy_spec.lua
+++ b/tests/spec/lazy_spec.lua
@@ -37,7 +37,7 @@ test("lazy.lua command triggers include every public Grip command", function()
     "GripTables", "GripQuery", "GripSave", "GripLoad", "GripHistory",
     "GripProfile", "GripExplain", "GripAsk", "GripDiff", "GripCreate",
     "GripDrop", "GripRename", "GripProperties", "GripExport", "GripAttach",
-    "GripDetach", "GripOpen", "GripToggle", "GripFill",
+    "GripDetach", "GripOpen", "GripToggle", "GripFill", "GripImport",
   }) do
     assert(has(cmd, name), "missing lazy command trigger: " .. name)
   end

--- a/tests/spec/live_workflow_spec.lua
+++ b/tests/spec/live_workflow_spec.lua
@@ -16,7 +16,10 @@ if not URL or URL == "" then
 end
 
 local db = require("dadbod-grip.db")
+local data = require("dadbod-grip.data")
+local importer = require("dadbod-grip.importer")
 local query = require("dadbod-grip.query")
+local sql = require("dadbod-grip.sql")
 local view = require("dadbod-grip.view")
 
 if not db.ping(URL) then
@@ -68,6 +71,70 @@ test("CRUD round-trip changes only the probe table", function()
     eq(#assert(db.query("SELECT id FROM grip_live_probe", URL)).rows, 1, "deleted row")
   end)
   db.execute("DROP TABLE IF EXISTS grip_live_probe", URL)
+  if not ok then error(err) end
+end)
+
+test("imported rows use the staged-insert pipeline and commit atomically", function()
+  db.execute("DROP TABLE IF EXISTS grip_import_probe", URL)
+  local ok, err = pcall(function()
+    assert(db.execute(table.concat({
+      "CREATE TABLE grip_import_probe (",
+      "id INTEGER PRIMARY KEY,",
+      "probe_value VARCHAR(40) NOT NULL,",
+      "optional_note VARCHAR(40) NULL)",
+    }, " "), URL))
+
+    local columns = { "id", "probe_value", "optional_note" }
+    local parsed = assert(importer.parse(table.concat({
+      "id,probe_value,optional_note",
+      "901,first import,kept",
+      "902,second import,",
+    }, "\n"), columns))
+    local state = data.new({
+      rows = {}, columns = columns, primary_keys = { "id" },
+      table_name = "grip_import_probe", url = URL,
+    })
+    state = data.insert_rows_with_values(state, #state.rows, parsed.rows)
+
+    local statements = {}
+    for _, insert in ipairs(data.get_inserts(state)) do
+      statements[#statements + 1] = sql.build_insert(
+        state.table_name, insert.values, insert.columns)
+    end
+    assert(db.execute(sql.wrap_transaction(statements,
+      require("dadbod-grip.adapters").kind(URL)), URL))
+
+    local result = assert(db.query(
+      "SELECT id, probe_value, optional_note FROM grip_import_probe ORDER BY id", URL))
+    eq(#result.rows, 2, "imported row count")
+    eq(result.rows[1][2], "first import", "first imported value")
+    eq(result.rows[2][2], "second import", "second imported value")
+    local null_count = assert(db.query(
+      "SELECT COUNT(*) FROM grip_import_probe WHERE optional_note IS NULL", URL))
+    eq(tonumber(null_count.rows[1][1]), 1, "empty import field committed as NULL")
+  end)
+  db.execute("DROP TABLE IF EXISTS grip_import_probe", URL)
+  if not ok then error(err) end
+end)
+
+test("a failed staged-insert transaction commits no partial import", function()
+  db.execute("DROP TABLE IF EXISTS grip_import_rollback_probe", URL)
+  local ok, err = pcall(function()
+    assert(db.execute(
+      "CREATE TABLE grip_import_rollback_probe (id INTEGER PRIMARY KEY, probe_value VARCHAR(40))", URL))
+    local statements = {
+      sql.build_insert("grip_import_rollback_probe", { id = "903", probe_value = "first" },
+        { "id", "probe_value" }),
+      sql.build_insert("grip_import_rollback_probe", { id = "903", probe_value = "duplicate" },
+        { "id", "probe_value" }),
+    }
+    local result, apply_err = db.execute(sql.wrap_transaction(statements,
+      require("dadbod-grip.adapters").kind(URL)), URL)
+    assert(not result and apply_err, "duplicate primary key unexpectedly succeeded")
+    local count = assert(db.query("SELECT COUNT(*) FROM grip_import_rollback_probe", URL))
+    eq(tonumber(count.rows[1][1]), 0, "failed import left a partial row")
+  end)
+  db.execute("DROP TABLE IF EXISTS grip_import_rollback_probe", URL)
   if not ok then error(err) end
 end)
 

--- a/tests/spec/readonly_mode_spec.lua
+++ b/tests/spec/readonly_mode_spec.lua
@@ -128,13 +128,14 @@ test("sqlite passes -readonly for an existing file", function()
   vim.fn.delete(f)
 end)
 
-test("sqlite rw argv is unchanged", function()
+test("sqlite rw argv keeps startup and transaction safety flags", function()
   local sq = require("dadbod-grip.adapters.sqlite")
   local f = vim.fn.tempname() .. ".sqlite"
   vim.fn.writefile({ "" }, f)
   eq(table.concat(sq._sqlite3_args(f, {}), "|"),
-    table.concat({ "sqlite3", "-init", "", "-csv", "-header", f }, "|"),
-    "rw argv contains only client flags and the database path")
+    table.concat({ "sqlite3", "-init", vim.fn.has("win32") == 1 and "NUL" or "/dev/null",
+      "-bail", "-csv", "-header", f }, "|"),
+    "rw argv contains startup safety flags and the database path")
   vim.fn.delete(f)
 end)
 

--- a/tests/spec/readonly_mode_spec.lua
+++ b/tests/spec/readonly_mode_spec.lua
@@ -91,14 +91,14 @@ test("duckdb never passes -readonly for a missing file", function()
   end
 end)
 
-test("duckdb rw argv is unchanged", function()
+test("duckdb rw argv keeps fail-fast flags", function()
   local dd = require("dadbod-grip.adapters.duckdb")
   local f = vim.fn.tempname() .. ".duckdb"
   vim.fn.writefile({ "" }, f)
   eq(table.concat(dd._args("duckdb:" .. f, {}, { "-csv", "-header" }), " "),
-    "duckdb -csv -header " .. f, "rw file-backed argv")
+    "duckdb -bail -csv -header " .. f, "rw file-backed argv")
   eq(table.concat(dd._args("duckdb::memory:", {}, { "-csv", "-header" }), " "),
-    "duckdb -csv -header", "rw :memory: argv carries no path")
+    "duckdb -bail -csv -header", "rw :memory: argv carries no path")
   vim.fn.delete(f)
 end)
 

--- a/tests/spec/sql_spec.lua
+++ b/tests/spec/sql_spec.lua
@@ -48,6 +48,16 @@ test("quote_value: boolean false", function()
   eq(sql.quote_value(false), "FALSE")
 end)
 
+test("wrap_transaction: keeps the shared transaction syntax", function()
+  eq(sql.wrap_transaction({ "INSERT ONE", "INSERT TWO" }, "sqlite"),
+    "BEGIN;\nINSERT ONE;\nINSERT TWO;\nCOMMIT;")
+end)
+
+test("wrap_transaction: uses SQL Server transaction statements", function()
+  eq(sql.wrap_transaction({ "INSERT ONE", "INSERT TWO" }, "sqlserver"),
+    "SET XACT_ABORT ON;\nBEGIN TRANSACTION;\nINSERT ONE;\nINSERT TWO;\nCOMMIT TRANSACTION;")
+end)
+
 -- ── quote_ident() ───────────────────────────────────────────────────────────
 
 test("quote_ident: wraps in double quotes", function()


### PR DESCRIPTION
## Summary

- add `:GripImport` for CSV, TSV, or JSON from the clipboard or an explicit `!command`
- preview imported rows, stage the batch as one undoable edit, and reuse the existing SQL review and apply flow
- seed the built-in demo through one fail-closed stdin path, keep its databases under Neovim's data directory, and attach the disposable supplier database only when federation is available
- correct the walkthrough's fixture counts, key mappings, engine distinctions, federation behavior, and documentation URL
- exercise the real import command, preview, staged SQL, one-step undo, apply confirmation, and committed SQLite rows in the attached-UI scenario
- lock walkthrough keys and claims to the keymap and documentation contracts

## Verification

- LuaCheck: 0 warnings and 0 errors across 162 files
- full deterministic suite on Neovim 0.10.0 and stable
- `just e2e-visual` on Neovim 0.10.0 and stable at 80, 100, and 160 columns
- isolated real `:GripStart` coverage for the complete DuckDB fixture, compact SQLite fallback, all fenced walkthrough queries, supplier attachment, project-directory safety, and failed seeding
- live PostgreSQL 16, MySQL 8.4, MariaDB 11.8, SQLite, SQL Server 2025, and DuckDB federation
- clean-clone `just check`
- full-history Gitleaks scan with redacted output

This PR does not add a dependency or change plugin configuration. It leaves `demo/capture/` untouched.
